### PR TITLE
Add tox.ini and lint for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 build/
 *egg*
 docs/build/
+.tox/
+retworkx/*.so
+retworkx/*pyd

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
 script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
-  - name: Compile and rustfmt
+  - name: Compile and lint
     if: tag IS blank
   - name: Linux x86_64
     if: tag IS blank
@@ -61,7 +61,7 @@ jobs:
   include:
     - name: Compile and rustfmt
       language: rust
-      stage: Compile and rustfmt
+      stage: Compile and lint
       before_install: echo ""
       install: echo ""
       before_script:
@@ -72,6 +72,12 @@ jobs:
       script:
         - cargo build
         - cargo fmt -- --check
+    - name: Python lint
+      language: python
+      stage: Compile and lint
+      before_install: pip install -U pip setuptools virtualenv
+      install: pip install -U flake8
+      script: flake8 setup.py tests
     - name: Python 3.5 Tests Linux
       stage: Linux x86_64
       python: 3.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,14 @@ does not break any existing tests and that any new tests that you've added
 also run successfully. Before you open a new pull request for your change,
 you'll want to run the test suite locally.
 
-Right now tests can only be run manually by invoking python's unittest (or
-a compatible runner) directly from a python environment with retworkx compiled
-and installed. To do this you run:
+The easiest way to run the test suite is to use
+[**tox**](https://tox.readthedocs.io/en/latest/#). You can install tox
+with pip: `pip install -U tox`. Tox provides several advantages, but the
+biggest one is that it builds an isolated virtualenv for running tests. This
+means it does not pollute your system python when running.
 
-```bash
-python -m unittest discover .
-```
-
-from `./tests` in the repo (adjust `.` accordingly if you are running it from
-another directoy). Note that you can **not** run the tests from the root of the
-repo, this is because retworkx packaging shim will conflict with imports from
-retworkx the installed version of retworkx (which contains the compiled
-extension).
+Note, if you run tests outside of tox that you can **not** run the tests from
+the root of the repo, this is because retworkx packaging shim will conflict
+with imports from retworkx the installed version of retworkx (which contains
+the compiled extension).
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
 from setuptools import setup
-from setuptools_rust import Binding, RustExtension
+try:
+    from setuptools_rust import Binding, RustExtension
+except ImportError:
+    import sys
+    import subprocess
+    subprocess.call([sys.executable, '-m', 'pip', 'install',
+                     'setuptools-rust'])
+    from setuptools_rust import Binding, RustExtension
 
 
 def readme():
     with open('README.md') as f:
         return f.read()
+
 
 setup(
     name="retworkx",
@@ -12,8 +20,8 @@ setup(
     description="A python graph library implemented in Rust",
     long_description=readme(),
     long_description_content_type='text/markdown',
-    author = "Matthew Treinish",
-    author_email = "mtreinish@kortar.org",
+    author="Matthew Treinish",
+    author_email="mtreinish@kortar.org",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Development Status :: 3 - Alpha",

--- a/tests/test_ancestors_descendants.py
+++ b/tests/test_ancestors_descendants.py
@@ -39,6 +39,7 @@ class TestAncestors(unittest.TestCase):
         res = retworkx.ancestors(dag, node_b)
         self.assertEqual({node_a}, res)
 
+
 class TestDescendants(unittest.TestCase):
     def test_descendants(self):
         dag = retworkx.PyDAG()

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -61,7 +61,7 @@ class TestEdges(unittest.TestCase):
 
     def test_edges_empty(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        dag.add_node('a')
         self.assertEqual([], dag.edges())
 
     def test_add_duplicates(self):
@@ -96,13 +96,13 @@ class TestEdges(unittest.TestCase):
     def test_remove_edge_from_index(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 'edgy')
+        dag.add_child(node_a, 'b', 'edgy')
         dag.remove_edge_from_index(0)
         self.assertEqual([], dag.edges())
 
     def test_remove_edge_no_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        dag.add_node('a')
         dag.remove_edge_from_index(0)
         self.assertEqual([], dag.edges())
 

--- a/tests/test_floyd_warshall.py
+++ b/tests/test_floyd_warshall.py
@@ -51,7 +51,7 @@ class TestFloydWarshall(unittest.TestCase):
         dag.add_edge(cr_0, cr_0_out, 'qr[2]')
         cr_1_out = dag.add_node('cr[1]_out')
         dag.add_edge(cr_1, cr_1_out, 'cr[1]')
-        
+
         result = retworkx.floyd_warshall(dag)
         expected = {
             0: {0: 0, 5: 1, 6: 2, 7: 2, 8: 3, 9: 4, 10: 4, 11: 3, 12: 5},

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -14,6 +14,7 @@ import unittest
 
 import retworkx
 
+
 class TestLayers(unittest.TestCase):
     def test_dagcircuit_basic(self):
         dag = retworkx.PyDAG()
@@ -35,7 +36,6 @@ class TestLayers(unittest.TestCase):
         x_gate = dag.add_child(measure_qr_1, "x", "qr[1]")
         dag.add_edge(measure_qr_1, x_gate, "cr[1]")
         dag.add_edge(cr_0_in, x_gate, "cr[0]")
-
 
         measure_qr_0 = dag.add_child(cx_gate, "measure", "qr[0]")
         dag.add_edge(measure_qr_0, qr_0_out, "qr[0]")

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -14,12 +14,13 @@ import unittest
 
 import retworkx
 
+
 class TestNodes(unittest.TestCase):
 
     def test_nodes(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        dag.add_child(node_a, 'b', "Edgy")
         res = dag.nodes()
         self.assertEqual(['a', 'b'], res)
         self.assertEqual([0, 1], dag.node_indexes())
@@ -27,7 +28,7 @@ class TestNodes(unittest.TestCase):
     def test_no_nodes(self):
         dag = retworkx.PyDAG()
         self.assertEqual([], dag.nodes())
-        self.assertEquals([], dag.node_indexes())
+        self.assertEqual([], dag.node_indexes())
 
     def test_topo_sort_empty(self):
         dag = retworkx.PyDAG()
@@ -89,9 +90,11 @@ class TestNodes(unittest.TestCase):
         cr_1_out = dag.add_node('cr[1]_out')
         dag.add_edge(cr_1, cr_1_out, 'cr[1]')
 
-        res = list(retworkx.lexicographical_topological_sort(dag, lambda x: str(x)))
-        expected = ['cr[0]', 'cr[0]_out', 'cr[1]', 'cr[1]_out', 'qr[0]', 'qr[1]', 'cx_1', 'h_1', 'qr[2]', 'cx_2',
-                    'cx_3', 'h_2', 'qr[0]_out', 'qr[1]_out', 'qr[2]_out']
+        res = list(retworkx.lexicographical_topological_sort(dag,
+                                                             lambda x: str(x)))
+        expected = ['cr[0]', 'cr[0]_out', 'cr[1]', 'cr[1]_out', 'qr[0]',
+                    'qr[1]', 'cx_1', 'h_1', 'qr[2]', 'cx_2', 'cx_3', 'h_2',
+                    'qr[0]_out', 'qr[1]_out', 'qr[2]_out']
         self.assertEqual(expected, res)
 
     def test_get_node_data(self):
@@ -103,16 +106,15 @@ class TestNodes(unittest.TestCase):
     def test_get_node_data_bad_index(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        dag.add_child(node_a, 'b', "Edgy")
         self.assertRaises(IndexError, dag.get_node_data, 42)
 
     def test_pydag_length(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        dag.add_child(node_a, 'b', "Edgy")
         self.assertEqual(2, len(dag))
 
     def test_pydag_length_empty(self):
         dag = retworkx.PyDAG()
         self.assertEqual(0, len(dag))
-

--- a/tests/test_pred_succ.py
+++ b/tests/test_pred_succ.py
@@ -19,7 +19,7 @@ class TestPredecessors(unittest.TestCase):
     def test_single_predecessor(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_a, 'c', {'a': 2})
         res = dag.predecessors(node_c)
         self.assertEqual(['a'], res)
@@ -27,7 +27,7 @@ class TestPredecessors(unittest.TestCase):
     def test_single_predecessor_multiple_edges(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
+        dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_a, 'c', {'a': 2})
         dag.add_edge(node_a, node_c, {'a': 3})
         res = dag.predecessors(node_c)
@@ -43,6 +43,7 @@ class TestPredecessors(unittest.TestCase):
                           {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
                           {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
                           {'numeral': 0}], res)
+
 
 class TestSuccessors(unittest.TestCase):
     def test_single_successor(self):
@@ -75,6 +76,7 @@ class TestSuccessors(unittest.TestCase):
                           {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
                           {'numeral': 0}], res)
 
+
 class TestBfsSuccessors(unittest.TestCase):
     def test_single_successor(self):
         dag = retworkx.PyDAG()
@@ -91,10 +93,10 @@ class TestBfsSuccessors(unittest.TestCase):
         for i in range(10):
             dag.add_child(node_a, {'numeral': i}, {'edge': i})
         res = retworkx.bfs_successors(dag, node_a)
-        self.assertEqual([('a', [{'numeral': 9}, {'numeral': 8}, {'numeral': 7},
-                          {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
-                          {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
-                          {'numeral': 0}])], res)
+        self.assertEqual([('a', [{'numeral': 9}, {'numeral': 8},
+                          {'numeral': 7}, {'numeral': 6}, {'numeral': 5},
+                          {'numeral': 4}, {'numeral': 3}, {'numeral': 2},
+                          {'numeral': 1}, {'numeral': 0}])], res)
 
     def test_bfs_succesors(self):
         dag = retworkx.PyDAG()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,45 @@
+[tox]
+minversion = 2.1
+envlist = py35, py36, py37, py38, lint
+
+[testenv]
+install_command = pip install -U {opts} {packages}
+setenv =
+  VIRTUAL_ENV={envdir}
+  LANGUAGE=en_US
+  LC_ALL=en_US.utf-8
+  ARGS="-V"
+deps = setuptools-rust
+changedir = {toxinidir}/tests
+commands =
+  python -m unittest discover .
+
+[testenv:lint]
+basepython = python3
+deps =
+  flake8
+  setuptools-rust
+whitelist_externals=cargo
+commands =
+  flake8 . ../setup.py
+  cargo fmt -- --check
+
+[testenv:docs]
+basepython = python3
+setenv =
+  {[testenv]setenv}
+  QISKIT_DOCS=TRUE
+deps =
+  sphinx
+  m2r
+commands =
+  sphinx-build -W -b html docs/ docs/build/html {posargs}
+
+[flake8]
+# E125 is deliberately excluded. See https://github.com/jcrocholl/pep8/issues/126
+# E123 skipped because it is ignored by default in the default pep8
+# E129 skipped because it is too limiting when combined with other rules
+# E711 skipped because sqlalchemy filter() requires using == instead of is
+ignore = E125,E123,E129,E711
+exclude = .venv,.git,.tox,dist,doc,*egg,build
+


### PR DESCRIPTION

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

To ease local development this commit adds a tox config to run tests
and style/lint checks locally. It also updates the unittests to pass
flake8 which will be used for style rule checking on the tests.