### PR TITLE
Remove sudo from pip calls in travis wheel jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS present
-  - name: Linux x86_64
-    if: tag IS present
-  - name: Linux non-x86_64
-    if: tag IS present
-  - name: macOS
-    if: tag IS present
-  - name: deploy
     if: tag IS blank
+  - name: Linux x86_64
+    if: tag IS blank
+  - name: Linux non-x86_64
+    if: tag IS blank
+  - name: macOS
+    if: tag IS blank
+  - name: deploy
+    if: tag IS present
 
 jobs:
   fast_finish: true
@@ -87,7 +87,7 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS blank
+      if: tag IS present
       script:
         - pip install -U cibuildwheel==1.2.0 twine
         - cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS blank
-  - name: Linux x86_64
-    if: tag IS blank
-  - name: Linux non-x86_64
-    if: tag IS blank
-  - name: macOS
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: Linux x86_64
+    if: tag IS present
+  - name: Linux non-x86_64
+    if: tag IS present
+  - name: macOS
+    if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -87,7 +87,7 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+      if: tag IS blank
       script:
         - pip install -U cibuildwheel==1.2.0 twine
         - cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U cibuildwheel==1.2.0 twine
+        - pip install -U cibuildwheel==1.2.0 twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -122,7 +122,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.2.0
+        - pip install -U twine cibuildwheel==1.2.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -141,6 +141,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.2.0
+        - pip install -U twine cibuildwheel==1.2.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

The travis x86 linux wheel job is not working because when it calls sudo
pip the job tries to use a python 2 version of pip which no longer works
(nor does it have a cibuildwheel package on pypi that is compatible with
it). This commit removes the sudo usage to ensure we're always using
python3 pip.