### PR TITLE
Rely on travis for macos wheel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS blank
-  - name: Linux x86_64
-    if: tag IS blank
-  - name: Linux non-x86_64
-    if: tag IS blank
-  - name: macOS
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: Linux x86_64
+    if: tag IS present
+  - name: Linux non-x86_64
+    if: tag IS present
+  - name: macOS
+    if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -147,7 +147,7 @@ jobs:
     - stage: deploy
       os: osx
       language: generic
-      if: tag IS present
+      if: tag IS blank
       before_install:
         - echo ""
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,3 +144,21 @@ jobs:
         - sudo pip install -U twine cibuildwheel==1.2.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
+    - stage: deploy
+      os: osx
+      language: generic
+      if: tag IS present
+      before_install:
+        - echo ""
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust && tools/install_rust.sh"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
+      script:
+        - sudo pip2 install -U cibuildwheel==1.1.0 twine
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS present
-  - name: Linux x86_64
-    if: tag IS present
-  - name: Linux non-x86_64
-    if: tag IS present
-  - name: macOS
-    if: tag IS present
-  - name: deploy
     if: tag IS blank
+  - name: Linux x86_64
+    if: tag IS blank
+  - name: Linux non-x86_64
+    if: tag IS blank
+  - name: macOS
+    if: tag IS blank
+  - name: deploy
+    if: tag IS present
 
 jobs:
   fast_finish: true
@@ -147,7 +147,7 @@ jobs:
     - stage: deploy
       os: osx
       language: generic
-      if: tag IS blank
+      if: tag IS present
       before_install:
         - echo ""
       install:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,30 +14,6 @@ stages:
   - stage: 'Wheel_Builds'
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:
-    - job: 'macos'
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-      pool: {vmImage: 'macOS-10.15'}
-      variables:
-        python.version: '3.7'
-        CIBW_BEFORE_BUILD: pip install -U setuptools-rust && rustup default nightly
-        CIBW_SKIP: cp27-* cp34-* pp*
-        TWINE_USERNAME: retworkx-ci
-        CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
-      steps:
-      - task: UsePythonVersion@0
-      - bash: |
-          set -e
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==1.2.0
-          pip install -U twine
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishBuildArtifacts@1
-        inputs: {pathtoPublish: 'wheelhouse'}
-        condition: succeededOrFailed()
-      - bash: |
-          twine upload wheelhouse/*
-        env:
-          TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows_64'
       pool: {vmImage: 'vs2017-win2016'}
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

For the 0.3.3 release we switched to using a newer cibuildwheel in azure
pipelines for building macos wheels. This resulted in an invalid wheel
be uploaded for most users. This commit fixes this issue by switching
back to the previous travis job which is known working and use that
instead.