### PR TITLE
Fix issue with cargo build on macOS

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
When developing on macOS attempting to just build the shared lib without
installing via setuptools-rust would lead to a linker error. This lead
those developing on macOS to often use cargo build to get debug syntax
and compiler errors in a good format and then switch to using pip for
testing that library actually could link and compile. However, this
issue is actually documented in the PyO3 README and it explains that
macOS needs additional linker flags to work. This commit adds the
necessary flags which should enable cargo build to fully compile on
macOS.