### PR TITLE
Upgrade PyO3 and option to enable check_cycle at init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ petgraph = "0.5"
 fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
-version = "0.8.5"
+version = "0.9.0"
 features = ["extension-module"]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,7 +17,12 @@ retworkx API
        dag = retworkx.PyDAG()
        dag.check_cycle = True
 
-   With check_cycle set to true any calls to :method:`PyDAG.add_edge` will
+   or at object creation::
+
+       import retworkx
+       dag = retworkx.PyDAG(True)
+
+   With check_cycle set to true any calls to :meth:`PyDAG.add_edge` will
    ensure that no cycles are added, ensuring that the PyDAG class truly
    represents a directed acyclic graph.
 
@@ -25,8 +30,11 @@ retworkx API
           When using ``copy.deepcopy()`` or pickling node indexes are not
           guaranteed to be preserved.
 
-    .. py:method:: __init__(self):
+    .. py:method:: __init__(self, check_cycle=False):
         Initialize an empty DAG.
+
+        :param bool check_cycle: If set true enable cycle checking on add_edge()
+            calls
 
     .. py:method:: __len__(self):
         Return the number of nodes in the graph. Use via ``len()`` function
@@ -188,6 +196,7 @@ retworkx API
             the value is the edge data object for all nodes that share an
             edge with the specified node.
         :rtype: dict
+
         :raises NoEdgeBetweenNodes if the DAG is broken and an edge can't be
             found to a neighbor node
 
@@ -202,6 +211,7 @@ retworkx API
         :returns in_edges: A list of tuples of the form:
             (parent_index, node_index, edge_data)
         :rtype: list
+
         :raises NoEdgeBetweenNodes if the DAG is broken and an edge can't be
             found to a neighbor node
 
@@ -216,6 +226,7 @@ retworkx API
         :returns out_edges: A list of tuples of the form:
             (node_index, child_index, edge_data)
         :rtype: list
+
         :raises NoEdgeBetweenNodes if the DAG is broken and an edge can't be
             found to a neighbor node
 

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -121,3 +121,10 @@ class TestEdges(unittest.TestCase):
         dag.add_edge(node_b, node_a, {})
         with self.assertRaises(Exception):
             dag.check_cycle = True
+
+    def test_cycle_checking_at_init(self):
+        dag = retworkx.PyDAG(True)
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        with self.assertRaises(Exception):
+            dag.add_edge(node_b, node_a, {})


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This commit upgrades the version of PyO3 being used to the latest
release 0.9.0 which had some api changes that needed to be taken into
account. Additionally, the new version has improved docs which show how
to add arguments to the __new__() constructor definition with a default
value. So while the new construct is being updated to use the new class
initializer an optional argument is added.