### PR TITLE
Temporarily disable s390x travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,10 @@ jobs:
       stage: Linux non-x86_64
       python: 3.7
       arch: ppc64le
-    - name: Python 3.7 Tests s390x Linux
-      stage: Linux non-x86_64
-      python: 3.7
-      arch: s390x
+#    - name: Python 3.7 Tests s390x Linux
+#      stage: Linux non-x86_64
+#      python: 3.7
+#      arch: s390x
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64
       python: 3.7


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

After the recent travis planned outage for a database upgrade the s390x
jobs are stuck in the queueing state and never run. This is blocking
development. This commit temporarily disables the s390x job until the
issue is resolved.