### PR TITLE
Revert "Temporarily disable s390x travis job (#55)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ jobs:
       stage: Linux non-x86_64
       python: 3.7
       arch: ppc64le
-#    - name: Python 3.7 Tests s390x Linux
-#      stage: Linux non-x86_64
-#      python: 3.7
-#      arch: s390x
+    - name: Python 3.7 Tests s390x Linux
+      stage: Linux non-x86_64
+      python: 3.7
+      arch: s390x
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64
       python: 3.7


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This reverts commit 28b97e7e8607f7df6792252fbce26d9a45737558.

Now that the issue with the s390x jobs in travis has been resolved
re-enable the job.