### PR TITLE
Bump pyo3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ petgraph = "0.5"
 fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
-version = "0.9.0"
+version = "0.9.1"
 features = ["extension-module"]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This commit bumps the pyo3 version again to be the latest release. It's
only a bugfix patch release, and it shouldn't effect the usage in
retworkx, but better to keep up to date when we can.