### PR TITLE
Fix travis coverage job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       python: 3.7
       stage: Compile and lint
       install:
-        - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+        - curl -L https://github.com/mozilla/grcov/releases/download/v0.5.9/grcov-linux-x86_64.tar.bz2 | tar jxf -
         - pip install -U setuptools-rust
         - gem install coveralls-lcov
         - export CARGO_INCREMENTAL=0


### PR DESCRIPTION
The travis coverage job has stopped working, it looks like because of
several new releases of grcov. This reverts to the version which was
working for previous commits.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
