### PR TITLE
Fix rustfmt job to use newer toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,10 @@ jobs:
       install: echo ""
       before_script:
         - rustup update
-        - rustup component add rustfmt
-        - rustup override set nightly-2020-02-06
-        - rustup component add rustfmt
+        - rustup override set nightly
       script:
         - cargo build
-        - cargo fmt -- --check
+        - cargo +stable fmt -- --check
     - name: Python lint
       language: python
       stage: Compile and lint


### PR DESCRIPTION
The rustfmt and compile test is failing right now because the pinned
nightly toolchain we're installing to get a working nightly rustfmt no
longer works. This commit fixes this by adjusting the job config to just
use the nightly toolchain and pin only rustfmt to a known working
version.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
