### PR TITLE
Bump PyO3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ petgraph = "0.5"
 fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
-version = "0.9.1"
+version = "0.9.2"
 features = ["extension-module"]


### PR DESCRIPTION
There has been another new PyO3 release recently that among other things
fixed a bug when building on 32bit systems. It is good to get this fix
before we release retworkx again. This commit bumps the dependency
version to keep retworkx up-to-date with new PyO3 versions.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
