### PR TITLE
Add PyGraph class for undirected graphs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -112,10 +112,6 @@ retworkx API
     .. py:method:: remove_node(self, node):
         Remove a node from the DAG.
 
-        NOTE: Removal of a node may change the index for other nodes in the
-        DAG. The last node will shift to the index of the removed node to take
-        its place.
-
         :param int node: The index of the node to remove
 
     .. py:method:: add_edge(self, parent, child, edge):
@@ -455,7 +451,8 @@ retworkx API
    the ``StableGraph`` type. The limitations and quirks with this library and
    type dictate how this operates. The biggest thing to be aware of when using
    the PyGraph class is that an integer node and edge index is used for
-   accessing elements on the DAG, not the data/weight of nodes and edges.
+   accessing elements on the graph, it doesn't support associative access via
+   the data/weight of nodes and edges.
 
     .. py:method:: __init__(self):
         Initialize an empty graph.
@@ -466,7 +463,7 @@ retworkx API
     .. py:method:: edges(self):
         Return a list of all edge data.
 
-        :returns: A list of all the edge data objects in the DAG
+        :returns: A list of all the edge data objects in the graph
         :rtype: list
 
     .. py:method:: has_edge(self, node_a, node_b):
@@ -503,7 +500,7 @@ retworkx API
 
         Note if there are multiple edges between the nodes only one will be
         returned. To get all edge data objects use
-        :py:method:`retworkx.PyGraph.get_all_edge_data`
+        :py:meth:`retworkx.PyGraph.get_all_edge_data`
 
         :param int node_a: The index for the first node
         :param int node_b: The index for the second node
@@ -522,7 +519,7 @@ retworkx API
         :raises: When there is no edge between nodes
 
     .. py:method:: remove_node(self, node):
-        Remove a node from the DAG.
+        Remove a node from the graph.
 
         :param int node: The index of the node to remove
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -446,3 +446,137 @@ retworkx API
 
     :returns layers: A list of layers, each layer is a list of node data
     :rtype: list
+
+
+.. py:class:: PyGraph
+   A class for creating undirected graphs.
+
+   The PyGraph class is constructed using the Rust library `petgraph`_ around
+   the ``StableGraph`` type. The limitations and quirks with this library and
+   type dictate how this operates. The biggest thing to be aware of when using
+   the PyGraph class is that an integer node and edge index is used for
+   accessing elements on the DAG, not the data/weight of nodes and edges.
+
+    .. py:method:: __init__(self):
+        Initialize an empty graph.
+
+    .. py:method:: __len__(self):
+        Return the number of nodes in the graph. Use via ``len()`` function
+
+    .. py:method:: edges(self):
+        Return a list of all edge data.
+
+        :returns: A list of all the edge data objects in the DAG
+        :rtype: list
+
+    .. py:method:: has_edge(self, node_a, node_b):
+        Return True if there is an edge between node_a to node_b.
+
+        :param int node_a: The node index to check for an edge between
+        :param int node_b: The node index to check for an edge between
+
+        :returns: True if there is an edge false if there is no edge
+        :rtype: bool
+
+    .. py:method:: nodes(self):
+        Return a list of all node data.
+
+        :returns: A list of all the node data objects in the graph
+        :rtype: list
+
+    .. py:method:: node_indexes(self):
+        Return a list of all node indexes.
+
+        :returns: A list of all the node indexes in the graph
+        :rtype: list
+
+    .. py:method:: get_node_data(self, node):
+        Return the node data for a given node index
+
+        :param int node: The index for the node
+
+        :returns: The data object set for that node
+        :raises IndexError: when an invalid node index is provided
+
+    .. py:method:: get_edge_data(self, node_a, node_b):
+        Return the edge data for the edge between 2 nodes.
+
+        Note if there are multiple edges between the nodes only one will be
+        returned. To get all edge data objects use
+        :py:method:`retworkx.PyGraph.get_all_edge_data`
+
+        :param int node_a: The index for the first node
+        :param int node_b: The index for the second node
+
+        :returns: The data object set for the edge
+        :raises: When there is no edge between nodes
+
+    .. py:method:: get_all_edge_data(self, node_a, node_b):
+        Return the edge data for all the edges between 2 nodes.
+
+        :param int node_a: The index for the first node
+        :param int node_b: The index for the second node
+
+        :returns: A list with all the data objects for the edges between nodes
+        :rtype: list
+        :raises: When there is no edge between nodes
+
+    .. py:method:: remove_node(self, node):
+        Remove a node from the DAG.
+
+        :param int node: The index of the node to remove
+
+    .. py:method:: add_edge(self, parent, child, edge):
+        Add an edge between 2 nodes.
+
+        Use add_child() or add_parent() to create a node with an edge at the
+        same time as an edge for better performance. Using this method will
+        enable adding duplicate edges between nodes.
+
+        :param int parent: Index of the parent node
+        :param int child: Index of the child node
+        :param edge: The object to set as the data for the edge. It can be any
+            python object.
+
+        :raises: When the new edge will create a cycle
+
+    .. py:method:: add_node(self, obj):
+        Add a new node to the dag.
+
+        :param obj: The python object to attach to the node
+
+        :returns index: The index of the newly created node
+        :rtype: int
+
+    .. py:method:: adj(self, node):
+        Get the index and data for the neighbors of a node.
+
+        This will return a dictionary where the keys are the node indexes of
+        the adjacent nodes (inbound or outbound) and the value is the edge data
+        objects between that adjacent node and the provided node.
+
+        :param int node: The index of the node to get the neighbors
+
+        :returns neighbors: A dictionary where the keys are node indexes and
+            the value is the edge data object for all nodes that share an
+            edge with the specified node.
+        :rtype: dict
+
+    .. py:method:: remove_edge(self, parent, child):
+        Remove an edge between 2 nodes.
+
+        Note if there are multiple edges between the specified nodes only one
+        will be removed.
+
+        :param int parent: The index for the parent node.
+        :param int child: The index of the child node.
+
+        :raises NoEdgeBetweenNodes: If there are no edges between the nodes
+            specified
+
+    .. py:method:: remove_edge_from_index(self, edge):
+        Remove an edge identified by the provided index
+
+        :param int edge: The index of the edge to remove
+
+.. _petgraph: https://github.com/bluss/petgraph

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -333,7 +333,7 @@ impl PyGraph {
         let neighbors = self.graph.neighbors(index);
         let out_dict = PyDict::new(py);
         for neighbor in neighbors {
-            let mut edge = self.graph.find_edge(index, neighbor);
+            let edge = self.graph.find_edge(index, neighbor);
             let edge_w = self.graph.edge_weight(edge.unwrap());
             out_dict.set_item(neighbor.index(), edge_w)?;
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -51,7 +51,7 @@ impl NodeCount for PyGraph {
 impl GraphProp for PyGraph {
     type EdgeType = petgraph::Undirected;
     fn is_directed(&self) -> bool {
-        true
+        false
     }
 }
 
@@ -334,10 +334,6 @@ impl PyGraph {
         let out_dict = PyDict::new(py);
         for neighbor in neighbors {
             let mut edge = self.graph.find_edge(index, neighbor);
-            // If there is no edge then it must be a parent neighbor
-            if edge.is_none() {
-                edge = self.graph.find_edge(neighbor, index);
-            }
             let edge_w = self.graph.edge_weight(edge.unwrap());
             out_dict.set_item(neighbor.index(), edge_w)?;
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,359 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use std::ops::{Index, IndexMut};
+
+use pyo3::class::PyMappingProtocol;
+use pyo3::exceptions::IndexError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use pyo3::Python;
+
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::prelude::*;
+use petgraph::stable_graph::StableUnGraph;
+use petgraph::visit::{
+    GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences,
+    NodeCompactIndexable, NodeCount, NodeIndexable, Visitable,
+};
+
+use super::NoEdgeBetweenNodes;
+
+#[pyclass(module = "retworkx")]
+pub struct PyGraph {
+    graph: StableUnGraph<PyObject, PyObject>,
+}
+
+pub type Edges<'a, E> =
+    petgraph::stable_graph::Edges<'a, E, petgraph::Undirected>;
+
+impl GraphBase for PyGraph {
+    type NodeId = NodeIndex;
+    type EdgeId = EdgeIndex;
+}
+
+impl NodeCount for PyGraph {
+    fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+}
+
+impl GraphProp for PyGraph {
+    type EdgeType = petgraph::Undirected;
+    fn is_directed(&self) -> bool {
+        true
+    }
+}
+
+impl petgraph::visit::Visitable for PyGraph {
+    type Map = <StableUnGraph<PyObject, PyObject> as Visitable>::Map;
+    fn visit_map(&self) -> Self::Map {
+        self.graph.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.graph.reset_map(map)
+    }
+}
+
+impl petgraph::visit::Data for PyGraph {
+    type NodeWeight = PyObject;
+    type EdgeWeight = PyObject;
+}
+
+impl petgraph::data::DataMap for PyGraph {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+        self.graph.node_weight(id)
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+
+impl petgraph::data::DataMapMut for PyGraph {
+    fn node_weight_mut(
+        &mut self,
+        id: Self::NodeId,
+    ) -> Option<&mut Self::NodeWeight> {
+        self.graph.node_weight_mut(id)
+    }
+    fn edge_weight_mut(
+        &mut self,
+        id: Self::EdgeId,
+    ) -> Option<&mut Self::EdgeWeight> {
+        self.graph.edge_weight_mut(id)
+    }
+}
+
+impl<'a> IntoNeighbors for &'a PyGraph {
+    type Neighbors = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors(self, n: NodeIndex) -> Self::Neighbors {
+        self.graph.neighbors(n)
+    }
+}
+
+impl<'a> IntoEdgeReferences for &'a PyGraph {
+    type EdgeRef = petgraph::stable_graph::EdgeReference<'a, PyObject>;
+    type EdgeReferences = petgraph::stable_graph::EdgeReferences<'a, PyObject>;
+    fn edge_references(self) -> Self::EdgeReferences {
+        self.graph.edge_references()
+    }
+}
+
+impl<'a> IntoEdges for &'a PyGraph {
+    type Edges = Edges<'a, PyObject>;
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        self.graph.edges(a)
+    }
+}
+
+impl<'a> IntoNodeIdentifiers for &'a PyGraph {
+    type NodeIdentifiers = petgraph::stable_graph::NodeIndices<'a, PyObject>;
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        self.graph.node_identifiers()
+    }
+}
+
+impl<'a> IntoNodeReferences for &'a PyGraph {
+    type NodeRef = (NodeIndex, &'a PyObject);
+    type NodeReferences = petgraph::stable_graph::NodeReferences<'a, PyObject>;
+    fn node_references(self) -> Self::NodeReferences {
+        self.graph.node_references()
+    }
+}
+
+impl NodeIndexable for PyGraph {
+    fn node_bound(&self) -> usize {
+        self.graph.node_bound()
+    }
+    fn to_index(&self, ix: NodeIndex) -> usize {
+        self.graph.to_index(ix)
+    }
+    fn from_index(&self, ix: usize) -> Self::NodeId {
+        self.graph.from_index(ix)
+    }
+}
+
+impl NodeCompactIndexable for PyGraph {}
+
+impl Index<NodeIndex> for PyGraph {
+    type Output = PyObject;
+    fn index(&self, index: NodeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<NodeIndex> for PyGraph {
+    fn index_mut(&mut self, index: NodeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl Index<EdgeIndex> for PyGraph {
+    type Output = PyObject;
+    fn index(&self, index: EdgeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<EdgeIndex> for PyGraph {
+    fn index_mut(&mut self, index: EdgeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl GetAdjacencyMatrix for PyGraph {
+    type AdjMatrix =
+        <StableUnGraph<PyObject, PyObject> as GetAdjacencyMatrix>::AdjMatrix;
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.graph.adjacency_matrix()
+    }
+    fn is_adjacent(
+        &self,
+        matrix: &Self::AdjMatrix,
+        a: NodeIndex,
+        b: NodeIndex,
+    ) -> bool {
+        self.graph.is_adjacent(matrix, a, b)
+    }
+}
+
+#[pymethods]
+impl PyGraph {
+    #[new]
+    fn new() -> Self {
+        PyGraph {
+            graph: StableUnGraph::<PyObject, PyObject>::default(),
+        }
+    }
+
+    pub fn edges(&self, py: Python) -> PyObject {
+        let raw_edges = self.graph.edge_indices();
+        let mut out: Vec<&PyObject> = Vec::new();
+        for edge in raw_edges {
+            out.push(self.graph.edge_weight(edge).unwrap());
+        }
+        PyList::new(py, out).into()
+    }
+
+    pub fn nodes(&self, py: Python) -> PyObject {
+        let raw_nodes = self.graph.node_indices();
+        let mut out: Vec<&PyObject> = Vec::new();
+        for node in raw_nodes {
+            out.push(self.graph.node_weight(node).unwrap());
+        }
+        PyList::new(py, out).into()
+    }
+
+    pub fn node_indexes(&self, py: Python) -> PyObject {
+        let mut out_list: Vec<usize> = Vec::new();
+        for node_index in self.graph.node_indices() {
+            out_list.push(node_index.index());
+        }
+        PyList::new(py, out_list).into()
+    }
+
+    pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        self.graph.find_edge(index_a, index_b).is_some()
+    }
+
+    pub fn get_edge_data(
+        &self,
+        node_a: usize,
+        node_b: usize,
+    ) -> PyResult<&PyObject> {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        let edge_index = match self.graph.find_edge(index_a, index_b) {
+            Some(edge_index) => edge_index,
+            None => {
+                return Err(NoEdgeBetweenNodes::py_err(
+                    "No edge found between nodes",
+                ))
+            }
+        };
+
+        let data = self.graph.edge_weight(edge_index).unwrap();
+        Ok(data)
+    }
+
+    pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
+        let index = NodeIndex::new(node);
+        let node = match self.graph.node_weight(index) {
+            Some(node) => node,
+            None => return Err(IndexError::py_err("No node found for index")),
+        };
+        Ok(node)
+    }
+
+    pub fn get_all_edge_data(
+        &self,
+        py: Python,
+        node_a: usize,
+        node_b: usize,
+    ) -> PyResult<PyObject> {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        let raw_edges = self.graph.edges(index_a);
+        let mut out: Vec<&PyObject> = Vec::new();
+        for edge in raw_edges {
+            if edge.target() == index_b {
+                out.push(edge.weight());
+            }
+        }
+        if out.is_empty() {
+            Err(NoEdgeBetweenNodes::py_err("No edge found between nodes"))
+        } else {
+            Ok(PyList::new(py, out).into())
+        }
+    }
+
+    pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
+        let index = NodeIndex::new(node);
+        self.graph.remove_node(index);
+
+        Ok(())
+    }
+
+    pub fn add_edge(
+        &mut self,
+        node_a: usize,
+        node_b: usize,
+        edge: PyObject,
+    ) -> PyResult<usize> {
+        let p_index = NodeIndex::new(node_a);
+        let c_index = NodeIndex::new(node_b);
+        let edge = self.graph.add_edge(p_index, c_index, edge);
+        Ok(edge.index())
+    }
+
+    pub fn remove_edge(
+        &mut self,
+        node_a: usize,
+        node_b: usize,
+    ) -> PyResult<()> {
+        let p_index = NodeIndex::new(node_a);
+        let c_index = NodeIndex::new(node_b);
+        let edge_index = match self.graph.find_edge(p_index, c_index) {
+            Some(edge_index) => edge_index,
+            None => {
+                return Err(NoEdgeBetweenNodes::py_err(
+                    "No edge found between nodes",
+                ))
+            }
+        };
+        self.graph.remove_edge(edge_index);
+        Ok(())
+    }
+
+    pub fn remove_edge_from_index(&mut self, edge: usize) -> PyResult<()> {
+        let edge_index = EdgeIndex::new(edge);
+        self.graph.remove_edge(edge_index);
+        Ok(())
+    }
+
+    pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
+        let index = self.graph.add_node(obj);
+        Ok(index.index())
+    }
+
+    pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let neighbors = self.graph.neighbors(index);
+        let out_dict = PyDict::new(py);
+        for neighbor in neighbors {
+            let mut edge = self.graph.find_edge(index, neighbor);
+            // If there is no edge then it must be a parent neighbor
+            if edge.is_none() {
+                edge = self.graph.find_edge(neighbor, index);
+            }
+            let edge_w = self.graph.edge_weight(edge.unwrap());
+            out_dict.set_item(neighbor.index(), edge_w)?;
+        }
+        Ok(out_dict.into())
+    }
+
+    pub fn degree(&self, node: usize) -> usize {
+        let index = NodeIndex::new(node);
+        let neighbors = self.graph.edges(index);
+        neighbors.count()
+    }
+}
+
+#[pyproto]
+impl PyMappingProtocol for PyGraph {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.graph.node_count())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate petgraph;
 extern crate pyo3;
 
 mod dag_isomorphism;
+mod graph;
 
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
@@ -1033,6 +1034,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(floyd_warshall))?;
     m.add_wrapped(wrap_pyfunction!(layers))?;
     m.add_class::<PyDAG>()?;
+    m.add_class::<graph::PyGraph>()?;
     Ok(())
 }
 

--- a/tests/graph/test_adj.py
+++ b/tests/graph/test_adj.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestAdj(unittest.TestCase):
+    def test_single_neighbor(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, {'a': 1})
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_c, {'a': 2})
+        res = graph.adj(node_a)
+        self.assertEqual({node_b: {'a': 1}, node_c: {'a': 2}}, res)
+
+    def test_no_neighbor(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        self.assertEqual({}, graph.adj(node_a))

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -1,0 +1,117 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestEdges(unittest.TestCase):
+
+    def test_get_edge_data(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        res = graph.get_edge_data(node_a, node_b)
+        self.assertEqual("Edgy", res)
+
+    def test_get_all_edge_data(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        graph.add_edge(node_a, node_b, 'b')
+        res = graph.get_all_edge_data(node_a, node_b)
+        self.assertIn('b', res)
+        self.assertIn('Edgy', res)
+
+    def test_no_edge(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(Exception, graph.get_edge_data,
+                          node_a, node_b)
+
+    def test_has_edge(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, {})
+        self.assertTrue(graph.has_edge(node_a, node_b))
+        self.assertTrue(graph.has_edge(node_b, node_a))
+
+    def test_has_edge_no_edge(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertFalse(graph.has_edge(node_a, node_b))
+
+    def test_edges(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, "Super edgy")
+        self.assertEqual(["Edgy", "Super edgy"], graph.edges())
+
+    def test_edges_empty(self):
+        graph = retworkx.PyGraph()
+        graph.add_node('a')
+        self.assertEqual([], graph.edges())
+
+    def test_add_duplicates(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('a')
+        graph.add_edge(node_a, node_b, 'a')
+        graph.add_edge(node_a, node_b, 'b')
+        self.assertEqual(['a', 'b'], graph.edges())
+
+    def test_remove_no_edge(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(Exception, graph.remove_edge,
+                          node_a, node_b)
+
+    def test_remove_edge_single(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge(node_a, node_b)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_multiple(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_b, 'super_edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual(['super_edgy'], graph.edges())
+
+    def test_remove_edge_from_index(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b =graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edge_no_edge(self):
+        graph = retworkx.PyGraph()
+        graph.add_node('a')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -112,7 +112,7 @@ class TestEdges(unittest.TestCase):
     def test_remove_edge_from_index(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')
-        node_b =graph.add_node('b')
+        node_b = graph.add_node('b')
         graph.add_edge(node_a, node_b, 'edgy')
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -42,6 +42,13 @@ class TestEdges(unittest.TestCase):
         self.assertRaises(Exception, graph.get_edge_data,
                           node_a, node_b)
 
+    def test_no_edge_get_all_edge_data(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(Exception, graph.get_all_edge_data,
+                          node_a, node_b)
+
     def test_has_edge(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')
@@ -115,3 +122,12 @@ class TestEdges(unittest.TestCase):
         graph.add_node('a')
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
+
+    def test_degree(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, "Super edgy")
+        self.assertEqual(2, graph.degree(node_b))

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestNodes(unittest.TestCase):
+
+    def test_nodes(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        graph.add_node('b')
+        res = graph.nodes()
+        self.assertEqual(['a', 'b'], res)
+        self.assertEqual([0, 1], graph.node_indexes())
+
+    def test_no_nodes(self):
+        graph = retworkx.PyGraph()
+        self.assertEqual([], graph.nodes())
+        self.assertEqual([], graph.node_indexes())
+
+    def test_remove_node(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_node('c')
+        graph.remove_node(node_b)
+        res = graph.nodes()
+        self.assertEqual(['a', 'c'], res)
+        self.assertEqual([0, 2], graph.node_indexes())
+
+    def test_get_node_data(self):
+        graph = retworkx.PyDAG()
+        graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertEqual('b', graph.get_node_data(node_b))
+
+    def test_get_node_data_bad_index(self):
+        graph = retworkx.PyDAG()
+        graph.add_node('a')
+        graph.add_node('b')
+        self.assertRaises(IndexError, graph.get_node_data, 42)
+
+    def test_pygraph_length(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'An_edge')
+        self.assertEqual(2, len(graph))
+
+    def test_pygraph_length_empty(self):
+        graph = retworkx.PyDAG()
+        self.assertEqual(0, len(graph))

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -19,7 +19,7 @@ class TestNodes(unittest.TestCase):
 
     def test_nodes(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
+        graph.add_node('a')
         graph.add_node('b')
         res = graph.nodes()
         self.assertEqual(['a', 'b'], res)
@@ -32,7 +32,7 @@ class TestNodes(unittest.TestCase):
 
     def test_remove_node(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
+        graph.add_node('a')
         node_b = graph.add_node('b')
         graph.add_node('c')
         graph.remove_node(node_b)

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -41,13 +41,13 @@ class TestNodes(unittest.TestCase):
         self.assertEqual([0, 2], graph.node_indexes())
 
     def test_get_node_data(self):
-        graph = retworkx.PyDAG()
+        graph = retworkx.PyGraph()
         graph.add_node('a')
         node_b = graph.add_node('b')
         self.assertEqual('b', graph.get_node_data(node_b))
 
     def test_get_node_data_bad_index(self):
-        graph = retworkx.PyDAG()
+        graph = retworkx.PyGraph()
         graph.add_node('a')
         graph.add_node('b')
         self.assertRaises(IndexError, graph.get_node_data, 42)
@@ -60,5 +60,5 @@ class TestNodes(unittest.TestCase):
         self.assertEqual(2, len(graph))
 
     def test_pygraph_length_empty(self):
-        graph = retworkx.PyDAG()
+        graph = retworkx.PyGraph()
         self.assertEqual(0, len(graph))


### PR DESCRIPTION
This commit adds a new class to retworkx PyGraph which is used to build
an undirected graph. Right now it only supports basic operations for
adding/removing nodes and edges and some graph queries (like neighbors,
etc). Additional, algorithms will be added for this in the future.

TODO:

- [x] add test
- [x] add docs

Fixes #34 

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
