### PR TITLE
Remove invalid flag for coverage job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
         - pip install -U setuptools-rust
         - gem install coveralls-lcov
         - export CARGO_INCREMENTAL=0
-        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
         - python setup.py develop
       script:
         - export CARGO_INCREMENTAL=0


### PR DESCRIPTION
The coverage job requires setting the -Zno-landing-pads flag, however on
the current version of rust nightly this flag has been removed (see:
rust-lang/rust#70175) and the job is no longer working. This commit works
around this by removing the flag to fix the job (see mozilla/grcov#427
for more details).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
