### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ name = "retworkx"
 crate-type = ["cdylib"]
 
 [dependencies]
-petgraph = "0.5"
+petgraph = "0.5.1"
 fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
-version = "0.9.2"
+version = "0.10.1"
 features = ["extension-module"]


### PR DESCRIPTION
There have been recent releases of both PyO3 and petgraph that add some
bugfixes and api changes. It doesn't look like this directly effects any
of the usage in retworkx, but it's best to keep it up-to-date
(especially for PyO3 because there is ongoing work to remove
specialization which will allow building with rust stable once it's finished and then subsequently released).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
