### PR TITLE
Add support for deepcopy/pickle to PyGraph

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -15,7 +15,7 @@ use std::ops::{Index, IndexMut};
 use pyo3::class::PyMappingProtocol;
 use pyo3::exceptions::IndexError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyLong, PyTuple};
 use pyo3::Python;
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -26,7 +26,6 @@ use petgraph::visit::{
     IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences,
     NodeCompactIndexable, NodeCount, NodeIndexable, Visitable,
 };
-
 use super::NoEdgeBetweenNodes;
 
 #[pyclass(module = "retworkx")]
@@ -194,6 +193,64 @@ impl PyGraph {
         PyGraph {
             graph: StableUnGraph::<PyObject, PyObject>::default(),
         }
+    }
+    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        let out_dict = PyDict::new(py);
+        let node_dict =  PyDict::new(py);
+        let mut out_list: Vec<PyObject> = Vec::new();
+        out_dict.set_item("nodes", node_dict)?;
+        for node_index in self.graph.node_indices() {
+            let node_data = self.graph.node_weight(node_index).unwrap();
+            node_dict.set_item(node_index.index(), node_data)?;
+        }
+        for edge in self.graph.edge_indices() {
+            let edge_w = self.graph.edge_weight(edge);
+            let endpoints = self.graph.edge_endpoints(edge).unwrap();
+
+            let triplet = (endpoints.0.index(), endpoints.1.index(), edge_w).to_object(py);
+            out_list.push(triplet);
+        }
+        let py_out_list: PyObject = PyList::new(py, out_list).into();
+        out_dict.set_item("edges", py_out_list)?;
+        Ok(out_dict.into())
+    }
+
+    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+        self.graph = StableUnGraph::<PyObject, PyObject>::default();
+        let dict_state = state.cast_as::<PyDict>(py)?;
+        let nodes_dict =
+            dict_state.get_item("nodes").unwrap().downcast::<PyDict>()?;
+        let edges_list =
+            dict_state.get_item("edges").unwrap().downcast::<PyList>()?;
+        let mut index_count = 0;
+        for raw_index in nodes_dict.keys().iter() {
+            let tmp_index = raw_index.downcast::<PyLong>()?;
+            let index: usize = tmp_index.extract()?;
+            if index > index_count {
+                for _ in 0..index - index_count {
+                    let tmp_node = self.graph.add_node(py.None());
+                    self.graph.remove_node(tmp_node);
+                }
+
+            }
+            let raw_data = nodes_dict.get_item(index).unwrap();
+            self.graph.add_node(raw_data.into());
+            index_count = index;
+        }
+
+        for raw_edge in edges_list.iter() {
+            let edge = raw_edge.downcast::<PyTuple>()?;
+            let raw_p_index = edge.get_item(0).downcast::<PyLong>()?;
+            let parent: usize = raw_p_index.extract()?;
+            let p_index = NodeIndex::new(parent);
+            let raw_c_index = edge.get_item(1).downcast::<PyLong>()?;
+            let child: usize = raw_c_index.extract()?;
+            let c_index = NodeIndex::new(child);
+            let edge_data = edge.get_item(2);
+
+            self.graph.add_edge(p_index, c_index, edge_data.into());
+        }
+        Ok(())
     }
 
     pub fn edges(&self, py: Python) -> PyObject {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -227,15 +227,20 @@ impl PyGraph {
         for raw_index in nodes_dict.keys().iter() {
             let tmp_index = raw_index.downcast::<PyLong>()?;
             let index: usize = tmp_index.extract()?;
-            if index > index_count {
-                for _ in 0..index - index_count {
+            let mut tmp_nodes: Vec<NodeIndex> = Vec::new();
+            if index > index_count + 1 {
+                let diff = index - (index_count + 1);
+                for _ in 0..diff {
                     let tmp_node = self.graph.add_node(py.None());
-                    self.graph.remove_node(tmp_node);
+                    tmp_nodes.push(tmp_node);
                 }
             }
             let raw_data = nodes_dict.get_item(index).unwrap();
-            self.graph.add_node(raw_data.into());
-            index_count = index;
+            let out_index = self.graph.add_node(raw_data.into());
+            for tmp_node in tmp_nodes {
+                self.graph.remove_node(tmp_node);
+            }
+            index_count = out_index.index();
         }
 
         for raw_edge in edges_list.iter() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -18,6 +18,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyLong, PyTuple};
 use pyo3::Python;
 
+use super::NoEdgeBetweenNodes;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::*;
 use petgraph::stable_graph::StableUnGraph;
@@ -26,7 +27,6 @@ use petgraph::visit::{
     IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences,
     NodeCompactIndexable, NodeCount, NodeIndexable, Visitable,
 };
-use super::NoEdgeBetweenNodes;
 
 #[pyclass(module = "retworkx")]
 pub struct PyGraph {
@@ -196,7 +196,7 @@ impl PyGraph {
     }
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         let out_dict = PyDict::new(py);
-        let node_dict =  PyDict::new(py);
+        let node_dict = PyDict::new(py);
         let mut out_list: Vec<PyObject> = Vec::new();
         out_dict.set_item("nodes", node_dict)?;
         for node_index in self.graph.node_indices() {
@@ -207,7 +207,8 @@ impl PyGraph {
             let edge_w = self.graph.edge_weight(edge);
             let endpoints = self.graph.edge_endpoints(edge).unwrap();
 
-            let triplet = (endpoints.0.index(), endpoints.1.index(), edge_w).to_object(py);
+            let triplet = (endpoints.0.index(), endpoints.1.index(), edge_w)
+                .to_object(py);
             out_list.push(triplet);
         }
         let py_out_list: PyObject = PyList::new(py, out_list).into();
@@ -231,7 +232,6 @@ impl PyGraph {
                     let tmp_node = self.graph.add_node(py.None());
                     self.graph.remove_node(tmp_node);
                 }
-
             }
             let raw_data = nodes_dict.get_item(index).unwrap();
             self.graph.add_node(raw_data.into());

--- a/tests/graph/test_deepcopy.py
+++ b/tests/graph/test_deepcopy.py
@@ -27,3 +27,15 @@ class TestDeepcopy(unittest.TestCase):
         dag_a.add_edge(node_b, node_c, 'edge_2')
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyGraph)
+
+    def test_deepcopy_with_holes_returns_graph(self):
+        dag_a = retworkx.PyGraph()
+        node_a = dag_a.add_node('a_1')
+        node_b = dag_a.add_node('a_2')
+        dag_a.add_edge(node_a, node_b, 'edge_1')
+        node_c = dag_a.add_node('a_3')
+        dag_a.add_edge(node_b, node_c, 'edge_2')
+        dag_a.remove_node(node_b)
+        dag_b = copy.deepcopy(dag_a)
+        self.assertIsInstance(dag_b, retworkx.PyGraph)
+        self.assertEqual([node_a, node_c], dag_b.node_indexes())

--- a/tests/graph/test_deepcopy.py
+++ b/tests/graph/test_deepcopy.py
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import copy
+import unittest
+
+import retworkx
+
+
+class TestDeepcopy(unittest.TestCase):
+
+    def test_deepcopy_returns_graph(self):
+        dag_a = retworkx.PyGraph()
+        node_a = dag_a.add_node('a_1')
+        node_b = dag_a.add_node('a_2')
+        dag_a.add_edge(node_a, node_b, 'edge_1')
+        node_c = dag_a.add_node('a_3')
+        dag_a.add_edge(node_b, node_c, 'edge_2')
+        dag_b = copy.deepcopy(dag_a)
+        self.assertIsInstance(dag_b, retworkx.PyGraph)


### PR DESCRIPTION
The PyGraph class was missing a __getstate__ and __setstate__ function
which were needed to enable support for pickling and deepcopy. This
commit adds the missing methods so PyGraph objects can be deepcopied.
One note on the test is that there aren't isomorphism functions that
support the pygraph type yet due to typing constraints a new trait will
need to be added for both PyGraph and PyDAG to leverage the existing
function. Until then the tests just assert that deepcopy() doesn't raise
and returns a PyGraph object.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
