### PR TITLE
Add adjacency_matrix functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ name = "retworkx"
 crate-type = ["cdylib"]
 
 [dependencies]
-petgraph = "0.5"
+petgraph = "0.5.1"
 fixedbitset = "0.2.0"
 
 [dependencies.pyo3]
-version = "0.9.2"
+version = "0.10.1"
 features = ["extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ crate-type = ["cdylib"]
 [dependencies]
 petgraph = "0.5.1"
 fixedbitset = "0.2.0"
+numpy = "0.9.0"
+ndarray = "0.13.0"
 
 [dependencies.pyo3]
 version = "0.10.1"

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -447,7 +447,13 @@ retworkx API
    Return the adjacency matrix for a PyDAG class
 
    In the case where there are multiple edges between nodes the value in the
-   output matrix will be the sum of the edges' weights.
+   output matrix will be the sum of the edges' weights. One edge case to be
+   aware of with this function is with graphs that have removed nodes. If a
+   node is removed the node indexes may not be contiguous (ie if you add 3
+   nodes and then remove node 2). In these cases the dimensions of the adjacency
+   matrix returned will be larger than expected because node index 2 which is
+   no longer used. However in these cases, all entries will be ``0`` for that
+   node.
 
    :param PyDAG dag: The DAG used to generate the adjacency matrix from
    :param weight_fn callable: A callable object (function, lambda, etc) which
@@ -470,7 +476,13 @@ retworkx API
    Return the adjacency matrix for a PyGraph class
 
    In the case where there are multiple edges between nodes the value in the
-   output matrix will be the sum of the edges' weights.
+   output matrix will be the sum of the edges' weights. One edge case to be
+   aware of with this function is with graphs that have removed nodes. If a
+   node is removed the node indexes may not be contiguous (ie if you add 3
+   nodes and then remove node 2). In these cases the dimensions of the adjacency
+   matrix returned will be larger than expected because node index 2 which is
+   no longer used. However in these cases, all entries will be ``0`` for that
+   node.
 
    :param PyGraph graph: The graph used to generate the adjacency matrix from
    :param weight_fn callable: A callable object (function, lambda, etc) which

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -443,6 +443,51 @@ retworkx API
     :returns layers: A list of layers, each layer is a list of node data
     :rtype: list
 
+.. py:function:: dag_adjacency_matrix(dag, weight_fn):
+   Return the adjacency matrix for a PyDAG class
+
+   In the case where there are multiple edges between nodes the value in the
+   output matrix will be the sum of the edges' weights.
+
+   :param PyDAG dag: The DAG used to generate the adjacency matrix from
+   :param weight_fn callable: A callable object (function, lambda, etc) which
+       will be passed the edge object and expected to return a ``float``. This
+       tells retworkx/rust how to extract a numerical weight as a ``float``
+       for edge object. Some simple examples are::
+
+         dag_adjacency_matrix(dag, weight_fn: lambda x: 1)
+
+       to return a weight of 1 for all edges. Also::
+
+         dag_adjacency_matrix(dag, weight_fn: lambda x: float(x))
+
+       to cast the edge object as a float as the weight.
+
+   :return matrix: The adjacency matrix for the input dag as a numpy array
+   :rtype: numpy.ndarray
+
+.. py:function:: graph_adjacency_matrix(dag, weight_fn):
+   Return the adjacency matrix for a PyGraph class
+
+   In the case where there are multiple edges between nodes the value in the
+   output matrix will be the sum of the edges' weights.
+
+   :param PyGraph graph: The graph used to generate the adjacency matrix from
+   :param weight_fn callable: A callable object (function, lambda, etc) which
+       will be passed the edge object and expected to return a ``float``. This
+       tells retworkx/rust how to extract a numerical weight as a ``float``
+       for edge object. Some simple examples are::
+
+         graph_adjacency_matrix(graph, weight_fn: lambda x: 1)
+
+       to return a weight of 1 for all edges. Also::
+
+         graph_adjacency_matrix(graph, weight_fn: lambda x: float(x))
+
+       to cast the edge object as a float as the weight.
+
+   :return matrix: The adjacency matrix for the input dag as a numpy array
+   :rtype: numpy.ndarray
 
 .. py:class:: PyGraph
    A class for creating undirected graphs.

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
     packages=["retworkx"],
     zip_safe=False,
     python_requires=">=3.5",
+    install_requires=['numpy>=0.16.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
     packages=["retworkx"],
     zip_safe=False,
     python_requires=">=3.5",
-    install_requires=['numpy>=0.16.0'],
+    install_requires=['numpy>=1.16.0'],
 )

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -31,7 +31,7 @@ use super::NoEdgeBetweenNodes;
 
 #[pyclass(module = "retworkx")]
 pub struct PyGraph {
-    graph: StableUnGraph<PyObject, PyObject>,
+    pub graph: StableUnGraph<PyObject, PyObject>,
 }
 
 pub type Edges<'a, E> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use petgraph::visit::{
 };
 
 use ndarray::prelude::*;
-use numpy::ToPyArray;
+use numpy::IntoPyArray;
 
 #[pyclass(module = "retworkx")]
 pub struct PyDAG {
@@ -1042,7 +1042,7 @@ fn dag_adjacency_matrix(
         let j = edge.target().index();
         matrix[[i, j]] += edge_weight;
     }
-    Ok(matrix.to_pyarray(py).into())
+    Ok(matrix.into_pyarray(py).into())
 }
 
 #[pyfunction]
@@ -1066,7 +1066,7 @@ fn graph_adjacency_matrix(
         matrix[[i, j]] += edge_weight;
         matrix[[j, i]] += edge_weight;
     }
-    Ok(matrix.to_pyarray(py).into())
+    Ok(matrix.into_pyarray(py).into())
 }
 
 #[pymodule]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 // under the License.
 
 extern crate fixedbitset;
+extern crate ndarray;
+extern crate numpy;
 extern crate petgraph;
 extern crate pyo3;
 
@@ -40,14 +42,17 @@ use petgraph::visit::{
     NodeIndexable, Reversed, Visitable,
 };
 
+use ndarray::prelude::*;
+use numpy::ToPyArray;
+
 #[pyclass(module = "retworkx")]
 pub struct PyDAG {
-    graph: StableDiGraph<PyObject, PyObject>,
+    pub graph: StableDiGraph<PyObject, PyObject>,
     cycle_state: algo::DfsSpace<
         NodeIndex,
         <StableDiGraph<PyObject, PyObject> as Visitable>::Map,
     >,
-    check_cycle: bool,
+    pub check_cycle: bool,
 }
 
 pub type Edges<'a, E> =
@@ -1017,6 +1022,53 @@ fn layers(
     Ok(PyList::new(py, output).into())
 }
 
+#[pyfunction]
+fn dag_adjacency_matrix(
+    py: Python,
+    graph: &PyDAG,
+    weight_fn: PyObject,
+) -> PyResult<PyObject> {
+    let n = graph.graph.node_bound();
+    let mut matrix = Array::<f64, _>::zeros((n, n).f());
+
+    let weight_callable = |a: &PyObject| -> PyResult<PyObject> {
+        let res = weight_fn.call1(py, (a,))?;
+        Ok(res.to_object(py))
+    };
+    for edge in graph.graph.edge_references() {
+        let edge_weight_raw = weight_callable(&edge.weight())?;
+        let edge_weight: f64 = edge_weight_raw.extract(py)?;
+        let i = edge.source().index();
+        let j = edge.target().index();
+        matrix[[i, j]] += edge_weight;
+    }
+    Ok(matrix.to_pyarray(py).into())
+}
+
+#[pyfunction]
+fn graph_adjacency_matrix(
+    py: Python,
+    graph: &graph::PyGraph,
+    weight_fn: PyObject,
+) -> PyResult<PyObject> {
+    let n = graph.graph.node_bound();
+    let mut matrix = Array::<f64, _>::zeros((n, n).f());
+
+    let weight_callable = |a: &PyObject| -> PyResult<PyObject> {
+        let res = weight_fn.call1(py, (a,))?;
+        Ok(res.to_object(py))
+    };
+    for edge in graph.graph.edge_references() {
+        let edge_weight_raw = weight_callable(&edge.weight())?;
+        let edge_weight: f64 = edge_weight_raw.extract(py)?;
+        let i = edge.source().index();
+        let j = edge.target().index();
+        matrix[[i, j]] += edge_weight;
+        matrix[[j, i]] += edge_weight;
+    }
+    Ok(matrix.to_pyarray(py).into())
+}
+
 #[pymodule]
 fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -1033,6 +1085,8 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(floyd_warshall))?;
     m.add_wrapped(wrap_pyfunction!(layers))?;
+    m.add_wrapped(wrap_pyfunction!(dag_adjacency_matrix))?;
+    m.add_wrapped(wrap_pyfunction!(graph_adjacency_matrix))?;
     m.add_class::<PyDAG>()?;
     m.add_class::<graph::PyGraph>()?;
     Ok(())

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -1,0 +1,96 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+import numpy as np
+
+
+class TestDAGAdjacencyMatrix(unittest.TestCase):
+    def test_single_neighbor(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        dag.add_child(node_a, 'b', {'a': 1})
+        dag.add_child(node_a, 'c', {'a': 2})
+        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array(
+                [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                dtype=np.float64),
+            res))
+
+    def test_float_cast_weight_func(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        dag.add_child(node_a, 'b', 7.0)
+        res = retworkx.dag_adjacency_matrix(dag, lambda x: float(x))
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0.0, 7.0], [0.0, 0.0]]), res))
+
+    def test_multigraph_sum_cast_weight_func(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', 7.0)
+        dag.add_edge(node_a, node_b, 0.5)
+        res = retworkx.dag_adjacency_matrix(dag, lambda x: float(x))
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0.0, 7.5], [0.0, 0.0]]), res))
+
+    def test_graph_to_dag_adjacency_matrix(self):
+        graph = retworkx.PyGraph()
+        self.assertRaises(TypeError, retworkx.dag_adjacency_matrix, graph)
+
+
+class TestGraphAdjacencyMatrix(unittest.TestCase):
+    def test_single_neighbor(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edge_a')
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, 'edge_b')
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array(
+                [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+                dtype=np.float64),
+            res))
+
+    def test_float_cast_weight_func(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 7.0)
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: float(x))
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0.0, 7.0], [7.0, 0.0]]), res))
+
+    def test_multigraph_sum_cast_weight_func(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 7.0)
+        graph.add_edge(node_a, node_b, 0.5)
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: float(x))
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0.0, 7.5], [7.5, 0.0]]), res))
+
+    def test_dag_to_graph_adjacency_matrix(self):
+        dag = retworkx.PyDAG()
+        self.assertRaises(TypeError, retworkx.graph_adjacency_matrix, dag)

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -53,6 +53,24 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         graph = retworkx.PyGraph()
         self.assertRaises(TypeError, retworkx.dag_adjacency_matrix, graph)
 
+    def test_no_edge_dag_adjacency_matrix(self):
+        dag = retworkx.PyDAG()
+        for i in range(50):
+            dag.add_node(i)
+        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        self.assertTrue(np.array_equal(np.zeros([50, 50]), res))
+
+    def test_dag_with_index_holes(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', 1)
+        dag.add_child(node_a, 'c', 1)
+        dag.remove_node(node_b)
+        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0, 0, 1], [0, 0, 0], [0, 0, 0]]), res))
+
 
 class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_single_neighbor(self):
@@ -94,3 +112,23 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_dag_to_graph_adjacency_matrix(self):
         dag = retworkx.PyDAG()
         self.assertRaises(TypeError, retworkx.graph_adjacency_matrix, dag)
+
+    def test_no_edge_dag_adjacency_matrix(self):
+        graph = retworkx.PyGraph()
+        for i in range(50):
+            graph.add_node(i)
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
+        self.assertTrue(np.array_equal(np.zeros([50, 50]), res))
+
+    def test_graph_with_index_holes(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 1)
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_c, 1)
+        graph.remove_node(node_b)
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
+        self.assertIsInstance(res, np.ndarray)
+        self.assertTrue(np.array_equal(
+            np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]]), res))


### PR DESCRIPTION
This commit adds 2 new functions to the retworkx module,
graph_adjacency_matrix and dag_adjacency_matrix for returing the
adjacency matrix as a numpy array for PyGraph and PyDAG respectively.

- [x] Add tests
- [x] Add docs

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
