### PR TITLE
Allow failures on the s390x travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ stages:
 
 jobs:
   fast_finish: true
+  allow_failures:
+    - name: Python 3.7 Tests s390x Linux
   include:
     - name: Compile and rustfmt
       language: rust


### PR DESCRIPTION
The s390x travis environment has a lot of issues, this is why we haven't
built wheels for s390x. Additionally, it looks like the configuration of
/tmp in the s390x is not working, users have reported issues with space
limitations [1] and in #75 the job is failing because pip can't use /tmp to
build a numpy wheel. Until all of these are fixed and the ci environment
for s390x is more stable this commit makes the CI job non-blocking.

[1] https://travis-ci.community/t/no-space-left-on-device-for-system-z/5954/10

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
