### PR TITLE
Bump version strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retworkx"
 description = "A python graph library implemented in Rust"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def readme():
 
 setup(
     name="retworkx",
-    version="0.3.4",
+    version="0.4.0",
     description="A python graph library implemented in Rust",
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
While the next release is probably a little while away enough new
features have landed since 0.3.4 that we can safely know that the next
release is 0.4.0. In preparation for that this bumps the version strings
in the setup.py and Cargo.toml, this is mostly to facilitate testing so
that we know when we're comparing a released version vs current master.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
