### PR TITLE
Fix edge case with *_adjacency_matrix() functions

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -447,13 +447,7 @@ retworkx API
    Return the adjacency matrix for a PyDAG class
 
    In the case where there are multiple edges between nodes the value in the
-   output matrix will be the sum of the edges' weights. One edge case to be
-   aware of with this function is with graphs that have removed nodes. If a
-   node is removed the node indexes may not be contiguous (ie if you add 3
-   nodes and then remove node 2). In these cases the dimensions of the adjacency
-   matrix returned will be larger than expected because node index 2 which is
-   no longer used. However in these cases, all entries will be ``0`` for that
-   node.
+   output matrix will be the sum of the edges' weights.
 
    :param PyDAG dag: The DAG used to generate the adjacency matrix from
    :param weight_fn callable: A callable object (function, lambda, etc) which
@@ -476,13 +470,7 @@ retworkx API
    Return the adjacency matrix for a PyGraph class
 
    In the case where there are multiple edges between nodes the value in the
-   output matrix will be the sum of the edges' weights. One edge case to be
-   aware of with this function is with graphs that have removed nodes. If a
-   node is removed the node indexes may not be contiguous (ie if you add 3
-   nodes and then remove node 2). In these cases the dimensions of the adjacency
-   matrix returned will be larger than expected because node index 2 which is
-   no longer used. However in these cases, all entries will be ``0`` for that
-   node.
+   output matrix will be the sum of the edges' weights.
 
    :param PyGraph graph: The graph used to generate the adjacency matrix from
    :param weight_fn callable: A callable object (function, lambda, etc) which

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -31,6 +31,7 @@ use petgraph::visit::{
 #[pyclass(module = "retworkx")]
 pub struct PyGraph {
     pub graph: StableUnGraph<PyObject, PyObject>,
+    pub node_removed: bool,
 }
 
 pub type Edges<'a, E> =
@@ -192,6 +193,7 @@ impl PyGraph {
     fn new() -> Self {
         PyGraph {
             graph: StableUnGraph::<PyObject, PyObject>::default(),
+            node_removed: false,
         }
     }
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
@@ -344,7 +346,7 @@ impl PyGraph {
     pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
         let index = NodeIndex::new(node);
         self.graph.remove_node(index);
-
+        self.node_removed = true;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub struct PyDAG {
         <StableDiGraph<PyObject, PyObject> as Visitable>::Map,
     >,
     pub check_cycle: bool,
+    pub node_removed: bool,
 }
 
 pub type Edges<'a, E> =
@@ -242,6 +243,7 @@ impl PyDAG {
             graph: StableDiGraph::<PyObject, PyObject>::new(),
             cycle_state: algo::DfsSpace::default(),
             check_cycle,
+            node_removed: false,
         }
     }
 
@@ -435,7 +437,7 @@ impl PyDAG {
     pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
         let index = NodeIndex::new(node);
         self.graph.remove_node(index);
-
+        self.node_removed = true;
         Ok(())
     }
 
@@ -1031,7 +1033,21 @@ fn dag_adjacency_matrix(
     graph: &PyDAG,
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
-    let n = graph.graph.node_bound();
+    let node_map: Option<HashMap<NodeIndex, usize>>;
+    let n: usize;
+    if graph.node_removed {
+        let mut node_hash_map: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut count = 0;
+        for node in graph.graph.node_indices() {
+            node_hash_map.insert(node, count);
+            count += 1;
+        }
+        n = count;
+        node_map = Some(node_hash_map);
+    } else {
+        n = graph.graph.node_bound();
+        node_map = None;
+    }
     let mut matrix = Array::<f64, _>::zeros((n, n).f());
 
     let weight_callable = |a: &PyObject| -> PyResult<PyObject> {
@@ -1041,8 +1057,20 @@ fn dag_adjacency_matrix(
     for edge in graph.graph.edge_references() {
         let edge_weight_raw = weight_callable(&edge.weight())?;
         let edge_weight: f64 = edge_weight_raw.extract(py)?;
-        let i = edge.source().index();
-        let j = edge.target().index();
+        let source = edge.source();
+        let target = edge.target();
+        let i: usize;
+        let j: usize;
+        match &node_map {
+            Some(map) => {
+                i = *map.get(&source).unwrap();
+                j = *map.get(&target).unwrap();
+            }
+            None => {
+                i = source.index();
+                j = target.index();
+            }
+        }
         matrix[[i, j]] += edge_weight;
     }
     Ok(matrix.into_pyarray(py).into())
@@ -1054,7 +1082,21 @@ fn graph_adjacency_matrix(
     graph: &graph::PyGraph,
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
-    let n = graph.graph.node_bound();
+    let node_map: Option<HashMap<NodeIndex, usize>>;
+    let n: usize;
+    if graph.node_removed {
+        let mut node_hash_map: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut count = 0;
+        for node in graph.graph.node_indices() {
+            node_hash_map.insert(node, count);
+            count += 1;
+        }
+        n = count;
+        node_map = Some(node_hash_map);
+    } else {
+        n = graph.graph.node_bound();
+        node_map = None;
+    }
     let mut matrix = Array::<f64, _>::zeros((n, n).f());
 
     let weight_callable = |a: &PyObject| -> PyResult<PyObject> {
@@ -1064,8 +1106,20 @@ fn graph_adjacency_matrix(
     for edge in graph.graph.edge_references() {
         let edge_weight_raw = weight_callable(&edge.weight())?;
         let edge_weight: f64 = edge_weight_raw.extract(py)?;
-        let i = edge.source().index();
-        let j = edge.target().index();
+        let source = edge.source();
+        let target = edge.target();
+        let i: usize;
+        let j: usize;
+        match &node_map {
+            Some(map) => {
+                i = *map.get(&source).unwrap();
+                j = *map.get(&target).unwrap();
+            }
+            None => {
+                i = source.index();
+                j = target.index();
+            }
+        }
         matrix[[i, j]] += edge_weight;
         matrix[[j, i]] += edge_weight;
     }

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -69,7 +69,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
-            np.array([[0, 0, 1], [0, 0, 0], [0, 0, 0]]), res))
+            np.array([[0, 1], [0, 0]]), res))
 
 
 class TestGraphAdjacencyMatrix(unittest.TestCase):
@@ -131,4 +131,4 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
-            np.array([[0, 0, 1], [0, 0, 0], [1, 0, 0]]), res))
+            np.array([[0, 1], [1, 0]]), res))


### PR DESCRIPTION
This commit fixes an edge case with the adjacency matrix functions
around holes in the node indexes. Previously the nodes were assumed to
be contiguous but in the case of node removals it was possible to have
holes in the list of indexes. This would result in a matrix that was
larger than expected because it was building it based on the maximum
number of nodes during the lifetime of the graph. To fix this issue a
new attribute is added to PyDAG and PyGraph to track if nodes have been
removed. If nodes have been removed a mapping of node_ids to compressed
indexes are built and as the edges are iterated over the compressed
index is used in the matrix. If no nodes are removed the mapping step
is skipped since it is unecessary.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
