### PR TITLE
Fix clippy warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,7 +645,7 @@ impl PyDAG {
                 return Ok(self.graph.node_weight(edge.target()).unwrap());
             }
         }
-        return Err(NoSuitableNeighbors::py_err("No suitable neighbor"));
+        Err(NoSuitableNeighbors::py_err("No suitable neighbor"))
     }
 }
 


### PR DESCRIPTION
In #25 a small warning from cargo clippy was introduced about a
unessecary return statement. Since rust doesn't require a return
statement if the last line in a function doesn't have a semicolor. While
this doesn't harm anything not having the return fixes the warning,
which will make it easier to debug future issues identified by running
cargo clippy. This commit makes that small cleanup.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
