### PR TITLE
Add add_nodes_from and add_edges_from methods

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -136,6 +136,25 @@ retworkx API
         :returns index: The index of the newly created node
         :rtype: int
 
+    .. py:method:: add_nodes_from(self, obj_list):
+        Add new nodes to the dag.
+
+        :param list obj_list: A list of python object to attach to the graph.
+
+        :returns indexes: A list of int indexes of the newly created nodes
+        :rtype: list
+
+    .. py:method:: add_edges_from(self, obj_list):
+        Add new edges to the dag.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child, obj)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added, and obj is the python object for the edge data.
+
+        :returns indexes: A list of int indexes of the newly created edges
+        :rtype: list
+
     .. py:method:: add_child(self, parent, obj, edge):
         Add a new child node to the dag.
 
@@ -611,12 +630,31 @@ retworkx API
         :raises: When the new edge will create a cycle
 
     .. py:method:: add_node(self, obj):
-        Add a new node to the dag.
+        Add a new node to the graph.
 
         :param obj: The python object to attach to the node
 
         :returns index: The index of the newly created node
         :rtype: int
+
+    .. py:method:: add_nodes_from(self, obj_list):
+        Add new nodes to the graph.
+
+        :param list obj_list: A list of python object to attach to the graph.
+
+        :returns indexes: A list of int indexes of the newly created nodes
+        :rtype: list
+
+    .. py:method:: add_edges_from(self, obj_list):
+        Add new edges to the graph.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child, obj)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added, and obj is the python object for the edge data.
+
+        :returns indexes: A list of int indexes of the newly created edges
+        :rtype: list
 
     .. py:method:: adj(self, node):
         Get the index and data for the neighbors of a node.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -141,7 +141,7 @@ retworkx API
 
         :param list obj_list: A list of python objects to attach to the graph.
 
-        :returns indexes: A list of int indexes of the newly created nodes
+        :returns indices: A list of int indices of the newly created nodes
         :rtype: list
 
     .. py:method:: add_edges_from(self, obj_list):
@@ -152,11 +152,11 @@ retworkx API
             ``child`` are integer indexes describing where an edge should be
             added, and obj is the python object for the edge data.
 
-        :returns indexes: A list of int indexes of the newly created edges
+        :returns indices: A list of int indices of the newly created edges
         :rtype: list
 
     .. py:method:: add_edges_from_no_data(self, obj_list):
-        Add new edges to the dag without data.
+        Add new edges to the dag without python data.
 
         :param list obj_list: A list of tuples of the form
             ``(parent, child)`` to attach to the graph. ``parent`` and
@@ -164,7 +164,7 @@ retworkx API
             added. Unlike :meth:`add_edges_from` there is no data payload and
             when the edge is created None will be used.
 
-        :returns indexes: A list of int indexes of the newly created edges
+        :returns indices: A list of int indices of the newly created edges
         :rtype: list
 
     .. py:method:: add_child(self, parent, obj, edge):
@@ -642,7 +642,7 @@ retworkx API
 
         :param list obj_list: A list of python object to attach to the graph.
 
-        :returns indexes: A list of int indexes of the newly created nodes
+        :returns indices: A list of int indices of the newly created nodes
         :rtype: list
 
     .. py:method:: add_edges_from(self, obj_list):
@@ -653,11 +653,11 @@ retworkx API
             ``child`` are integer indexes describing where an edge should be
             added, and obj is the python object for the edge data.
 
-        :returns indexes: A list of int indexes of the newly created edges
+        :returns indices: A list of int indices of the newly created edges
         :rtype: list
 
    .. py:method:: add_edges_from_no_data(self, obj_list):
-        Add new edges to the dag without data.
+        Add new edges to the dag without python data.
 
         :param list obj_list: A list of tuples of the form
             ``(parent, child)`` to attach to the graph. ``parent`` and
@@ -665,7 +665,7 @@ retworkx API
             added. Unlike :meth:`add_edges_from` there is no data payload and
             when the edge is created None will be used.
 
-        :returns indexes: A list of int indexes of the newly created edges
+        :returns indices: A list of int indices of the newly created edges
         :rtype: list
 
     .. py:method:: adj(self, node):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -139,7 +139,7 @@ retworkx API
     .. py:method:: add_nodes_from(self, obj_list):
         Add new nodes to the dag.
 
-        :param list obj_list: A list of python object to attach to the graph.
+        :param list obj_list: A list of python objects to attach to the graph.
 
         :returns indexes: A list of int indexes of the newly created nodes
         :rtype: list

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -155,6 +155,18 @@ retworkx API
         :returns indexes: A list of int indexes of the newly created edges
         :rtype: list
 
+    .. py:method:: add_edges_from_no_data(self, obj_list):
+        Add new edges to the dag without data.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added. Unlike :meth:`add_edges_from` there is no data payload and
+            when the edge is created None will be used.
+
+        :returns indexes: A list of int indexes of the newly created edges
+        :rtype: list
+
     .. py:method:: add_child(self, parent, obj, edge):
         Add a new child node to the dag.
 
@@ -640,6 +652,18 @@ retworkx API
             ``(parent, child, obj)`` to attach to the graph. ``parent`` and
             ``child`` are integer indexes describing where an edge should be
             added, and obj is the python object for the edge data.
+
+        :returns indexes: A list of int indexes of the newly created edges
+        :rtype: list
+
+   .. py:method:: add_edges_from_no_data(self, obj_list):
+        Add new edges to the dag without data.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added. Unlike :meth:`add_edges_from` there is no data payload and
+            when the edge is created None will be used.
 
         :returns indexes: A list of int indexes of the newly created edges
         :rtype: list

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -376,6 +376,21 @@ impl PyGraph {
         Ok(out_list)
     }
 
+     pub fn add_edges_from_no_data(
+         &mut self,
+         py: Python,
+         obj_list: Vec<(usize, usize)>,
+     ) -> PyResult<Vec<usize>> {
+         let mut out_list: Vec<usize> = Vec::new();
+         for obj in obj_list {
+             let p_index = NodeIndex::new(obj.0);
+             let c_index = NodeIndex::new(obj.1);
+             let edge = self.graph.add_edge(p_index, c_index, py.None());
+             out_list.push(edge.index());
+         }
+         Ok(out_list)
+     }
+
     pub fn remove_edge(
         &mut self,
         node_a: usize,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -360,6 +360,20 @@ impl PyGraph {
         Ok(edge.index())
     }
 
+    pub fn add_edges_from(
+        &mut self,
+        obj_list: Vec<(usize, usize, PyObject)>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let p_index = NodeIndex::new(obj.0);
+            let c_index = NodeIndex::new(obj.1);
+            let edge = self.graph.add_edge(p_index, c_index, obj.2);
+            out_list.push(edge.index());
+        }
+        Ok(out_list)
+    }
+
     pub fn remove_edge(
         &mut self,
         node_a: usize,
@@ -388,6 +402,18 @@ impl PyGraph {
     pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
         let index = self.graph.add_node(obj);
         Ok(index.index())
+    }
+
+    pub fn add_nodes_from(
+        &mut self,
+        obj_list: Vec<PyObject>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let node_index = self.graph.add_node(obj);
+            out_list.push(node_index.index());
+        }
+        Ok(out_list)
     }
 
     pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -376,20 +376,20 @@ impl PyGraph {
         Ok(out_list)
     }
 
-     pub fn add_edges_from_no_data(
-         &mut self,
-         py: Python,
-         obj_list: Vec<(usize, usize)>,
-     ) -> PyResult<Vec<usize>> {
-         let mut out_list: Vec<usize> = Vec::new();
-         for obj in obj_list {
-             let p_index = NodeIndex::new(obj.0);
-             let c_index = NodeIndex::new(obj.1);
-             let edge = self.graph.add_edge(p_index, c_index, py.None());
-             out_list.push(edge.index());
-         }
-         Ok(out_list)
-     }
+    pub fn add_edges_from_no_data(
+        &mut self,
+        py: Python,
+        obj_list: Vec<(usize, usize)>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let p_index = NodeIndex::new(obj.0);
+            let c_index = NodeIndex::new(obj.1);
+            let edge = self.graph.add_edge(p_index, c_index, py.None());
+            out_list.push(edge.index());
+        }
+        Ok(out_list)
+    }
 
     pub fn remove_edge(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl PyDAG {
         // Only check for cycles if instance attribute is set to true
         if self.check_cycle {
             // Only check for a cycle (by running has_path_connecting) if
-            // the new edge could potentiall add a cycle
+            // the new edge could potentially add a cycle
             let cycle_check_required =
                 is_cycle_check_required(self, p_index, c_index);
             let state = Some(&mut self.cycle_state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,6 +499,21 @@ impl PyDAG {
         Ok(out_list)
     }
 
+    pub fn add_edges_from_no_data(
+        &mut self,
+        py: Python,
+        obj_list: Vec<(usize, usize)>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let p_index = NodeIndex::new(obj.0);
+            let c_index = NodeIndex::new(obj.1);
+            let edge = self._add_edge(p_index, c_index, py.None())?;
+            out_list.push(edge);
+        }
+        Ok(out_list)
+    }
+
     pub fn remove_edge(&mut self, parent: usize, child: usize) -> PyResult<()> {
         let p_index = NodeIndex::new(parent);
         let c_index = NodeIndex::new(child);

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -131,3 +131,22 @@ class TestEdges(unittest.TestCase):
         node_c = graph.add_node('c')
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(2, graph.degree(node_b))
+
+    def test_add_edge_from(self):
+        graph = retworkx.PyGraph()
+        nodes = list(range(4))
+        graph.add_nodes_from(nodes)
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        res = graph.add_edges_from(edge_list)
+        self.assertEqual(len(res), 5)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(3, graph.degree(0))
+        self.assertEqual(2, graph.degree(1))
+        self.assertEqual(3, graph.degree(2))
+        self.assertEqual(2, graph.degree(3))
+
+    def test_add_edge_from_empty(self):
+        graph = retworkx.PyGraph()
+        res = graph.add_edges_from([])
+        self.assertEqual([], res)

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -150,3 +150,22 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         res = graph.add_edges_from([])
         self.assertEqual([], res)
+
+    def test_add_edge_from_no_data(self):
+        graph = retworkx.PyGraph()
+        nodes = list(range(4))
+        graph.add_nodes_from(nodes)
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        res = graph.add_edges_from_no_data(edge_list)
+        self.assertEqual(len(res), 5)
+        self.assertEqual([None, None, None, None, None], graph.edges())
+        self.assertEqual(3, graph.degree(0))
+        self.assertEqual(2, graph.degree(1))
+        self.assertEqual(3, graph.degree(2))
+        self.assertEqual(2, graph.degree(3))
+
+    def test_add_edge_from_empty_no_data(self):
+        graph = retworkx.PyGraph()
+        res = graph.add_edges_from_no_data([])
+        self.assertEqual([], res)

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -62,3 +62,15 @@ class TestNodes(unittest.TestCase):
     def test_pygraph_length_empty(self):
         graph = retworkx.PyGraph()
         self.assertEqual(0, len(graph))
+
+    def test_add_nodes_from(self):
+        graph = retworkx.PyGraph()
+        nodes = list(range(100))
+        res = graph.add_nodes_from(nodes)
+        self.assertEqual(len(res), 100)
+        self.assertEqual(res, nodes)
+
+    def test_add_node_from_empty(self):
+        graph = retworkx.PyGraph()
+        res = graph.add_nodes_from([])
+        self.assertEqual(len(res), 0)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -160,3 +160,31 @@ class TestEdges(unittest.TestCase):
 
         with self.assertRaises(Exception):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
+
+    def test_add_edge_from(self):
+        dag = retworkx.PyDAG()
+        nodes = list(range(4))
+        dag.add_nodes_from(nodes)
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        res = dag.add_edges_from(edge_list)
+        self.assertEqual(len(res), 5)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], dag.edges())
+        self.assertEqual(3, dag.out_degree(0))
+        self.assertEqual(0, dag.in_degree(0))
+        self.assertEqual(1, dag.out_degree(1))
+        self.assertEqual(1, dag.out_degree(2))
+        self.assertEqual(2, dag.in_degree(3))
+
+    def test_add_edge_from_empty(self):
+        dag = retworkx.PyDAG()
+        res = dag.add_edges_from([])
+        self.assertEqual([], res)
+
+    def test_cycle_checking_at_init_nodes_from(self):
+        dag = retworkx.PyDAG(True)
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        node_c = dag.add_child(node_b, 'c', {})
+        with self.assertRaises(Exception):
+            dag.add_edges_from([(node_a, node_c, {}), (node_c, node_b, {})])

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -188,3 +188,31 @@ class TestEdges(unittest.TestCase):
         node_c = dag.add_child(node_b, 'c', {})
         with self.assertRaises(Exception):
             dag.add_edges_from([(node_a, node_c, {}), (node_c, node_b, {})])
+
+    def test_add_edge_from_no_data(self):
+        dag = retworkx.PyDAG()
+        nodes = list(range(4))
+        dag.add_nodes_from(nodes)
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        res = dag.add_edges_from_no_data(edge_list)
+        self.assertEqual(len(res), 5)
+        self.assertEqual([None, None, None, None, None], dag.edges())
+        self.assertEqual(3, dag.out_degree(0))
+        self.assertEqual(0, dag.in_degree(0))
+        self.assertEqual(1, dag.out_degree(1))
+        self.assertEqual(1, dag.out_degree(2))
+        self.assertEqual(2, dag.in_degree(3))
+
+    def test_add_edge_from_empty_no_data(self):
+        dag = retworkx.PyDAG()
+        res = dag.add_edges_from_no_data([])
+        self.assertEqual([], res)
+
+    def test_cycle_checking_at_init_nodes_from_no_data(self):
+        dag = retworkx.PyDAG(True)
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', {})
+        node_c = dag.add_child(node_b, 'c', {})
+        with self.assertRaises(Exception):
+            dag.add_edges_from_no_data([(node_a, node_c), (node_c, node_b)])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -135,3 +135,15 @@ class TestNodes(unittest.TestCase):
     def test_pydag_length_empty(self):
         dag = retworkx.PyDAG()
         self.assertEqual(0, len(dag))
+
+    def test_add_nodes_from(self):
+        dag = retworkx.PyDAG()
+        nodes = list(range(100))
+        res = dag.add_nodes_from(nodes)
+        self.assertEqual(len(res), 100)
+        self.assertEqual(res, nodes)
+
+    def test_add_node_from_empty(self):
+        dag = retworkx.PyDAG()
+        res = dag.add_nodes_from([])
+        self.assertEqual(len(res), 0)


### PR DESCRIPTION
This commit adds 2 methods to PyDAG and PyGraph, add_nodes_from() and
add_edges_from(). These methods take in lists of objects to add to the
graph to minimize the back and forth calling when adding many objects to
the graph at once. add_nodes_from() takes in a list of objects which
will be the data for the node, and add_nodes_from() takes in a list of
tuples with 2 node indexes for where the edge should be added and the
3rd tuple element is the data for the edge.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
