### PR TITLE
Add astar shortest_path function for PyGraph and PyDAG

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -563,13 +563,13 @@ retworkx API
 
   :param PyDAG graph: The input graph to use
   :param int node: The node index to compute the path from
-  :param goal_fn: A python callable that will take in 1 parameter a node's data
+  :param goal_fn: A python callable that will take in 1 parameter, a node's data
       object and will return a boolean which will be True if it is the finish
       node.
-  :param edge_cost_fn: A python callable that will take in 1 parameter, a edge's
+  :param edge_cost_fn: A python callable that will take in 1 parameter, an edge's
       data object and will return a float that represents the cost of that
       edge. It must be non-negative.
-  :param estimate_cost: A python callable that will take in 1 parameter, a
+  :param estimate_cost_fn: A python callable that will take in 1 parameter, a
       node's data object and will return a float which represents the estimated
       cost for the next node. The return must be non-negative. For the
       algorithm to find the actual shortest path, it should be admissible,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -541,13 +541,13 @@ retworkx API
 
   :param PyGraph graph: The input graph to use
   :param int node: The node index to compute the path from
-  :param goal_fn: A python callable that will take in 1 parameter a node's data
+  :param goal_fn: A python callable that will take in 1 parameter, a node's data
       object and will return a boolean which will be True if it is the finish
       node.
-  :param edge_cost_fn: A python callable that will take in 1 parameter, a edge's
+  :param edge_cost_fn: A python callable that will take in 1 parameter, an edge's
       data object and will return a float that represents the cost of that
       edge. It must be non-negative.
-  :param estimate_cost: A python callable that will take in 1 parameter, a
+  :param estimate_cost_fn: A python callable that will take in 1 parameter, a
       node's data object and will return a float which represents the estimated
       cost for the next node. The return must be non-negative. For the
       algorithm to find the actual shortest path, it should be admissible,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -505,6 +505,50 @@ retworkx API
    :return matrix: The adjacency matrix for the input dag as a numpy array
    :rtype: numpy.ndarray
 
+.. py:function:: graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+   Compute the A* shortest path for a PyGraph
+
+  :param PyGraph graph: The input graph to use
+  :param int node: The node index to compute the path from
+  :param goal_fn: A python callable that will take in 1 parameter a node's data
+      object and will return a boolean which will be True if it is the finish
+      node.
+  :param edge_cost_fn: A python callable that will take in 1 parameter, a edge's
+      data object and will return a float that represents the cost of that
+      edge. It must be non-negative.
+  :param estimate_cost: A python callable that will take in 1 parameter, a
+      node's data object and will return a float which represents the estimated
+      cost for the next node. The return must be non-negative. For the
+      algorithm to find the actual shortest path, it should be admissible,
+      meaning that it should never overestimate the actual cost to get to the
+      nearest goal node.
+
+  :return path: The computed shortest path between node and finish as a list
+      of node indices.
+  :rtype: list
+
+.. py:function:: dag_astar_shortest_path(dag, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+   Compute the A* shortest path for a PyDAG
+
+  :param PyDAG graph: The input graph to use
+  :param int node: The node index to compute the path from
+  :param goal_fn: A python callable that will take in 1 parameter a node's data
+      object and will return a boolean which will be True if it is the finish
+      node.
+  :param edge_cost_fn: A python callable that will take in 1 parameter, a edge's
+      data object and will return a float that represents the cost of that
+      edge. It must be non-negative.
+  :param estimate_cost: A python callable that will take in 1 parameter, a
+      node's data object and will return a float which represents the estimated
+      cost for the next node. The return must be non-negative. For the
+      algorithm to find the actual shortest path, it should be admissible,
+      meaning that it should never overestimate the actual cost to get to the
+      nearest goal node.
+
+  :return path: The computed shortest path between node and finish as a list
+      of node indices.
+  :rtype: list
+
 .. py:class:: PyGraph
    A class for creating undirected graphs.
 

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -16,7 +16,7 @@
 // https://github.com/petgraph/petgraph/blob/0.5.1/src/scored.rs
 // this was necessary to modify the error handling to allow python callables
 // to be use for the input functions for is_goal, edge_cost, estimate_cost
-// and return any exceptions raised in Python instaed of panickng
+// and return any exceptions raised in Python instead of panicking
 
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -1,0 +1,251 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// This module is copied and forked from the upstream petgraph repository,
+// specifically:
+// https://github.com/petgraph/petgraph/blob/0.5.1/src/astar.rs and
+// https://github.com/petgraph/petgraph/blob/0.5.1/src/scored.rs
+// this was necessary to modify the error handling to allow python callables
+// to be use for the input functions for is_goal, edge_cost, estimate_cost
+// and return any exceptions raised in Python instaed of panickng
+
+use std::cmp::Ordering;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::collections::{BinaryHeap, HashMap};
+
+use std::hash::Hash;
+
+use petgraph::visit::{EdgeRef, GraphBase, IntoEdges, VisitMap, Visitable};
+
+use petgraph::algo::Measure;
+use pyo3::prelude::*;
+
+/// `MinScored<K, T>` holds a score `K` and a scored object `T` in
+/// a pair for use with a `BinaryHeap`.
+///
+/// `MinScored` compares in reverse order by the score, so that we can
+/// use `BinaryHeap` as a min-heap to extract the score-value pair with the
+/// least score.
+///
+/// **Note:** `MinScored` implements a total order (`Ord`), so that it is
+/// possible to use float types as scores.
+#[derive(Copy, Clone, Debug)]
+pub struct MinScored<K, T>(pub K, pub T);
+
+impl<K: PartialOrd, T> PartialEq for MinScored<K, T> {
+    #[inline]
+    fn eq(&self, other: &MinScored<K, T>) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<K: PartialOrd, T> Eq for MinScored<K, T> {}
+
+impl<K: PartialOrd, T> PartialOrd for MinScored<K, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &MinScored<K, T>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: PartialOrd, T> Ord for MinScored<K, T> {
+    #[inline]
+    fn cmp(&self, other: &MinScored<K, T>) -> Ordering {
+        let a = &self.0;
+        let b = &other.0;
+        if a == b {
+            Ordering::Equal
+        } else if a < b {
+            Ordering::Greater
+        } else if a > b {
+            Ordering::Less
+        } else if a.ne(a) && b.ne(b) {
+            // these are the NaN cases
+            Ordering::Equal
+        } else if a.ne(a) {
+            // Order NaN less, so that it is last in the MinScore order
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
+    }
+}
+
+/// \[Generic\] A* shortest path algorithm.
+///
+/// Computes the shortest path from `start` to `finish`, including the total path cost.
+///
+/// `finish` is implicitly given via the `is_goal` callback, which should return `true` if the
+/// given node is the finish node.
+///
+/// The function `edge_cost` should return the cost for a particular edge. Edge costs must be
+/// non-negative.
+///
+/// The function `estimate_cost` should return the estimated cost to the finish for a particular
+/// node. For the algorithm to find the actual shortest path, it should be admissible, meaning that
+/// it should never overestimate the actual cost to get to the nearest goal node. Estimate costs
+/// must also be non-negative.
+///
+/// The graph should be `Visitable` and implement `IntoEdges`.
+///
+/// # Example
+/// ```
+/// use petgraph::Graph;
+/// use petgraph::algo::astar;
+///
+/// let mut g = Graph::new();
+/// let a = g.add_node((0., 0.));
+/// let b = g.add_node((2., 0.));
+/// let c = g.add_node((1., 1.));
+/// let d = g.add_node((0., 2.));
+/// let e = g.add_node((3., 3.));
+/// let f = g.add_node((4., 2.));
+/// g.extend_with_edges(&[
+///     (a, b, 2),
+///     (a, d, 4),
+///     (b, c, 1),
+///     (b, f, 7),
+///     (c, e, 5),
+///     (e, f, 1),
+///     (d, e, 1),
+/// ]);
+///
+/// // Graph represented with the weight of each edge
+/// // Edges with '*' are part of the optimal path.
+/// //
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4*    | 7     |
+/// // d       f       | 5
+/// // | 1*    | 1*    |
+/// // \------ e ------/
+///
+/// let path = astar(&g, a, |finish| finish == f, |e| *e.weight(), |_| 0);
+/// assert_eq!(path, Some((6, vec![a, d, e, f])));
+/// ```
+///
+/// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
+/// found.
+pub fn astar<G, F, H, K, IsGoal>(
+    graph: G,
+    start: G::NodeId,
+    mut is_goal: IsGoal,
+    mut edge_cost: F,
+    mut estimate_cost: H,
+) -> PyResult<Option<(K, Vec<G::NodeId>)>>
+where
+    G: IntoEdges + Visitable,
+    IsGoal: FnMut(G::NodeId) -> PyResult<bool>,
+    G::NodeId: Eq + Hash,
+    F: FnMut(G::EdgeRef) -> PyResult<K>,
+    H: FnMut(G::NodeId) -> PyResult<K>,
+    K: Measure + Copy,
+{
+    let mut visited = graph.visit_map();
+    let mut visit_next = BinaryHeap::new();
+    let mut scores = HashMap::new();
+    let mut path_tracker = PathTracker::<G>::new();
+
+    let zero_score = K::default();
+    scores.insert(start, zero_score);
+    let estimate = estimate_cost(start)?;
+    visit_next.push(MinScored(estimate, start));
+
+    while let Some(MinScored(_, node)) = visit_next.pop() {
+        let result = is_goal(node)?;
+        if result {
+            let path = path_tracker.reconstruct_path_to(node);
+            let cost = scores[&node];
+            return Ok(Some((cost, path)));
+        }
+
+        // Don't visit the same node several times, as the first time it was visited it was using
+        // the shortest available path.
+        if !visited.visit(node) {
+            continue;
+        }
+
+        // This lookup can be unwrapped without fear of panic since the node was necessarily scored
+        // before adding him to `visit_next`.
+        let node_score = scores[&node];
+
+        for edge in graph.edges(node) {
+            let next = edge.target();
+            if visited.is_visited(&next) {
+                continue;
+            }
+
+            let cost = edge_cost(edge)?;
+            let mut next_score = node_score + cost;
+
+            match scores.entry(next) {
+                Occupied(ent) => {
+                    let old_score = *ent.get();
+                    if next_score < old_score {
+                        *ent.into_mut() = next_score;
+                        path_tracker.set_predecessor(next, node);
+                    } else {
+                        next_score = old_score;
+                    }
+                }
+                Vacant(ent) => {
+                    ent.insert(next_score);
+                    path_tracker.set_predecessor(next, node);
+                }
+            }
+
+            let estimate = estimate_cost(next)?;
+            let next_estimate_score = next_score + estimate;
+            visit_next.push(MinScored(next_estimate_score, next));
+        }
+    }
+
+    Ok(None)
+}
+
+struct PathTracker<G>
+where
+    G: GraphBase,
+    G::NodeId: Eq + Hash,
+{
+    came_from: HashMap<G::NodeId, G::NodeId>,
+}
+
+impl<G> PathTracker<G>
+where
+    G: GraphBase,
+    G::NodeId: Eq + Hash,
+{
+    fn new() -> PathTracker<G> {
+        PathTracker {
+            came_from: HashMap::new(),
+        }
+    }
+
+    fn set_predecessor(&mut self, node: G::NodeId, previous: G::NodeId) {
+        self.came_from.insert(node, previous);
+    }
+
+    fn reconstruct_path_to(&self, last: G::NodeId) -> Vec<G::NodeId> {
+        let mut path = vec![last];
+
+        let mut current = last;
+        while let Some(&previous) = self.came_from.get(&current) {
+            path.push(previous);
+            current = previous;
+        }
+
+        path.reverse();
+
+        path
+    }
+}

--- a/tests/test_astar.py
+++ b/tests/test_astar.py
@@ -1,0 +1,169 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestAstarDAG(unittest.TestCase):
+
+    def test_astar_null_heuristic(self):
+        g = retworkx.PyDAG();
+        a = g.add_node("A")
+        b = g.add_node("B")
+        c = g.add_node("C")
+        d = g.add_node("D")
+        e = g.add_node("E")
+        f = g.add_node("F")
+        g.add_edge(a, b, 7)
+        g.add_edge(c, a, 9)
+        g.add_edge(a, d, 14)
+        g.add_edge(b, c, 10)
+        g.add_edge(d, c, 2)
+        g.add_edge(d, e, 9)
+        g.add_edge(b, f, 15)
+        g.add_edge(c, f, 11)
+        g.add_edge(e, f, 6)
+        path = retworkx.dag_astar_shortest_path(g, a,
+                                                lambda goal: goal == "E",
+                                                lambda x: float(x),
+                                                lambda y: 0)
+        expected = [a, d, e]
+        self.assertEqual(expected, path)
+
+    def test_astar_manhattan_heuristic(self):
+        g = retworkx.PyDAG()
+        a = g.add_node((0., 0.))
+        b = g.add_node((2., 0.))
+        c = g.add_node((1., 1.))
+        d = g.add_node((0., 2.))
+        e = g.add_node((3., 3.))
+        f = g.add_node((4., 2.))
+        no_path = g.add_node((5., 5.))  # no path to node
+        g.add_edge(a, b, 2.)
+        g.add_edge(a, d, 4.)
+        g.add_edge(b, c, 1.)
+        g.add_edge(b, f, 7.)
+        g.add_edge(c, e, 5.)
+        g.add_edge(e, f, 1.)
+        g.add_edge(d, e, 1.)
+
+        def heuristic_func(f):
+            x1, x2 = f
+            return abs(x2 - x1)
+
+        def finish_func(node, x):
+            return x == g.get_node_data(node)
+
+        expected = [
+            [0],
+            [0, 1],
+            [0, 1, 2],
+            [0, 3],
+            [0, 3, 4],
+            [0, 3, 4, 5],
+        ]
+
+        for index, end in enumerate([a, b, c, d, e, f]):
+            path = retworkx.dag_astar_shortest_path(
+                g, a, lambda finish: finish_func(end, finish),
+                lambda x: float(x), heuristic_func)
+            self.assertEqual(expected[index], path)
+
+        self.assertRaises(Exception, retworkx.dag_astar_shortest_path,
+                          (g, a, lambda finish: finish_func(no_path, finish),
+                           lambda x: float(x), heuristic_func))
+
+    def test_astar_dag_with_graph_input(self):
+        g = retworkx.PyGraph()
+        g.add_node(0)
+        with self.assertRaises(TypeError):
+            retworkx.dag_astar_shortest_path(g, 0, lambda x: x,
+                                             lambda y: 1, lambda z: 0)
+
+
+class TestAstarGraph(unittest.TestCase):
+
+    def test_astar_null_heuristic(self):
+        g = retworkx.PyGraph();
+        a = g.add_node("A")
+        b = g.add_node("B")
+        c = g.add_node("C")
+        d = g.add_node("D")
+        e = g.add_node("E")
+        f = g.add_node("F")
+        g.add_edge(a, b, 7)
+        g.add_edge(c, a, 9)
+        g.add_edge(a, d, 14)
+        g.add_edge(b, c, 10)
+        g.add_edge(d, c, 2)
+        g.add_edge(d, e, 9)
+        g.add_edge(b, f, 15)
+        g.add_edge(c, f, 11)
+        g.add_edge(e, f, 6)
+        path = retworkx.graph_astar_shortest_path(g, a,
+                                                  lambda goal: goal == "E",
+                                                  lambda x: float(x),
+                                                  lambda y: 0)
+        expected = [a, c, d, e]
+        self.assertEqual(expected, path)
+
+    def test_astar_manhattan_heuristic(self):
+        g = retworkx.PyGraph()
+        a = g.add_node((0., 0.))
+        b = g.add_node((2., 0.))
+        c = g.add_node((1., 1.))
+        d = g.add_node((0., 2.))
+        e = g.add_node((3., 3.))
+        f = g.add_node((4., 2.))
+        no_path = g.add_node((5., 5.))  # no path to node
+        g.add_edge(a, b, 2.)
+        g.add_edge(a, d, 4.)
+        g.add_edge(b, c, 1.)
+        g.add_edge(b, f, 7.)
+        g.add_edge(c, e, 5.)
+        g.add_edge(e, f, 1.)
+        g.add_edge(d, e, 1.)
+
+        def heuristic_func(f):
+            x1, x2 = f
+            return abs(x2 - x1)
+
+        def finish_func(node, x):
+            return x == g.get_node_data(node)
+
+        expected = [
+            [0],
+            [0, 1],
+            [0, 1, 2],
+            [0, 3],
+            [0, 3, 4],
+            [0, 3, 4, 5],
+        ]
+
+        for index, end in enumerate([a, b, c, d, e, f]):
+            path = retworkx.graph_astar_shortest_path(
+                g, a, lambda finish: finish_func(end, finish),
+                lambda x: float(x), heuristic_func)
+            self.assertEqual(expected[index], path)
+
+        self.assertRaises(Exception, retworkx.graph_astar_shortest_path,
+                          (g, a, lambda finish: finish_func(no_path, finish),
+                           lambda x: float(x), heuristic_func))
+
+    def test_astar_graph_with_dag_input(self):
+        g = retworkx.PyDAG()
+        g.add_node(0)
+        with self.assertRaises(TypeError):
+            retworkx.graph_astar_shortest_path(
+                g, 0, lambda x: x, lambda y: 1, lambda z: 0)

--- a/tests/test_astar.py
+++ b/tests/test_astar.py
@@ -18,7 +18,7 @@ import retworkx
 class TestAstarDAG(unittest.TestCase):
 
     def test_astar_null_heuristic(self):
-        g = retworkx.PyDAG();
+        g = retworkx.PyDAG()
         a = g.add_node("A")
         b = g.add_node("B")
         c = g.add_node("C")
@@ -95,7 +95,7 @@ class TestAstarDAG(unittest.TestCase):
 class TestAstarGraph(unittest.TestCase):
 
     def test_astar_null_heuristic(self):
-        g = retworkx.PyGraph();
+        g = retworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
         c = g.add_node("C")


### PR DESCRIPTION
This commit adds a new function for finding the shortest path from a
node to a node that satisfies an arbitrary condition. This is built
using the astar algorithm from the [upstream petgraph lib](https://github.com/petgraph/petgraph), however
because the data for the graphs being traversed are `PyObject`s we needed
to be able to handle python exceptions gracefully (instead of panicking)
which was not possible with the [upstream astar function](https://github.com/petgraph/petgraph/blob/master/src/astar.rs). So this
function has been forked into retworkx and modified to handle `PyResult<>`
wrapped returns from the callables and ensure the inner exception would be passed back to python.

TODO:

- [x] Add tests
- [x] Add docs

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
