### PR TITLE
Add all_simple_paths for dag and graph

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -505,6 +505,36 @@ retworkx API
    :return matrix: The adjacency matrix for the input dag as a numpy array
    :rtype: numpy.ndarray
 
+.. py:function:: graph_all_simple_paths(graph, from, to, cutoff=-1)
+   Return all simple paths between 2 nodes in a PyGraph object
+
+   A simple path is a path with no repeated nodes.
+
+   :param PyGraph graph: The graph to find the path in
+   :param int from: The node index to find the paths from
+   :param int to: The node index to find the paths to
+   :param int cutoff: The maximum depth of path to include in the output list
+       of paths. Defaults to -1 which includes all paths regardless of length.
+       Also, any integer value < 1 will include all found paths.
+
+   :returns paths: A list of lists where each inner list is a path path
+   :rtype: list
+
+.. py:function:: dag_all_simple_paths(graph, from, to, cutoff=-1)
+   Return all simple paths between 2 nodes in a PyGraph object
+
+   A simple path is a path with no repeated nodes.
+
+   :param PyDAG graph: The graph to find the path in
+   :param int from: The node index to find the paths from
+   :param int to: The node index to find the paths to
+   :param int cutoff: The maximum depth of path to include in the output list
+       of paths. Defaults to -1 which includes all paths regardless of length.
+       Also, any integer value < 1 will include all found paths.
+
+   :returns paths: A list of lists where each inner list is a path path
+   :rtype: list
+
 .. py:class:: PyGraph
    A class for creating undirected graphs.
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -505,7 +505,7 @@ retworkx API
    :return matrix: The adjacency matrix for the input dag as a numpy array
    :rtype: numpy.ndarray
 
-.. py:function:: graph_all_simple_paths(graph, from, to, cutoff=-1)
+.. py:function:: graph_all_simple_paths(graph, from, to, min_depth=None, cutoff=None)
    Return all simple paths between 2 nodes in a PyGraph object
 
    A simple path is a path with no repeated nodes.
@@ -513,14 +513,17 @@ retworkx API
    :param PyGraph graph: The graph to find the path in
    :param int from: The node index to find the paths from
    :param int to: The node index to find the paths to
+   :param int min_depth: The minimum depth of the path to include in the output
+       list of paths. By default all paths are included regardless of depth,
+       sett to 0 will behave like the default.
    :param int cutoff: The maximum depth of path to include in the output list
-       of paths. Defaults to -1 which includes all paths regardless of length.
-       Also, any integer value < 1 will include all found paths.
+       of paths. By default includes all paths regardless of depth, setting to
+       0 will behave like default.
 
    :returns paths: A list of lists where each inner list is a path path
    :rtype: list
 
-.. py:function:: dag_all_simple_paths(graph, from, to, cutoff=-1)
+.. py:function:: dag_all_simple_paths(graph, from, to, min_depth=None, cutoff=None)
    Return all simple paths between 2 nodes in a PyGraph object
 
    A simple path is a path with no repeated nodes.
@@ -528,9 +531,12 @@ retworkx API
    :param PyDAG graph: The graph to find the path in
    :param int from: The node index to find the paths from
    :param int to: The node index to find the paths to
+   :param int min_depth: The minimum depth of the path to include in the output
+       list of paths. By default all paths are included regardless of depth,
+       sett to 0 will behave like the default.
    :param int cutoff: The maximum depth of path to include in the output list
-       of paths. Defaults to -1 which includes all paths regardless of length.
-       Also, any integer value < 1 will include all found paths.
+       of paths. By default includes all paths regardless of depth, setting to
+       0 will behave like default.
 
    :returns paths: A list of lists where each inner list is a path path
    :rtype: list

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -546,16 +546,16 @@ retworkx API
    :param int to: The node index to find the paths to
    :param int min_depth: The minimum depth of the path to include in the output
        list of paths. By default all paths are included regardless of depth,
-       sett to 0 will behave like the default.
+       setting to 0 will behave like the default.
    :param int cutoff: The maximum depth of path to include in the output list
        of paths. By default includes all paths regardless of depth, setting to
        0 will behave like default.
 
-   :returns paths: A list of lists where each inner list is a path path
+   :returns paths: A list of lists where each inner list is a path
    :rtype: list
 
 .. py:function:: dag_all_simple_paths(graph, from, to, min_depth=None, cutoff=None)
-   Return all simple paths between 2 nodes in a PyGraph object
+   Return all simple paths between 2 nodes in a PyDAG object
 
    A simple path is a path with no repeated nodes.
 
@@ -569,7 +569,7 @@ retworkx API
        of paths. By default includes all paths regardless of depth, setting to
        0 will behave like default.
 
-   :returns paths: A list of lists where each inner list is a path path
+   :returns paths: A list of lists where each inner list is a path
    :rtype: list
 
 .. py:class:: PyGraph

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -24,8 +24,9 @@ use petgraph::prelude::*;
 use petgraph::stable_graph::StableUnGraph;
 use petgraph::visit::{
     GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
-    IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences,
-    NodeCompactIndexable, NodeCount, NodeIndexable, Visitable,
+    IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
+    IntoNodeReferences, NodeCompactIndexable, NodeCount, NodeIndexable,
+    Visitable,
 };
 
 #[pyclass(module = "retworkx")]
@@ -98,6 +99,17 @@ impl<'a> IntoNeighbors for &'a PyGraph {
     type Neighbors = petgraph::stable_graph::Neighbors<'a, PyObject>;
     fn neighbors(self, n: NodeIndex) -> Self::Neighbors {
         self.graph.neighbors(n)
+    }
+}
+
+impl<'a> IntoNeighborsDirected for &'a PyGraph {
+    type NeighborsDirected = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors_directed(
+        self,
+        n: NodeIndex,
+        d: petgraph::Direction,
+    ) -> Self::Neighbors {
+        self.graph.neighbors_directed(n, d)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1149,49 +1149,66 @@ fn graph_adjacency_matrix(
     Ok(matrix.into_pyarray(py).into())
 }
 
-#[pyfunction(cutoff=-1)]
+#[pyfunction]
 fn graph_all_simple_paths(
     graph: &graph::PyGraph,
     from: usize,
     to: usize,
-    cutoff: isize,
+    min_depth: Option<usize>,
+    cutoff: Option<usize>,
 ) -> PyResult<Vec<Vec<usize>>> {
     let from_index = NodeIndex::new(from);
     let to_index = NodeIndex::new(to);
-    let cutoff_petgraph: Option<usize>;
-    if cutoff < 1 {
-        cutoff_petgraph = None;
-    } else {
-        cutoff_petgraph = Some(cutoff as usize - 2);
-    }
-    let result: Vec<Vec<usize>> =
-        algo::all_simple_paths(graph, from_index, to_index, 0, cutoff_petgraph)
-            .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
-            .collect();
+    let min_intermediate_nodes: usize = match min_depth {
+        Some(depth) => depth - 2,
+        None => 0,
+    };
+    let cutoff_petgraph: Option<usize> = match cutoff {
+        Some(depth) => Some(depth - 2),
+        None => None,
+    };
+    let result: Vec<Vec<usize>> = algo::all_simple_paths(
+        graph,
+        from_index,
+        to_index,
+        min_intermediate_nodes,
+        cutoff_petgraph,
+    )
+    .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
+    .collect();
     Ok(result)
 }
 
-#[pyfunction(cutoff=-1)]
+#[pyfunction]
 fn dag_all_simple_paths(
     graph: &PyDAG,
     from: usize,
     to: usize,
-    cutoff: isize,
+    min_depth: Option<usize>,
+    cutoff: Option<usize>,
 ) -> PyResult<Vec<Vec<usize>>> {
     let from_index = NodeIndex::new(from);
     let to_index = NodeIndex::new(to);
-    let cutoff_petgraph: Option<usize>;
-    if cutoff < 1 {
-        cutoff_petgraph = None;
-    } else {
-        cutoff_petgraph = Some(cutoff as usize - 2)
-    }
-    let result: Vec<Vec<usize>> =
-        algo::all_simple_paths(graph, from_index, to_index, 0, cutoff_petgraph)
-            .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
-            .collect();
+    let min_intermediate_nodes: usize = match min_depth {
+        Some(depth) => depth - 2,
+        None => 0,
+    };
+    let cutoff_petgraph: Option<usize> = match cutoff {
+        Some(depth) => Some(depth - 2),
+        None => None,
+    };
+    let result: Vec<Vec<usize>> = algo::all_simple_paths(
+        graph,
+        from_index,
+        to_index,
+        min_intermediate_nodes,
+        cutoff_petgraph,
+    )
+    .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
+    .collect();
     Ok(result)
 }
+
 #[pymodule]
 fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1312,6 +1312,7 @@ fn dag_all_simple_paths(
     .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
     .collect();
     Ok(result)
+}
 
 #[pyfunction]
 fn graph_astar_shortest_path(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1204,7 +1204,17 @@ fn graph_all_simple_paths(
     cutoff: Option<usize>,
 ) -> PyResult<Vec<Vec<usize>>> {
     let from_index = NodeIndex::new(from);
+    if !graph.graph.contains_node(from_index) {
+        return Err(InvalidNode::py_err(
+            "The input index for 'from' is not a valid node index",
+        ));
+    }
     let to_index = NodeIndex::new(to);
+    if !graph.graph.contains_node(to_index) {
+        return Err(InvalidNode::py_err(
+            "The input index for 'to' is not a valid node index",
+        ));
+    }
     let min_intermediate_nodes: usize = match min_depth {
         Some(depth) => depth - 2,
         None => 0,
@@ -1234,7 +1244,17 @@ fn dag_all_simple_paths(
     cutoff: Option<usize>,
 ) -> PyResult<Vec<Vec<usize>>> {
     let from_index = NodeIndex::new(from);
+    if !graph.graph.contains_node(from_index) {
+        return Err(InvalidNode::py_err(
+            "The input index for 'from' is not a valid node index",
+        ));
+    }
     let to_index = NodeIndex::new(to);
+    if !graph.graph.contains_node(to_index) {
+        return Err(InvalidNode::py_err(
+            "The input index for 'to' is not a valid node index",
+        ));
+    }
     let min_intermediate_nodes: usize = match min_depth {
         Some(depth) => depth - 2,
         None => 0,
@@ -1280,6 +1300,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+create_exception!(retworkx, InvalidNode, Exception);
 create_exception!(retworkx, DAGWouldCycle, Exception);
 create_exception!(retworkx, NoEdgeBetweenNodes, Exception);
 create_exception!(retworkx, DAGHasCycle, Exception);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1149,6 +1149,49 @@ fn graph_adjacency_matrix(
     Ok(matrix.into_pyarray(py).into())
 }
 
+#[pyfunction(cutoff=-1)]
+fn graph_all_simple_paths(
+    graph: &graph::PyGraph,
+    from: usize,
+    to: usize,
+    cutoff: isize,
+) -> PyResult<Vec<Vec<usize>>> {
+    let from_index = NodeIndex::new(from);
+    let to_index = NodeIndex::new(to);
+    let cutoff_petgraph: Option<usize>;
+    if cutoff < 1 {
+        cutoff_petgraph = None;
+    } else {
+        cutoff_petgraph = Some(cutoff as usize - 2);
+    }
+    let result: Vec<Vec<usize>> =
+        algo::all_simple_paths(graph, from_index, to_index, 0, cutoff_petgraph)
+            .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
+            .collect();
+    Ok(result)
+}
+
+#[pyfunction(cutoff=-1)]
+fn dag_all_simple_paths(
+    graph: &PyDAG,
+    from: usize,
+    to: usize,
+    cutoff: isize,
+) -> PyResult<Vec<Vec<usize>>> {
+    let from_index = NodeIndex::new(from);
+    let to_index = NodeIndex::new(to);
+    let cutoff_petgraph: Option<usize>;
+    if cutoff < 1 {
+        cutoff_petgraph = None;
+    } else {
+        cutoff_petgraph = Some(cutoff as usize - 2)
+    }
+    let result: Vec<Vec<usize>> =
+        algo::all_simple_paths(graph, from_index, to_index, 0, cutoff_petgraph)
+            .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
+            .collect();
+    Ok(result)
+}
 #[pymodule]
 fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -1167,6 +1210,8 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(layers))?;
     m.add_wrapped(wrap_pyfunction!(dag_adjacency_matrix))?;
     m.add_wrapped(wrap_pyfunction!(graph_adjacency_matrix))?;
+    m.add_wrapped(wrap_pyfunction!(graph_all_simple_paths))?;
+    m.add_wrapped(wrap_pyfunction!(dag_all_simple_paths))?;
     m.add_class::<PyDAG>()?;
     m.add_class::<graph::PyGraph>()?;
     Ok(())

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -16,11 +16,9 @@ import retworkx
 
 
 class TestDAGAllSimplePaths(unittest.TestCase):
-    def test_all_simple_paths(self):
-        dag = retworkx.PyDAG()
-        for i in range(6):
-            dag.add_node(i)
-        edges = [
+    def setUp(self):
+        super().setUp()
+        self.edges = [
             (0, 1),
             (0, 2),
             (0, 3),
@@ -34,8 +32,12 @@ class TestDAGAllSimplePaths(unittest.TestCase):
             (4, 5),
             (5, 2),
             (5, 3)]
-        for edge in edges:
-            dag.add_edge(edge[0], edge[1], None)
+
+    def test_all_simple_paths(self):
+        dag = retworkx.PyDAG()
+        for i in range(6):
+            dag.add_node(i)
+        dag.add_edges_from_no_data(self.edges)
         paths = retworkx.dag_all_simple_paths(dag, 0, 5)
         expected = [
             [0, 1, 2, 3, 4, 5],
@@ -53,22 +55,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         for i in range(6):
             dag.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            dag.add_edge(edge[0], edge[1], None)
+        dag.add_edges_from_no_data(self.edges)
         paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=6)
         expected = [
             [0, 1, 2, 3, 4, 5],
@@ -81,22 +68,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         for i in range(6):
             dag.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            dag.add_edge(edge[0], edge[1], None)
+        dag.add_edges_from_no_data(self.edges)
         paths = retworkx.dag_all_simple_paths(dag, 0, 5, cutoff=4)
         expected = [
             [0, 2, 4, 5],
@@ -109,22 +81,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         for i in range(6):
             dag.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            dag.add_edge(edge[0], edge[1], None)
+        dag.add_edges_from_no_data(self.edges)
         paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
         expected = [
             [0, 3, 2, 4, 5],
@@ -140,7 +97,13 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 5))
+        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 1))
+
+    def test_all_simple_path_invalid_node_index(self):
+        dag = retworkx.PyDAG()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertRaises(Exception, retworkx.dag_all_simple_paths, (dag, 0, 5))
 
     def test_graph_dag_all_simple_paths(self):
         dag = retworkx.PyGraph()
@@ -151,11 +114,9 @@ class TestDAGAllSimplePaths(unittest.TestCase):
 
 
 class TestGraphAllSimplePaths(unittest.TestCase):
-    def test_all_simple_paths(self):
-        graph = retworkx.PyGraph()
-        for i in range(6):
-            graph.add_node(i)
-        edges = [
+    def setUp(self):
+        super().setUp()
+        self.edges = [
             (0, 1),
             (0, 2),
             (0, 3),
@@ -169,8 +130,12 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             (4, 5),
             (5, 2),
             (5, 3)]
-        for edge in edges:
-            graph.add_edge(edge[0], edge[1], None)
+
+    def test_all_simple_paths(self):
+        graph = retworkx.PyGraph()
+        for i in range(6):
+            graph.add_node(i)
+        graph.add_edges_from_no_data(self.edges)
         paths = retworkx.graph_all_simple_paths(graph, 0, 5)
         expected = [
             [0, 3, 4, 5],
@@ -224,22 +189,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         graph = retworkx.PyGraph()
         for i in range(6):
             graph.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            graph.add_edge(edge[0], edge[1], None)
+        graph.add_edges_from_no_data(self.edges)
         paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=6)
         expected = [
             [0, 3, 1, 2, 4, 5],
@@ -264,22 +214,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         graph = retworkx.PyGraph()
         for i in range(6):
             graph.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            graph.add_edge(edge[0], edge[1], None)
+        graph.add_edges_from_no_data(self.edges)
         paths = retworkx.graph_all_simple_paths(graph, 0, 5, cutoff=4)
         expected = [
             [0, 3, 4, 5],
@@ -301,22 +236,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         graph = retworkx.PyGraph()
         for i in range(6):
             graph.add_node(i)
-        edges = [
-            (0, 1),
-            (0, 2),
-            (0, 3),
-            (1, 2),
-            (1, 3),
-            (2, 3),
-            (2, 4),
-            (3, 2),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (5, 2),
-            (5, 3)]
-        for edge in edges:
-            graph.add_edge(edge[0], edge[1], None)
+        graph.add_edges_from_no_data(self.edges)
         paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4,
                                                 cutoff=4)
         expected = [
@@ -334,10 +254,16 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             self.assertIn(i, paths)
 
     def test_all_simple_path_no_path(self):
-        dag = retworkx.PyDAG()
+        dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 5))
+        self.assertEqual([], retworkx.graph_all_simple_paths(dag, 0, 1))
+
+    def test_all_simple_path_invalid_node_index(self):
+        dag = retworkx.PyGraph()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertRaises(Exception, retworkx.graph_all_simple_paths, (dag, 0, 5))
 
     def test_dag_graph_all_simple_paths(self):
         dag = retworkx.PyDAG()

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -49,6 +49,34 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in expected:
             self.assertIn(i, paths)
 
+    def test_all_simple_paths_min_depth(self):
+        dag = retworkx.PyDAG()
+        for i in range(6):
+            dag.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            dag.add_edge(edge[0], edge[1], None)
+        paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=6)
+        expected = [
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 3, 2, 4, 5],
+        ]
+        for i in expected:
+            self.assertIn(i, paths)
+
     def test_all_simple_paths_with_cutoff(self):
         dag = retworkx.PyDAG()
         for i in range(6):
@@ -73,6 +101,37 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         expected = [
             [0, 2, 4, 5],
             [0, 3, 4, 5]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_with_min_depth_and_cutoff(self):
+        dag = retworkx.PyDAG()
+        for i in range(6):
+            dag.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            dag.add_edge(edge[0], edge[1], None)
+        paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
+        expected = [
+            [0, 3, 2, 4, 5],
+            [0, 2, 3, 4, 5],
+            [0, 1, 3, 4, 5],
+            [0, 1, 2, 4, 5]
+        ]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -161,6 +220,46 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         for i in expected:
             self.assertIn(i, paths)
 
+    def test_all_simple_paths_with_min_depth(self):
+        graph = retworkx.PyGraph()
+        for i in range(6):
+            graph.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            graph.add_edge(edge[0], edge[1], None)
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=6)
+        expected = [
+            [0, 3, 1, 2, 4, 5],
+            [0, 3, 1, 2, 4, 5],
+            [0, 2, 1, 3, 4, 5],
+            [0, 1, 3, 4, 2, 5],
+            [0, 1, 3, 4, 2, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 2, 4, 3, 5],
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 2, 4, 3, 5],
+            [0, 1, 2, 3, 4, 5],
+        ]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
     def test_all_simple_paths_with_cutoff(self):
         graph = retworkx.PyGraph()
         for i in range(6):
@@ -190,6 +289,42 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             [0, 2, 4, 5],
             [0, 2, 3, 5],
             [0, 2, 5],
+            [0, 2, 4, 5],
+            [0, 2, 3, 5],
+            [0, 1, 3, 5],
+            [0, 1, 2, 5]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_with_min_depth_and_cutoff(self):
+        graph = retworkx.PyGraph()
+        for i in range(6):
+            graph.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            graph.add_edge(edge[0], edge[1], None)
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4,
+                                                cutoff=4)
+        expected = [
+            [0, 3, 4, 5],
+            [0, 3, 2, 5],
+            [0, 3, 2, 5],
+            [0, 2, 4, 5],
+            [0, 2, 3, 5],
             [0, 2, 4, 5],
             [0, 2, 3, 5],
             [0, 1, 3, 5],

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -1,0 +1,212 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestDAGAllSimplePaths(unittest.TestCase):
+    def test_all_simple_paths(self):
+        dag = retworkx.PyDAG()
+        for i in range(6):
+            dag.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            dag.add_edge(edge[0], edge[1], None)
+        paths = retworkx.dag_all_simple_paths(dag, 0, 5)
+        expected = [
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 2, 4, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 4, 5],
+            [0, 2, 3, 4, 5],
+            [0, 2, 4, 5],
+            [0, 3, 2, 4, 5],
+            [0, 3, 4, 5]]
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_with_cutoff(self):
+        dag = retworkx.PyDAG()
+        for i in range(6):
+            dag.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            dag.add_edge(edge[0], edge[1], None)
+        paths = retworkx.dag_all_simple_paths(dag, 0, 5, cutoff=4)
+        expected = [
+            [0, 2, 4, 5],
+            [0, 3, 4, 5]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_path_no_path(self):
+        dag = retworkx.PyDAG()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 5))
+
+    def test_graph_dag_all_simple_paths(self):
+        dag = retworkx.PyGraph()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertRaises(TypeError, retworkx.dag_all_simple_paths,
+                          (dag, 0, 1))
+
+
+class TestGraphAllSimplePaths(unittest.TestCase):
+    def test_all_simple_paths(self):
+        graph = retworkx.PyGraph()
+        for i in range(6):
+            graph.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            graph.add_edge(edge[0], edge[1], None)
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5)
+        expected = [
+            [0, 3, 4, 5],
+            [0, 3, 4, 2, 5],
+            [0, 3, 4, 2, 5],
+            [0, 3, 2, 4, 5],
+            [0, 3, 2, 5],
+            [0, 3, 2, 4, 5],
+            [0, 3, 5],
+            [0, 3, 2, 4, 5],
+            [0, 3, 2, 5],
+            [0, 3, 2, 4, 5],
+            [0, 3, 1, 2, 4, 5],
+            [0, 3, 1, 2, 5],
+            [0, 3, 1, 2, 4, 5],
+            [0, 2, 4, 5],
+            [0, 2, 4, 3, 5],
+            [0, 2, 3, 4, 5],
+            [0, 2, 3, 5],
+            [0, 2, 5],
+            [0, 2, 4, 5],
+            [0, 2, 4, 3, 5],
+            [0, 2, 3, 4, 5],
+            [0, 2, 3, 5],
+            [0, 2, 1, 3, 4, 5],
+            [0, 2, 1, 3, 5],
+            [0, 1, 3, 4, 5],
+            [0, 1, 3, 4, 2, 5],
+            [0, 1, 3, 4, 2, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 2, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 3, 2, 5],
+            [0, 1, 3, 2, 4, 5],
+            [0, 1, 2, 4, 5],
+            [0, 1, 2, 4, 3, 5],
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 2, 3, 5],
+            [0, 1, 2, 5],
+            [0, 1, 2, 4, 5],
+            [0, 1, 2, 4, 3, 5],
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 2, 3, 5]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_with_cutoff(self):
+        graph = retworkx.PyGraph()
+        for i in range(6):
+            graph.add_node(i)
+        edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 2),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (3, 2),
+            (3, 4),
+            (4, 2),
+            (4, 5),
+            (5, 2),
+            (5, 3)]
+        for edge in edges:
+            graph.add_edge(edge[0], edge[1], None)
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5, cutoff=4)
+        expected = [
+            [0, 3, 4, 5],
+            [0, 3, 2, 5],
+            [0, 3, 5],
+            [0, 3, 2, 5],
+            [0, 2, 4, 5],
+            [0, 2, 3, 5],
+            [0, 2, 5],
+            [0, 2, 4, 5],
+            [0, 2, 3, 5],
+            [0, 1, 3, 5],
+            [0, 1, 2, 5]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_path_no_path(self):
+        dag = retworkx.PyDAG()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 5))
+
+    def test_dag_graph_all_simple_paths(self):
+        dag = retworkx.PyDAG()
+        dag.add_node(0)
+        dag.add_node(1)
+        self.assertRaises(TypeError, retworkx.graph_all_simple_paths,
+                          (dag, 0, 1))

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -103,7 +103,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(Exception, retworkx.dag_all_simple_paths, (dag, 0, 5))
+        self.assertRaises(Exception, retworkx.dag_all_simple_paths,
+                          (dag, 0, 5))
 
     def test_graph_dag_all_simple_paths(self):
         dag = retworkx.PyGraph()
@@ -263,7 +264,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(Exception, retworkx.graph_all_simple_paths, (dag, 0, 5))
+        self.assertRaises(Exception, retworkx.graph_all_simple_paths,
+                          (dag, 0, 5))
 
     def test_dag_graph_all_simple_paths(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
This commit adds 2 new functions dag_all_simple_paths() and
graph_all_simple_paths() to find all simple paths between 2 nodes in a
PyDAG and PyGraph object.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
