### PR TITLE
Temporarily pin nightly version used for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       install: echo ""
       before_script:
         - rustup update
-        - rustup override set nightly
+        - rustup override set nightly-2020-06-10
       script:
         - cargo build
         - cargo +stable fmt -- --check

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
       pool: {vmImage: 'macOS-10.15'}
       variables:
         python.version: '3.7'
-        CIBW_BEFORE_BUILD: pip install -U setuptools-rust && rustup default nightly
+        CIBW_BEFORE_BUILD: pip install -U setuptools-rust && rustup default nightly-2020-06-10
         CIBW_SKIP: cp27-* cp34-* pp*
         TWINE_USERNAME: retworkx-ci
         CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -43,7 +43,7 @@ stages:
       pool: {vmImage: 'vs2017-win2016'}
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
-        CIBW_BEFORE_BUILD: rustup default nightly && pip install -U setuptools-rust
+        CIBW_BEFORE_BUILD: rustup default nightly-2020-06-10 && pip install -U setuptools-rust
         CIBW_SKIP: cp27-* cp34-* pp* *win32
         TWINE_USERNAME: retworkx-ci
         CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -65,7 +65,7 @@ stages:
       pool: {vmImage: 'vs2017-win2016'}
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
-        CIBW_BEFORE_BUILD: rustup default nightly-i686-pc-windows-msvc && pip install -U setuptools-rust
+        CIBW_BEFORE_BUILD: rustup default nightly-i686-pc-windows-msvc-2020-06-10 && pip install -U setuptools-rust
         CIBW_SKIP: cp27-* cp34-* pp* *amd64
         TWINE_USERNAME: retworkx-ci
         CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -100,7 +100,7 @@ stages:
           inputs:
             versionSpec: '$(python.version)'
           displayName: 'Use Python $(python.version)'
-        - bash: rustup default nightly
+        - bash: rustup default nightly-2020-06-10
           displayName: 'Install Rust'
         - bash: python -m pip install --upgrade pip setuptools virtualenv setuptools-rust
           displayName: 'Install dependencies'
@@ -126,7 +126,7 @@ stages:
           inputs:
             versionSpec: '$(python.version)'
           displayName: 'Use Python $(python.version)'
-        - bash: rustup default nightly
+        - bash: rustup default nightly-2020-06-10
           displayName: 'Install Rust'
         - bash: |
             set -e
@@ -165,7 +165,7 @@ stages:
           inputs:
             versionSpec: '$(python.version)'
           displayName: 'Use Python $(python.version)'
-        - bash: rustup default nightly
+        - bash: rustup default nightly-2020-06-10
           displayName: 'Install Rust'
         - bash: python -m pip install --upgrade pip setuptools virtualenv setuptools-rust
           displayName: 'Install dependencies'
@@ -195,7 +195,7 @@ stages:
           inputs:
             versionSpec: '$(python.version)'
           displayName: 'Use Python $(python.version)'
-        - bash: rustup default nightly
+        - bash: rustup default nightly-2020-06-10
           displayName: 'Install Rust'
         - bash: |
             set -e

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,5 +1,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh --default-toolchain nightly -y
+    sh rust-installer/rustup.sh --default-toolchain nightly-2020-06-10 -y
 fi


### PR DESCRIPTION
In the most recent nightly build of cargo a regression slipped in around
handling of READMEs in published crates [1]. Unfortunately this breaks CI
builds because a 3rd level dependency (pyo3->inventory->ctor) triggers
this regression. The issue has been corrected in cargo and the next
nightly should fix this. However, to unblock things in the meantime this
commit pins the nightly version to a known working version. We can
simply revert this after the fix has been released.

[1] https://github.com/rust-lang/cargo/issues/8351

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
