### PR TITLE
Rename PyDAG to PyDiGraph and reorganize modules

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -557,12 +557,12 @@ retworkx API
    :returns paths: A list of lists where each inner list is a path
    :rtype: list
 
-.. py:function:: dag_all_simple_paths(graph, from, to, min_depth=None, cutoff=None)
-   Return all simple paths between 2 nodes in a PyDAG object
+.. py:function:: digraph_all_simple_paths(graph, from, to, min_depth=None, cutoff=None)
+   Return all simple paths between 2 nodes in a PyDiGraph object
 
    A simple path is a path with no repeated nodes.
 
-   :param PyDAG graph: The graph to find the path in
+   :param PyDiGraph graph: The graph to find the path in
    :param int from: The node index to find the paths from
    :param int to: The node index to find the paths to
    :param int min_depth: The minimum depth of the path to include in the output
@@ -597,10 +597,10 @@ retworkx API
       of node indices.
   :rtype: list
 
-.. py:function:: dag_astar_shortest_path(dag, node, goal_fn, edge_cost_fn, estimate_cost_fn):
-   Compute the A* shortest path for a PyDAG
+.. py:function:: digraph_astar_shortest_path(dag, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+   Compute the A* shortest path for a PyDiGraph
 
-  :param PyDAG graph: The input graph to use
+  :param PyDigraph graph: The input graph to use
   :param int node: The node index to compute the path from
   :param goal_fn: A python callable that will take in 1 parameter, a node's data
       object and will return a boolean which will be True if it is the finish

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -493,7 +493,7 @@ retworkx API
     :returns layers: A list of layers, each layer is a list of node data
     :rtype: list
 
-.. py:function:: dag_adjacency_matrix(dag, weight_fn):
+.. py:function:: digraph_adjacency_matrix(dag, weight_fn):
    Return the adjacency matrix for a PyDAG class
 
    In the case where there are multiple edges between nodes the value in the

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,6 +30,9 @@ retworkx API
           When using ``copy.deepcopy()`` or pickling node indexes are not
           guaranteed to be preserved.
 
+    PyDAG, is a subclass of the PyDiGraph class and behaves identically to
+    the PyDiGraph class.
+
     .. py:method:: __init__(self, check_cycle=False):
         Initialize an empty DAG.
 
@@ -698,5 +701,312 @@ retworkx API
         Remove an edge identified by the provided index
 
         :param int edge: The index of the edge to remove
+
+.. _petgraph: https://github.com/bluss/petgraph
+
+.. py:class:: PyDiGraph
+   A class for creating directed graph
+
+   The PyDiGraph class is constructed using the Rust library `petgraph`_ around
+   the ``StableGraph`` type. The limitations and quirks with this library and
+   type dictate how this operates. The biggest thing to be aware of when using
+   the PyDiGraph class is that an integer node and edge index is used for accessing
+   elements on the graph, not the data/weight of nodes and edges.
+
+   If you would like to use a PyDiGraph object as a directed acyclic graph you
+   can do this by enabling realtime cycle checking. For example::
+
+       import retworkx
+       dag = retworkx.PyDiGraph()
+       dag.check_cycle = True
+
+   or at object creation::
+
+       import retworkx
+       dag = retworkx.PyDiGraph(True)
+
+   With check_cycle set to true any calls to :meth:`PyDiGraph.add_edge` will
+   ensure that no cycles are added, ensuring that the PyDiGraph class truly
+   represents a directed acyclic graph.
+
+     .. note::
+          When using ``copy.deepcopy()`` or pickling node indexes are not
+          guaranteed to be preserved.
+
+    .. py:method:: __init__(self, check_cycle=False):
+        Initialize an empty directed graph.
+
+        :param bool check_cycle: If set true enable cycle checking on add_edge()
+            calls
+
+    .. py:method:: __len__(self):
+        Return the number of nodes in the graph. Use via ``len()`` function
+
+    .. py:method:: edges(self):
+        Return a list of all edge data.
+
+        :returns: A list of all the edge data objects in the graph
+        :rtype: list
+
+    .. py:method:: has_edge(self, node_a, node_b):
+        Return True if there is an edge from node_a to node_b.
+
+        :param int node_a: The source node index to check for an edge
+        :param int node_b: The destination node index to check for an edge
+
+        :returns: True if there is an edge false if there is no edge
+        :rtype: bool
+
+    .. py:method:: nodes(self):
+        Return a list of all node data.
+
+        :returns: A list of all the node data objects in the graph
+        :rtype: list
+
+    .. py:method:: node_indexes(self):
+        Return a list of all node indexes.
+
+        :returns: A list of all the node indexes in the graph
+        :rtype: list
+
+    .. py:method:: successors(self, node):
+        Return a list of all the node successor data.
+
+        :param int node: The index for the node to get the successors for
+
+        :returns: A list of the node data for all the child neighbor nodes
+        :rtype: list
+
+    .. py:method:: predecessors(self, node):
+        Return a list of all the node predecessor data.
+
+        :param int node: The index for the node to get the predecessors for
+
+        :returns: A list of the node data for all the parent neighbor nodes
+        :rtype: list
+
+    .. py:method:: get_node_data(self, node):
+        Return the node data for a given node index
+
+        :param int node: The index for the node
+
+        :returns: The data object set for that node
+        :raises IndexError: when an invalid node index is provided
+
+    .. py:method:: get_edge_data(self, node_a, node_b):
+        Return the edge data for the edge between 2 nodes.
+
+        :param int node_a: The index for the first node
+        :param int node_b: The index for the second node
+
+        :returns: The data object set for the edge
+        :raises: When there is no edge between nodes
+
+    .. py:method:: get_all_edge_data(self, node_a, node_b):
+        Return the edge data for all the edges between 2 nodes.
+
+        :param int node_a: The index for the first node
+        :param int node_b: The index for the second node
+
+        :returns: A list with all the data objects for the edges between nodes
+        :rtype: list
+        :raises: When there is no edge between nodes
+
+    .. py:method:: remove_node(self, node):
+        Remove a node from the graph.
+
+        :param int node: The index of the node to remove
+
+    .. py:method:: add_edge(self, parent, child, edge):
+        Add an edge between 2 nodes.
+
+        Use add_child() or add_parent() to create a node with an edge at the
+        same time as an edge for better performance. Using this method will
+        enable adding duplicate edges between nodes.
+
+        :param int parent: Index of the parent node
+        :param int child: Index of the child node
+        :param edge: The object to set as the data for the edge. It can be any
+            python object.
+
+        :raises: When the new edge will create a cycle
+
+    .. py:method:: add_node(self, obj):
+        Add a new node to the dag.
+
+        :param obj: The python object to attach to the node
+
+        :returns index: The index of the newly created node
+        :rtype: int
+
+    .. py:method:: add_nodes_from(self, obj_list):
+        Add new nodes to the dag.
+
+        :param list obj_list: A list of python objects to attach to the graph.
+
+        :returns indices: A list of int indices of the newly created nodes
+        :rtype: list
+
+    .. py:method:: add_edges_from(self, obj_list):
+        Add new edges to the dag.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child, obj)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added, and obj is the python object for the edge data.
+
+        :returns indices: A list of int indices of the newly created edges
+        :rtype: list
+
+    .. py:method:: add_edges_from_no_data(self, obj_list):
+        Add new edges to the dag without python data.
+
+        :param list obj_list: A list of tuples of the form
+            ``(parent, child)`` to attach to the graph. ``parent`` and
+            ``child`` are integer indexes describing where an edge should be
+            added. Unlike :meth:`add_edges_from` there is no data payload and
+            when the edge is created None will be used.
+
+        :returns indices: A list of int indices of the newly created edges
+        :rtype: list
+
+    .. py:method:: add_child(self, parent, obj, edge):
+        Add a new child node to the dag.
+
+        This will create a new node on the dag and add an edge from the parent
+        to that new node.
+
+        :param int parent: The index for the parent node
+        :param obj: The python object to attach to the node
+        :param edge: The python object to attach to the edge
+
+        :returns index: The index of the newly created child node
+        :rtype: int
+
+    .. py:method:: add_parent(self, child, obj, edge):
+        Add a new parent node to the dag.
+
+        This create a new node on the dag and add an edge to the child from
+        that new node
+
+        :param int child: The index of the child node
+        :param obj: The python object to attach to the node
+        :param edge: The python object to attach to the edge
+
+        :returns index: The index of the newly created parent node
+        :rtype: int
+
+    .. py:method:: adj(self, node):
+        Get the index and data for the neighbors of a node.
+
+        This will return a dictionary where the keys are the node indexes of
+        the adjacent nodes (inbound or outbound) and the value is the edge data
+        objects between that adjacent node and the provided node.
+
+        :param int node: The index of the node to get the neighbors
+
+        :returns neighbors: A dictionary where the keys are node indexes and
+            the value is the edge data object for all nodes that share an
+            edge with the specified node.
+        :rtype: dict
+
+    .. py:method:: adj_direction(self, node, direction):
+        Get the index and data for either the parent or children of a node.
+
+        This will return a dictionary where the keys are the node indexes of
+        the adjacent nodes (inbound or outbound as specified) and the value
+        is the edge data objects for the edges between that adjacent node
+        and the provided node.
+
+        :param int node: The index of the node to get the neighbors
+        :param bool direction: The direction to use for finding nodes,
+            True means inbound edges and False means outbound edges.
+
+        :returns neighbors: A dictionary where the keys are node indexes and
+            the value is the edge data object for all nodes that share an
+            edge with the specified node.
+        :rtype: dict
+
+        :raises NoEdgeBetweenNodes if the graph is broken and an edge can't be
+            found to a neighbor node
+
+    .. py:method:: in_edges(self, node):
+        Get the index and edge data for all parents of a node.
+
+        This will return a list of tuples with the parent index the node index
+        and the edge data. This can be used to recreate add_edge() calls.
+
+        :param int node: The index of the node to get the edges for
+
+        :returns in_edges: A list of tuples of the form:
+            (parent_index, node_index, edge_data)
+        :rtype: list
+
+        :raises NoEdgeBetweenNodes if the graph is broken and an edge can't be
+            found to a neighbor node
+
+    .. py:method:: out_edges(self, node):
+        Get the index and edge data for all children of a node.
+
+        This will return a list of tuples with the child index the node index
+        and the edge data. This can be used to recreate add_edge() calls.
+
+        :param int node: The index of the node to get the edges for
+
+        :returns out_edges: A list of tuples of the form:
+            (node_index, child_index, edge_data)
+        :rtype: list
+
+        :raises NoEdgeBetweenNodes if the graph is broken and an edge can't be
+            found to a neighbor node
+
+    .. py:method:: in_degree(self, node):
+        Get the degree of a node for inbound edges.
+
+        :param int node: The index of the node to find the inbound degree of
+
+        :returns degree: The inbound degree for the specified node
+        :rtype: int
+
+    .. py:method:: out_degree(self, node):
+        Get the degree of a node for outbound edges.
+
+        :param int node: The index of the node to find the outbound degree of
+
+        :returns degree: The outbound degree for the specified node
+        :rtype: int
+
+    .. py:method:: remove_edge(self, parent, child):
+        Remove an edge between 2 nodes.
+
+        Note if there are multiple edges between the specified nodes only one
+        will be removed.
+
+        :param int parent: The index for the parent node.
+        :param int child: The index of the child node.
+
+        :raises NoEdgeBetweenNodes: If there are no edges between the nodes
+            specified
+
+    .. py:method:: remove_edge_from_index(self, edge):
+        Remove an edge identified by the provided index
+
+        :param int edge: The index of the edge to remove
+
+    .. py:method:: find_adjacent_node_by_edge(self, edge, predicate):
+        Find a target node with a specific edge
+
+        This method is used to find a target node for
+
+        :param int node: The node to use as the source of the search
+        :param callable predicate: A python callable that will take a single
+            parameter, the edge object, and will return a boolean if the
+            edge matches or not
+
+        :returns: The node object that has an edge to it from the provided
+            node index which matches the provided condition
+
+        :raises Exception: If no neighbor is found that matches the predicate
+            callable
 
 .. _petgraph: https://github.com/bluss/petgraph

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,7 +20,7 @@ retworkx API
    or at object creation::
 
        import retworkx
-       dag = retworkx.PyDAG(True)
+       dag = retworkx.PyDAG(check_cycle=True)
 
    With check_cycle set to true any calls to :meth:`PyDAG.add_edge` will
    ensure that no cycles are added, ensuring that the PyDAG class truly
@@ -723,7 +723,7 @@ retworkx API
    or at object creation::
 
        import retworkx
-       dag = retworkx.PyDiGraph(True)
+       dag = retworkx.PyDiGraph(check_cycle=True)
 
    With check_cycle set to true any calls to :meth:`PyDiGraph.add_edge` will
    ensure that no cycles are added, ensuring that the PyDiGraph class truly

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,7 +30,7 @@ retworkx API
           When using ``copy.deepcopy()`` or pickling node indexes are not
           guaranteed to be preserved.
 
-    PyDAG, is a subclass of the PyDiGraph class and behaves identically to
+    PyDAG is a subclass of the PyDiGraph class and behaves identically to
     the PyDiGraph class.
 
     .. py:method:: __init__(self, check_cycle=False):

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -1,1 +1,5 @@
 from .retworkx import *
+
+
+class PyDAG(PyDiGraph):
+    pass

--- a/src/dag_isomorphism.rs
+++ b/src/dag_isomorphism.rs
@@ -11,12 +11,12 @@
 // under the License.
 
 // This module is a forked version of petgraph's isomorphism module @ 0.5.0.
-// It has then been modified to function with PyDAG inputs instead of Graph.
+// It has then been modified to function with PyDiGraph inputs instead of Graph.
 
 use fixedbitset::FixedBitSet;
 use std::marker;
 
-use super::PyDAG;
+use super::digraph::PyDiGraph;
 
 use pyo3::prelude::*;
 
@@ -46,7 +46,7 @@ struct Vf2State {
 }
 
 impl Vf2State {
-    pub fn new(dag: &PyDAG) -> Self {
+    pub fn new(dag: &PyDiGraph) -> Self {
         let g = &dag.graph;
         let c0 = g.node_count();
         let mut state = Vf2State {
@@ -77,7 +77,7 @@ impl Vf2State {
         &mut self,
         from: NodeIndex,
         to: NodeIndex,
-        dag: &PyDAG,
+        dag: &PyDiGraph,
     ) {
         let g = &dag.graph;
         self.generation += 1;
@@ -103,7 +103,7 @@ impl Vf2State {
     }
 
     /// Restore the state to before the last added mapping
-    pub fn pop_mapping(&mut self, from: NodeIndex, dag: &PyDAG) {
+    pub fn pop_mapping(&mut self, from: NodeIndex, dag: &PyDiGraph) {
         let g = &dag.graph;
         let s = self.generation;
         self.generation -= 1;
@@ -171,7 +171,7 @@ impl Vf2State {
 ///
 /// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
 ///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
-pub fn is_isomorphic(dag0: &PyDAG, dag1: &PyDAG) -> PyResult<bool> {
+pub fn is_isomorphic(dag0: &PyDiGraph, dag1: &PyDiGraph) -> PyResult<bool> {
     let g0 = &dag0.graph;
     let g1 = &dag1.graph;
     if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
@@ -197,8 +197,8 @@ pub fn is_isomorphic(dag0: &PyDAG, dag1: &PyDAG) -> PyResult<bool> {
 ///
 /// The graphs should not be multigraphs.
 pub fn is_isomorphic_matching<F, G>(
-    dag0: &PyDAG,
-    dag1: &PyDAG,
+    dag0: &PyDiGraph,
+    dag1: &PyDiGraph,
     mut node_match: F,
     mut edge_match: G,
 ) -> PyResult<bool>
@@ -254,8 +254,8 @@ where
 /// Return Some(bool) if isomorphism is decided, else None.
 fn try_match<F, G>(
     mut st: &mut [Vf2State; 2],
-    dag0: &PyDAG,
-    dag1: &PyDAG,
+    dag0: &PyDiGraph,
+    dag1: &PyDiGraph,
     node_match: &mut F,
     edge_match: &mut G,
 ) -> PyResult<Option<bool>>

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1,0 +1,717 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+extern crate fixedbitset;
+extern crate hashbrown;
+extern crate ndarray;
+extern crate numpy;
+extern crate petgraph;
+extern crate pyo3;
+
+use std::collections::HashSet;
+use std::ops::{Index, IndexMut};
+
+use hashbrown::HashMap;
+
+use pyo3::class::PyMappingProtocol;
+use pyo3::exceptions::IndexError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyLong, PyTuple};
+use pyo3::Python;
+
+use petgraph::algo;
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::prelude::*;
+use petgraph::stable_graph::StableDiGraph;
+use petgraph::visit::{
+    GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
+    IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
+    NodeIndexable, Visitable,
+};
+
+use super::{
+    is_directed_acyclic_graph, DAGHasCycle, DAGWouldCycle, NoEdgeBetweenNodes,
+    NoSuitableNeighbors,
+};
+
+#[pyclass(module = "retworkx", subclass)]
+pub struct PyDiGraph {
+    pub graph: StableDiGraph<PyObject, PyObject>,
+    cycle_state: algo::DfsSpace<
+        NodeIndex,
+        <StableDiGraph<PyObject, PyObject> as Visitable>::Map,
+    >,
+    pub check_cycle: bool,
+    pub node_removed: bool,
+}
+
+pub type Edges<'a, E> =
+    petgraph::stable_graph::Edges<'a, E, petgraph::Directed>;
+
+impl GraphBase for PyDiGraph {
+    type NodeId = NodeIndex;
+    type EdgeId = EdgeIndex;
+}
+
+impl NodeCount for PyDiGraph {
+    fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+}
+
+impl GraphProp for PyDiGraph {
+    type EdgeType = petgraph::Directed;
+    fn is_directed(&self) -> bool {
+        true
+    }
+}
+
+impl petgraph::visit::Visitable for PyDiGraph {
+    type Map = <StableDiGraph<PyObject, PyObject> as Visitable>::Map;
+    fn visit_map(&self) -> Self::Map {
+        self.graph.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.graph.reset_map(map)
+    }
+}
+
+impl petgraph::visit::Data for PyDiGraph {
+    type NodeWeight = PyObject;
+    type EdgeWeight = PyObject;
+}
+
+impl petgraph::data::DataMap for PyDiGraph {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+        self.graph.node_weight(id)
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+
+impl petgraph::data::DataMapMut for PyDiGraph {
+    fn node_weight_mut(
+        &mut self,
+        id: Self::NodeId,
+    ) -> Option<&mut Self::NodeWeight> {
+        self.graph.node_weight_mut(id)
+    }
+    fn edge_weight_mut(
+        &mut self,
+        id: Self::EdgeId,
+    ) -> Option<&mut Self::EdgeWeight> {
+        self.graph.edge_weight_mut(id)
+    }
+}
+
+impl<'a> IntoNeighbors for &'a PyDiGraph {
+    type Neighbors = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors(self, n: NodeIndex) -> Self::Neighbors {
+        self.graph.neighbors(n)
+    }
+}
+
+impl<'a> IntoNeighborsDirected for &'a PyDiGraph {
+    type NeighborsDirected = petgraph::stable_graph::Neighbors<'a, PyObject>;
+    fn neighbors_directed(
+        self,
+        n: NodeIndex,
+        d: petgraph::Direction,
+    ) -> Self::Neighbors {
+        self.graph.neighbors_directed(n, d)
+    }
+}
+
+impl<'a> IntoEdgeReferences for &'a PyDiGraph {
+    type EdgeRef = petgraph::stable_graph::EdgeReference<'a, PyObject>;
+    type EdgeReferences = petgraph::stable_graph::EdgeReferences<'a, PyObject>;
+    fn edge_references(self) -> Self::EdgeReferences {
+        self.graph.edge_references()
+    }
+}
+
+impl<'a> IntoEdges for &'a PyDiGraph {
+    type Edges = Edges<'a, PyObject>;
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        self.graph.edges(a)
+    }
+}
+
+impl<'a> IntoEdgesDirected for &'a PyDiGraph {
+    type EdgesDirected = Edges<'a, PyObject>;
+    fn edges_directed(
+        self,
+        a: Self::NodeId,
+        dir: petgraph::Direction,
+    ) -> Self::EdgesDirected {
+        self.graph.edges_directed(a, dir)
+    }
+}
+
+impl<'a> IntoNodeIdentifiers for &'a PyDiGraph {
+    type NodeIdentifiers = petgraph::stable_graph::NodeIndices<'a, PyObject>;
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        self.graph.node_identifiers()
+    }
+}
+
+impl<'a> IntoNodeReferences for &'a PyDiGraph {
+    type NodeRef = (NodeIndex, &'a PyObject);
+    type NodeReferences = petgraph::stable_graph::NodeReferences<'a, PyObject>;
+    fn node_references(self) -> Self::NodeReferences {
+        self.graph.node_references()
+    }
+}
+
+impl NodeIndexable for PyDiGraph {
+    fn node_bound(&self) -> usize {
+        self.graph.node_bound()
+    }
+    fn to_index(&self, ix: NodeIndex) -> usize {
+        self.graph.to_index(ix)
+    }
+    fn from_index(&self, ix: usize) -> Self::NodeId {
+        self.graph.from_index(ix)
+    }
+}
+
+impl NodeCompactIndexable for PyDiGraph {}
+
+impl Index<NodeIndex> for PyDiGraph {
+    type Output = PyObject;
+    fn index(&self, index: NodeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<NodeIndex> for PyDiGraph {
+    fn index_mut(&mut self, index: NodeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl Index<EdgeIndex> for PyDiGraph {
+    type Output = PyObject;
+    fn index(&self, index: EdgeIndex) -> &PyObject {
+        &self.graph[index]
+    }
+}
+
+impl IndexMut<EdgeIndex> for PyDiGraph {
+    fn index_mut(&mut self, index: EdgeIndex) -> &mut PyObject {
+        &mut self.graph[index]
+    }
+}
+
+impl GetAdjacencyMatrix for PyDiGraph {
+    type AdjMatrix =
+        <StableDiGraph<PyObject, PyObject> as GetAdjacencyMatrix>::AdjMatrix;
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.graph.adjacency_matrix()
+    }
+    fn is_adjacent(
+        &self,
+        matrix: &Self::AdjMatrix,
+        a: NodeIndex,
+        b: NodeIndex,
+    ) -> bool {
+        self.graph.is_adjacent(matrix, a, b)
+    }
+}
+
+// Rust side only PyDiGraph methods
+impl PyDiGraph {
+    fn _add_edge(
+        &mut self,
+        p_index: NodeIndex,
+        c_index: NodeIndex,
+        edge: PyObject,
+    ) -> PyResult<usize> {
+        // Only check for cycles if instance attribute is set to true
+        if self.check_cycle {
+            // Only check for a cycle (by running has_path_connecting) if
+            // the new edge could potentially add a cycle
+            let cycle_check_required =
+                is_cycle_check_required(self, p_index, c_index);
+            let state = Some(&mut self.cycle_state);
+            if cycle_check_required
+                && algo::has_path_connecting(
+                    &self.graph,
+                    c_index,
+                    p_index,
+                    state,
+                )
+            {
+                return Err(DAGWouldCycle::py_err(
+                    "Adding an edge would cycle",
+                ));
+            }
+        }
+        let edge = self.graph.add_edge(p_index, c_index, edge);
+        Ok(edge.index())
+    }
+}
+
+#[pymethods]
+impl PyDiGraph {
+    #[new]
+    #[args(check_cycle = "false")]
+    fn new(check_cycle: bool) -> Self {
+        PyDiGraph {
+            graph: StableDiGraph::<PyObject, PyObject>::new(),
+            cycle_state: algo::DfsSpace::default(),
+            check_cycle,
+            node_removed: false,
+        }
+    }
+
+    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        let out_dict = PyDict::new(py);
+        let node_dict = PyDict::new(py);
+        let mut out_list: Vec<PyObject> = Vec::new();
+        out_dict.set_item("nodes", node_dict)?;
+
+        let dir = petgraph::Direction::Incoming;
+        for node_index in self.graph.node_indices() {
+            let node_data = self.graph.node_weight(node_index).unwrap();
+            node_dict.set_item(node_index.index(), node_data)?;
+            for edge in self.graph.edges_directed(node_index, dir) {
+                let edge_w = edge.weight();
+                let triplet =
+                    (edge.source().index(), edge.target().index(), edge_w)
+                        .to_object(py);
+                out_list.push(triplet);
+            }
+        }
+        let py_out_list: PyObject = PyList::new(py, out_list).into();
+        out_dict.set_item("edges", py_out_list)?;
+        Ok(out_dict.into())
+    }
+
+    fn __setstate__(&mut self, state: PyObject) -> PyResult<()> {
+        let mut node_mapping: HashMap<usize, NodeIndex> = HashMap::new();
+        self.graph = StableDiGraph::<PyObject, PyObject>::new();
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let dict_state = state.cast_as::<PyDict>(py)?;
+
+        let nodes_dict =
+            dict_state.get_item("nodes").unwrap().downcast::<PyDict>()?;
+        let edges_list =
+            dict_state.get_item("edges").unwrap().downcast::<PyList>()?;
+        for raw_index in nodes_dict.keys().iter() {
+            let tmp_index = raw_index.downcast::<PyLong>()?;
+            let index: usize = tmp_index.extract()?;
+            let raw_data = nodes_dict.get_item(index).unwrap();
+            let node_index = self.graph.add_node(raw_data.into());
+            node_mapping.insert(index, node_index);
+        }
+        for raw_edge in edges_list.iter() {
+            let edge = raw_edge.downcast::<PyTuple>()?;
+            let raw_p_index = edge.get_item(0).downcast::<PyLong>()?;
+            let tmp_p_index: usize = raw_p_index.extract()?;
+            let raw_c_index = edge.get_item(1).downcast::<PyLong>()?;
+            let tmp_c_index: usize = raw_c_index.extract()?;
+            let edge_data = edge.get_item(2);
+
+            let p_index = node_mapping.get(&tmp_p_index).unwrap();
+            let c_index = node_mapping.get(&tmp_c_index).unwrap();
+            self.graph.add_edge(*p_index, *c_index, edge_data.into());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn get_check_cycle(&self) -> PyResult<bool> {
+        Ok(self.check_cycle)
+    }
+
+    #[setter]
+    fn set_check_cycle(&mut self, value: bool) -> PyResult<()> {
+        if !self.check_cycle && value && !is_directed_acyclic_graph(self) {
+            return Err(DAGHasCycle::py_err("PyDiGraph object has a cycle"));
+        }
+        self.check_cycle = value;
+        Ok(())
+    }
+
+    pub fn edges(&self, py: Python) -> PyObject {
+        let raw_edges = self.graph.edge_indices();
+        let mut out: Vec<&PyObject> = Vec::new();
+        for edge in raw_edges {
+            out.push(self.graph.edge_weight(edge).unwrap());
+        }
+        PyList::new(py, out).into()
+    }
+
+    pub fn nodes(&self, py: Python) -> PyObject {
+        let raw_nodes = self.graph.node_indices();
+        let mut out: Vec<&PyObject> = Vec::new();
+        for node in raw_nodes {
+            out.push(self.graph.node_weight(node).unwrap());
+        }
+        PyList::new(py, out).into()
+    }
+
+    pub fn node_indexes(&self, py: Python) -> PyObject {
+        let mut out_list: Vec<usize> = Vec::new();
+        for node_index in self.graph.node_indices() {
+            out_list.push(node_index.index());
+        }
+        PyList::new(py, out_list).into()
+    }
+
+    pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        self.graph.find_edge(index_a, index_b).is_some()
+    }
+
+    pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let children = self
+            .graph
+            .neighbors_directed(index, petgraph::Direction::Outgoing);
+        let mut succesors: Vec<&PyObject> = Vec::new();
+        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
+        for succ in children {
+            if !used_indexes.contains(&succ) {
+                succesors.push(self.graph.node_weight(succ).unwrap());
+                used_indexes.insert(succ);
+            }
+        }
+        Ok(PyList::new(py, succesors).into())
+    }
+
+    pub fn predecessors(&self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let parents = self
+            .graph
+            .neighbors_directed(index, petgraph::Direction::Incoming);
+        let mut predec: Vec<&PyObject> = Vec::new();
+        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
+        for pred in parents {
+            if !used_indexes.contains(&pred) {
+                predec.push(self.graph.node_weight(pred).unwrap());
+                used_indexes.insert(pred);
+            }
+        }
+        Ok(PyList::new(py, predec).into())
+    }
+
+    pub fn get_edge_data(
+        &self,
+        node_a: usize,
+        node_b: usize,
+    ) -> PyResult<&PyObject> {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        let edge_index = match self.graph.find_edge(index_a, index_b) {
+            Some(edge_index) => edge_index,
+            None => {
+                return Err(NoEdgeBetweenNodes::py_err(
+                    "No edge found between nodes",
+                ))
+            }
+        };
+
+        let data = self.graph.edge_weight(edge_index).unwrap();
+        Ok(data)
+    }
+
+    pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
+        let index = NodeIndex::new(node);
+        let node = match self.graph.node_weight(index) {
+            Some(node) => node,
+            None => return Err(IndexError::py_err("No node found for index")),
+        };
+        Ok(node)
+    }
+
+    pub fn get_all_edge_data(
+        &self,
+        py: Python,
+        node_a: usize,
+        node_b: usize,
+    ) -> PyResult<PyObject> {
+        let index_a = NodeIndex::new(node_a);
+        let index_b = NodeIndex::new(node_b);
+        let raw_edges = self
+            .graph
+            .edges_directed(index_a, petgraph::Direction::Outgoing);
+        let mut out: Vec<&PyObject> = Vec::new();
+        for edge in raw_edges {
+            if edge.target() == index_b {
+                out.push(edge.weight());
+            }
+        }
+        if out.is_empty() {
+            Err(NoEdgeBetweenNodes::py_err("No edge found between nodes"))
+        } else {
+            Ok(PyList::new(py, out).into())
+        }
+    }
+
+    pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
+        let index = NodeIndex::new(node);
+        self.graph.remove_node(index);
+        self.node_removed = true;
+        Ok(())
+    }
+
+    pub fn add_edge(
+        &mut self,
+        parent: usize,
+        child: usize,
+        edge: PyObject,
+    ) -> PyResult<usize> {
+        let p_index = NodeIndex::new(parent);
+        let c_index = NodeIndex::new(child);
+        let out_index = self._add_edge(p_index, c_index, edge)?;
+        Ok(out_index)
+    }
+
+    pub fn add_edges_from(
+        &mut self,
+        obj_list: Vec<(usize, usize, PyObject)>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let p_index = NodeIndex::new(obj.0);
+            let c_index = NodeIndex::new(obj.1);
+            let edge = self._add_edge(p_index, c_index, obj.2)?;
+            out_list.push(edge);
+        }
+        Ok(out_list)
+    }
+
+    pub fn add_edges_from_no_data(
+        &mut self,
+        py: Python,
+        obj_list: Vec<(usize, usize)>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let p_index = NodeIndex::new(obj.0);
+            let c_index = NodeIndex::new(obj.1);
+            let edge = self._add_edge(p_index, c_index, py.None())?;
+            out_list.push(edge);
+        }
+        Ok(out_list)
+    }
+
+    pub fn remove_edge(&mut self, parent: usize, child: usize) -> PyResult<()> {
+        let p_index = NodeIndex::new(parent);
+        let c_index = NodeIndex::new(child);
+        let edge_index = match self.graph.find_edge(p_index, c_index) {
+            Some(edge_index) => edge_index,
+            None => {
+                return Err(NoEdgeBetweenNodes::py_err(
+                    "No edge found between nodes",
+                ))
+            }
+        };
+        self.graph.remove_edge(edge_index);
+        Ok(())
+    }
+
+    pub fn remove_edge_from_index(&mut self, edge: usize) -> PyResult<()> {
+        let edge_index = EdgeIndex::new(edge);
+        self.graph.remove_edge(edge_index);
+        Ok(())
+    }
+
+    pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
+        let index = self.graph.add_node(obj);
+        Ok(index.index())
+    }
+
+    pub fn add_child(
+        &mut self,
+        parent: usize,
+        obj: PyObject,
+        edge: PyObject,
+    ) -> PyResult<usize> {
+        let index = NodeIndex::new(parent);
+        let child_node = self.graph.add_node(obj);
+        self.graph.add_edge(index, child_node, edge);
+        Ok(child_node.index())
+    }
+
+    pub fn add_parent(
+        &mut self,
+        child: usize,
+        obj: PyObject,
+        edge: PyObject,
+    ) -> PyResult<usize> {
+        let index = NodeIndex::new(child);
+        let parent_node = self.graph.add_node(obj);
+        self.graph.add_edge(parent_node, index, edge);
+        Ok(parent_node.index())
+    }
+
+    pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let neighbors = self.graph.neighbors(index);
+        let out_dict = PyDict::new(py);
+        for neighbor in neighbors {
+            let mut edge = self.graph.find_edge(index, neighbor);
+            // If there is no edge then it must be a parent neighbor
+            if edge.is_none() {
+                edge = self.graph.find_edge(neighbor, index);
+            }
+            let edge_w = self.graph.edge_weight(edge.unwrap());
+            out_dict.set_item(neighbor.index(), edge_w)?;
+        }
+        Ok(out_dict.into())
+    }
+
+    pub fn adj_direction(
+        &mut self,
+        py: Python,
+        node: usize,
+        direction: bool,
+    ) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let dir = if direction {
+            petgraph::Direction::Incoming
+        } else {
+            petgraph::Direction::Outgoing
+        };
+        let neighbors = self.graph.neighbors_directed(index, dir);
+        let out_dict = PyDict::new(py);
+        for neighbor in neighbors {
+            let edge = if direction {
+                match self.graph.find_edge(neighbor, index) {
+                    Some(edge) => edge,
+                    None => {
+                        return Err(NoEdgeBetweenNodes::py_err(
+                            "No edge found between nodes",
+                        ))
+                    }
+                }
+            } else {
+                match self.graph.find_edge(index, neighbor) {
+                    Some(edge) => edge,
+                    None => {
+                        return Err(NoEdgeBetweenNodes::py_err(
+                            "No edge found between nodes",
+                        ))
+                    }
+                }
+            };
+            let edge_w = self.graph.edge_weight(edge);
+            out_dict.set_item(neighbor.index(), edge_w)?;
+        }
+        Ok(out_dict.into())
+    }
+
+    pub fn in_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Incoming;
+        let mut out_list: Vec<PyObject> = Vec::new();
+        let raw_edges = self.graph.edges_directed(index, dir);
+        for edge in raw_edges {
+            let edge_w = edge.weight();
+            let triplet = (edge.source().index(), node, edge_w).to_object(py);
+            out_list.push(triplet)
+        }
+        Ok(PyList::new(py, out_list).into())
+    }
+
+    pub fn out_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Outgoing;
+        let mut out_list: Vec<PyObject> = Vec::new();
+        let raw_edges = self.graph.edges_directed(index, dir);
+        for edge in raw_edges {
+            let edge_w = edge.weight();
+            let triplet = (node, edge.target().index(), edge_w).to_object(py);
+            out_list.push(triplet)
+        }
+        Ok(PyList::new(py, out_list).into())
+    }
+
+    pub fn add_nodes_from(
+        &mut self,
+        obj_list: Vec<PyObject>,
+    ) -> PyResult<Vec<usize>> {
+        let mut out_list: Vec<usize> = Vec::new();
+        for obj in obj_list {
+            let node_index = self.graph.add_node(obj);
+            out_list.push(node_index.index());
+        }
+        Ok(out_list)
+    }
+
+    pub fn in_degree(&self, node: usize) -> usize {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Incoming;
+        let neighbors = self.graph.edges_directed(index, dir);
+        neighbors.count()
+    }
+
+    pub fn out_degree(&self, node: usize) -> usize {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Outgoing;
+        let neighbors = self.graph.edges_directed(index, dir);
+        neighbors.count()
+    }
+
+    pub fn find_adjacent_node_by_edge(
+        &self,
+        py: Python,
+        node: usize,
+        predicate: PyObject,
+    ) -> PyResult<&PyObject> {
+        let predicate_callable = |a: &PyObject| -> PyResult<PyObject> {
+            let res = predicate.call1(py, (a,))?;
+            Ok(res.to_object(py))
+        };
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Outgoing;
+        let edges = self.graph.edges_directed(index, dir);
+        for edge in edges {
+            let edge_predicate_raw = predicate_callable(&edge.weight())?;
+            let edge_predicate: bool = edge_predicate_raw.extract(py)?;
+            if edge_predicate {
+                return Ok(self.graph.node_weight(edge.target()).unwrap());
+            }
+        }
+        Err(NoSuitableNeighbors::py_err("No suitable neighbor"))
+    }
+}
+
+#[pyproto]
+impl PyMappingProtocol for PyDiGraph {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.graph.node_count())
+    }
+}
+
+fn is_cycle_check_required(
+    dag: &PyDiGraph,
+    a: NodeIndex,
+    b: NodeIndex,
+) -> bool {
+    let mut parents_a = dag
+        .graph
+        .neighbors_directed(a, petgraph::Direction::Incoming);
+    let mut children_b = dag
+        .graph
+        .neighbors_directed(b, petgraph::Direction::Outgoing);
+    parents_a.next().is_some()
+        && children_b.next().is_some()
+        && dag.graph.find_edge(a, b).is_none()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,705 +18,30 @@ extern crate petgraph;
 extern crate pyo3;
 
 mod dag_isomorphism;
+mod digraph;
 mod graph;
 
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
-use std::ops::{Index, IndexMut};
 
 use hashbrown::HashMap;
 
-use pyo3::class::PyMappingProtocol;
 use pyo3::create_exception;
-use pyo3::exceptions::{Exception, IndexError};
+use pyo3::exceptions::Exception;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyLong, PyTuple};
+use pyo3::types::{PyDict, PyList};
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
 use petgraph::algo;
-use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
-use petgraph::stable_graph::StableDiGraph;
-use petgraph::visit::{
-    Bfs, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,
-    IntoEdges, IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
-    IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
-    NodeIndexable, Reversed, Visitable,
-};
+use petgraph::visit::{Bfs, IntoEdgeReferences, NodeIndexable, Reversed};
 
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
 
-#[pyclass(module = "retworkx")]
-pub struct PyDAG {
-    pub graph: StableDiGraph<PyObject, PyObject>,
-    cycle_state: algo::DfsSpace<
-        NodeIndex,
-        <StableDiGraph<PyObject, PyObject> as Visitable>::Map,
-    >,
-    pub check_cycle: bool,
-    pub node_removed: bool,
-}
-
-pub type Edges<'a, E> =
-    petgraph::stable_graph::Edges<'a, E, petgraph::Directed>;
-
-impl GraphBase for PyDAG {
-    type NodeId = NodeIndex;
-    type EdgeId = EdgeIndex;
-}
-
-impl NodeCount for PyDAG {
-    fn node_count(&self) -> usize {
-        self.graph.node_count()
-    }
-}
-
-impl GraphProp for PyDAG {
-    type EdgeType = petgraph::Directed;
-    fn is_directed(&self) -> bool {
-        true
-    }
-}
-
-impl petgraph::visit::Visitable for PyDAG {
-    type Map = <StableDiGraph<PyObject, PyObject> as Visitable>::Map;
-    fn visit_map(&self) -> Self::Map {
-        self.graph.visit_map()
-    }
-    fn reset_map(&self, map: &mut Self::Map) {
-        self.graph.reset_map(map)
-    }
-}
-
-impl petgraph::visit::Data for PyDAG {
-    type NodeWeight = PyObject;
-    type EdgeWeight = PyObject;
-}
-
-impl petgraph::data::DataMap for PyDAG {
-    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
-        self.graph.node_weight(id)
-    }
-    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
-        self.graph.edge_weight(id)
-    }
-}
-
-impl petgraph::data::DataMapMut for PyDAG {
-    fn node_weight_mut(
-        &mut self,
-        id: Self::NodeId,
-    ) -> Option<&mut Self::NodeWeight> {
-        self.graph.node_weight_mut(id)
-    }
-    fn edge_weight_mut(
-        &mut self,
-        id: Self::EdgeId,
-    ) -> Option<&mut Self::EdgeWeight> {
-        self.graph.edge_weight_mut(id)
-    }
-}
-
-impl<'a> IntoNeighbors for &'a PyDAG {
-    type Neighbors = petgraph::stable_graph::Neighbors<'a, PyObject>;
-    fn neighbors(self, n: NodeIndex) -> Self::Neighbors {
-        self.graph.neighbors(n)
-    }
-}
-
-impl<'a> IntoNeighborsDirected for &'a PyDAG {
-    type NeighborsDirected = petgraph::stable_graph::Neighbors<'a, PyObject>;
-    fn neighbors_directed(
-        self,
-        n: NodeIndex,
-        d: petgraph::Direction,
-    ) -> Self::Neighbors {
-        self.graph.neighbors_directed(n, d)
-    }
-}
-
-impl<'a> IntoEdgeReferences for &'a PyDAG {
-    type EdgeRef = petgraph::stable_graph::EdgeReference<'a, PyObject>;
-    type EdgeReferences = petgraph::stable_graph::EdgeReferences<'a, PyObject>;
-    fn edge_references(self) -> Self::EdgeReferences {
-        self.graph.edge_references()
-    }
-}
-
-impl<'a> IntoEdges for &'a PyDAG {
-    type Edges = Edges<'a, PyObject>;
-    fn edges(self, a: Self::NodeId) -> Self::Edges {
-        self.graph.edges(a)
-    }
-}
-
-impl<'a> IntoEdgesDirected for &'a PyDAG {
-    type EdgesDirected = Edges<'a, PyObject>;
-    fn edges_directed(
-        self,
-        a: Self::NodeId,
-        dir: petgraph::Direction,
-    ) -> Self::EdgesDirected {
-        self.graph.edges_directed(a, dir)
-    }
-}
-
-impl<'a> IntoNodeIdentifiers for &'a PyDAG {
-    type NodeIdentifiers = petgraph::stable_graph::NodeIndices<'a, PyObject>;
-    fn node_identifiers(self) -> Self::NodeIdentifiers {
-        self.graph.node_identifiers()
-    }
-}
-
-impl<'a> IntoNodeReferences for &'a PyDAG {
-    type NodeRef = (NodeIndex, &'a PyObject);
-    type NodeReferences = petgraph::stable_graph::NodeReferences<'a, PyObject>;
-    fn node_references(self) -> Self::NodeReferences {
-        self.graph.node_references()
-    }
-}
-
-impl NodeIndexable for PyDAG {
-    fn node_bound(&self) -> usize {
-        self.graph.node_bound()
-    }
-    fn to_index(&self, ix: NodeIndex) -> usize {
-        self.graph.to_index(ix)
-    }
-    fn from_index(&self, ix: usize) -> Self::NodeId {
-        self.graph.from_index(ix)
-    }
-}
-
-impl NodeCompactIndexable for PyDAG {}
-
-impl Index<NodeIndex> for PyDAG {
-    type Output = PyObject;
-    fn index(&self, index: NodeIndex) -> &PyObject {
-        &self.graph[index]
-    }
-}
-
-impl IndexMut<NodeIndex> for PyDAG {
-    fn index_mut(&mut self, index: NodeIndex) -> &mut PyObject {
-        &mut self.graph[index]
-    }
-}
-
-impl Index<EdgeIndex> for PyDAG {
-    type Output = PyObject;
-    fn index(&self, index: EdgeIndex) -> &PyObject {
-        &self.graph[index]
-    }
-}
-
-impl IndexMut<EdgeIndex> for PyDAG {
-    fn index_mut(&mut self, index: EdgeIndex) -> &mut PyObject {
-        &mut self.graph[index]
-    }
-}
-
-impl GetAdjacencyMatrix for PyDAG {
-    type AdjMatrix =
-        <StableDiGraph<PyObject, PyObject> as GetAdjacencyMatrix>::AdjMatrix;
-    fn adjacency_matrix(&self) -> Self::AdjMatrix {
-        self.graph.adjacency_matrix()
-    }
-    fn is_adjacent(
-        &self,
-        matrix: &Self::AdjMatrix,
-        a: NodeIndex,
-        b: NodeIndex,
-    ) -> bool {
-        self.graph.is_adjacent(matrix, a, b)
-    }
-}
-
-// Rust side only PyDAG methods
-impl PyDAG {
-    fn _add_edge(
-        &mut self,
-        p_index: NodeIndex,
-        c_index: NodeIndex,
-        edge: PyObject,
-    ) -> PyResult<usize> {
-        // Only check for cycles if instance attribute is set to true
-        if self.check_cycle {
-            // Only check for a cycle (by running has_path_connecting) if
-            // the new edge could potentially add a cycle
-            let cycle_check_required =
-                is_cycle_check_required(self, p_index, c_index);
-            let state = Some(&mut self.cycle_state);
-            if cycle_check_required
-                && algo::has_path_connecting(
-                    &self.graph,
-                    c_index,
-                    p_index,
-                    state,
-                )
-            {
-                return Err(DAGWouldCycle::py_err(
-                    "Adding an edge would cycle",
-                ));
-            }
-        }
-        let edge = self.graph.add_edge(p_index, c_index, edge);
-        Ok(edge.index())
-    }
-}
-
-#[pymethods]
-impl PyDAG {
-    #[new]
-    #[args(check_cycle = "false")]
-    fn new(check_cycle: bool) -> Self {
-        PyDAG {
-            graph: StableDiGraph::<PyObject, PyObject>::new(),
-            cycle_state: algo::DfsSpace::default(),
-            check_cycle,
-            node_removed: false,
-        }
-    }
-
-    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
-        let out_dict = PyDict::new(py);
-        let node_dict = PyDict::new(py);
-        let mut out_list: Vec<PyObject> = Vec::new();
-        out_dict.set_item("nodes", node_dict)?;
-
-        let dir = petgraph::Direction::Incoming;
-        for node_index in self.graph.node_indices() {
-            let node_data = self.graph.node_weight(node_index).unwrap();
-            node_dict.set_item(node_index.index(), node_data)?;
-            for edge in self.graph.edges_directed(node_index, dir) {
-                let edge_w = edge.weight();
-                let triplet =
-                    (edge.source().index(), edge.target().index(), edge_w)
-                        .to_object(py);
-                out_list.push(triplet);
-            }
-        }
-        let py_out_list: PyObject = PyList::new(py, out_list).into();
-        out_dict.set_item("edges", py_out_list)?;
-        Ok(out_dict.into())
-    }
-
-    fn __setstate__(&mut self, state: PyObject) -> PyResult<()> {
-        let mut node_mapping: HashMap<usize, NodeIndex> = HashMap::new();
-        self.graph = StableDiGraph::<PyObject, PyObject>::new();
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let dict_state = state.cast_as::<PyDict>(py)?;
-
-        let nodes_dict =
-            dict_state.get_item("nodes").unwrap().downcast::<PyDict>()?;
-        let edges_list =
-            dict_state.get_item("edges").unwrap().downcast::<PyList>()?;
-        for raw_index in nodes_dict.keys().iter() {
-            let tmp_index = raw_index.downcast::<PyLong>()?;
-            let index: usize = tmp_index.extract()?;
-            let raw_data = nodes_dict.get_item(index).unwrap();
-            let node_index = self.graph.add_node(raw_data.into());
-            node_mapping.insert(index, node_index);
-        }
-        for raw_edge in edges_list.iter() {
-            let edge = raw_edge.downcast::<PyTuple>()?;
-            let raw_p_index = edge.get_item(0).downcast::<PyLong>()?;
-            let tmp_p_index: usize = raw_p_index.extract()?;
-            let raw_c_index = edge.get_item(1).downcast::<PyLong>()?;
-            let tmp_c_index: usize = raw_c_index.extract()?;
-            let edge_data = edge.get_item(2);
-
-            let p_index = node_mapping.get(&tmp_p_index).unwrap();
-            let c_index = node_mapping.get(&tmp_c_index).unwrap();
-            self.graph.add_edge(*p_index, *c_index, edge_data.into());
-        }
-        Ok(())
-    }
-
-    #[getter]
-    fn get_check_cycle(&self) -> PyResult<bool> {
-        Ok(self.check_cycle)
-    }
-
-    #[setter]
-    fn set_check_cycle(&mut self, value: bool) -> PyResult<()> {
-        if !self.check_cycle && value && !is_directed_acyclic_graph(self) {
-            return Err(DAGHasCycle::py_err("PyDAG object has a cycle"));
-        }
-        self.check_cycle = value;
-        Ok(())
-    }
-
-    pub fn edges(&self, py: Python) -> PyObject {
-        let raw_edges = self.graph.edge_indices();
-        let mut out: Vec<&PyObject> = Vec::new();
-        for edge in raw_edges {
-            out.push(self.graph.edge_weight(edge).unwrap());
-        }
-        PyList::new(py, out).into()
-    }
-
-    pub fn nodes(&self, py: Python) -> PyObject {
-        let raw_nodes = self.graph.node_indices();
-        let mut out: Vec<&PyObject> = Vec::new();
-        for node in raw_nodes {
-            out.push(self.graph.node_weight(node).unwrap());
-        }
-        PyList::new(py, out).into()
-    }
-
-    pub fn node_indexes(&self, py: Python) -> PyObject {
-        let mut out_list: Vec<usize> = Vec::new();
-        for node_index in self.graph.node_indices() {
-            out_list.push(node_index.index());
-        }
-        PyList::new(py, out_list).into()
-    }
-
-    pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
-        let index_a = NodeIndex::new(node_a);
-        let index_b = NodeIndex::new(node_b);
-        self.graph.find_edge(index_a, index_b).is_some()
-    }
-
-    pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let children = self
-            .graph
-            .neighbors_directed(index, petgraph::Direction::Outgoing);
-        let mut succesors: Vec<&PyObject> = Vec::new();
-        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
-        for succ in children {
-            if !used_indexes.contains(&succ) {
-                succesors.push(self.graph.node_weight(succ).unwrap());
-                used_indexes.insert(succ);
-            }
-        }
-        Ok(PyList::new(py, succesors).into())
-    }
-
-    pub fn predecessors(&self, py: Python, node: usize) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let parents = self
-            .graph
-            .neighbors_directed(index, petgraph::Direction::Incoming);
-        let mut predec: Vec<&PyObject> = Vec::new();
-        let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
-        for pred in parents {
-            if !used_indexes.contains(&pred) {
-                predec.push(self.graph.node_weight(pred).unwrap());
-                used_indexes.insert(pred);
-            }
-        }
-        Ok(PyList::new(py, predec).into())
-    }
-
-    pub fn get_edge_data(
-        &self,
-        node_a: usize,
-        node_b: usize,
-    ) -> PyResult<&PyObject> {
-        let index_a = NodeIndex::new(node_a);
-        let index_b = NodeIndex::new(node_b);
-        let edge_index = match self.graph.find_edge(index_a, index_b) {
-            Some(edge_index) => edge_index,
-            None => {
-                return Err(NoEdgeBetweenNodes::py_err(
-                    "No edge found between nodes",
-                ))
-            }
-        };
-
-        let data = self.graph.edge_weight(edge_index).unwrap();
-        Ok(data)
-    }
-
-    pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
-        let index = NodeIndex::new(node);
-        let node = match self.graph.node_weight(index) {
-            Some(node) => node,
-            None => return Err(IndexError::py_err("No node found for index")),
-        };
-        Ok(node)
-    }
-
-    pub fn get_all_edge_data(
-        &self,
-        py: Python,
-        node_a: usize,
-        node_b: usize,
-    ) -> PyResult<PyObject> {
-        let index_a = NodeIndex::new(node_a);
-        let index_b = NodeIndex::new(node_b);
-        let raw_edges = self
-            .graph
-            .edges_directed(index_a, petgraph::Direction::Outgoing);
-        let mut out: Vec<&PyObject> = Vec::new();
-        for edge in raw_edges {
-            if edge.target() == index_b {
-                out.push(edge.weight());
-            }
-        }
-        if out.is_empty() {
-            Err(NoEdgeBetweenNodes::py_err("No edge found between nodes"))
-        } else {
-            Ok(PyList::new(py, out).into())
-        }
-    }
-
-    pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
-        let index = NodeIndex::new(node);
-        self.graph.remove_node(index);
-        self.node_removed = true;
-        Ok(())
-    }
-
-    pub fn add_edge(
-        &mut self,
-        parent: usize,
-        child: usize,
-        edge: PyObject,
-    ) -> PyResult<usize> {
-        let p_index = NodeIndex::new(parent);
-        let c_index = NodeIndex::new(child);
-        let out_index = self._add_edge(p_index, c_index, edge)?;
-        Ok(out_index)
-    }
-
-    pub fn add_edges_from(
-        &mut self,
-        obj_list: Vec<(usize, usize, PyObject)>,
-    ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
-        for obj in obj_list {
-            let p_index = NodeIndex::new(obj.0);
-            let c_index = NodeIndex::new(obj.1);
-            let edge = self._add_edge(p_index, c_index, obj.2)?;
-            out_list.push(edge);
-        }
-        Ok(out_list)
-    }
-
-    pub fn add_edges_from_no_data(
-        &mut self,
-        py: Python,
-        obj_list: Vec<(usize, usize)>,
-    ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
-        for obj in obj_list {
-            let p_index = NodeIndex::new(obj.0);
-            let c_index = NodeIndex::new(obj.1);
-            let edge = self._add_edge(p_index, c_index, py.None())?;
-            out_list.push(edge);
-        }
-        Ok(out_list)
-    }
-
-    pub fn remove_edge(&mut self, parent: usize, child: usize) -> PyResult<()> {
-        let p_index = NodeIndex::new(parent);
-        let c_index = NodeIndex::new(child);
-        let edge_index = match self.graph.find_edge(p_index, c_index) {
-            Some(edge_index) => edge_index,
-            None => {
-                return Err(NoEdgeBetweenNodes::py_err(
-                    "No edge found between nodes",
-                ))
-            }
-        };
-        self.graph.remove_edge(edge_index);
-        Ok(())
-    }
-
-    pub fn remove_edge_from_index(&mut self, edge: usize) -> PyResult<()> {
-        let edge_index = EdgeIndex::new(edge);
-        self.graph.remove_edge(edge_index);
-        Ok(())
-    }
-
-    pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
-        let index = self.graph.add_node(obj);
-        Ok(index.index())
-    }
-
-    pub fn add_child(
-        &mut self,
-        parent: usize,
-        obj: PyObject,
-        edge: PyObject,
-    ) -> PyResult<usize> {
-        let index = NodeIndex::new(parent);
-        let child_node = self.graph.add_node(obj);
-        self.graph.add_edge(index, child_node, edge);
-        Ok(child_node.index())
-    }
-
-    pub fn add_parent(
-        &mut self,
-        child: usize,
-        obj: PyObject,
-        edge: PyObject,
-    ) -> PyResult<usize> {
-        let index = NodeIndex::new(child);
-        let parent_node = self.graph.add_node(obj);
-        self.graph.add_edge(parent_node, index, edge);
-        Ok(parent_node.index())
-    }
-
-    pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let neighbors = self.graph.neighbors(index);
-        let out_dict = PyDict::new(py);
-        for neighbor in neighbors {
-            let mut edge = self.graph.find_edge(index, neighbor);
-            // If there is no edge then it must be a parent neighbor
-            if edge.is_none() {
-                edge = self.graph.find_edge(neighbor, index);
-            }
-            let edge_w = self.graph.edge_weight(edge.unwrap());
-            out_dict.set_item(neighbor.index(), edge_w)?;
-        }
-        Ok(out_dict.into())
-    }
-
-    pub fn adj_direction(
-        &mut self,
-        py: Python,
-        node: usize,
-        direction: bool,
-    ) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let dir = if direction {
-            petgraph::Direction::Incoming
-        } else {
-            petgraph::Direction::Outgoing
-        };
-        let neighbors = self.graph.neighbors_directed(index, dir);
-        let out_dict = PyDict::new(py);
-        for neighbor in neighbors {
-            let edge = if direction {
-                match self.graph.find_edge(neighbor, index) {
-                    Some(edge) => edge,
-                    None => {
-                        return Err(NoEdgeBetweenNodes::py_err(
-                            "No edge found between nodes",
-                        ))
-                    }
-                }
-            } else {
-                match self.graph.find_edge(index, neighbor) {
-                    Some(edge) => edge,
-                    None => {
-                        return Err(NoEdgeBetweenNodes::py_err(
-                            "No edge found between nodes",
-                        ))
-                    }
-                }
-            };
-            let edge_w = self.graph.edge_weight(edge);
-            out_dict.set_item(neighbor.index(), edge_w)?;
-        }
-        Ok(out_dict.into())
-    }
-
-    pub fn in_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let dir = petgraph::Direction::Incoming;
-        let mut out_list: Vec<PyObject> = Vec::new();
-        let raw_edges = self.graph.edges_directed(index, dir);
-        for edge in raw_edges {
-            let edge_w = edge.weight();
-            let triplet = (edge.source().index(), node, edge_w).to_object(py);
-            out_list.push(triplet)
-        }
-        Ok(PyList::new(py, out_list).into())
-    }
-
-    pub fn out_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
-        let index = NodeIndex::new(node);
-        let dir = petgraph::Direction::Outgoing;
-        let mut out_list: Vec<PyObject> = Vec::new();
-        let raw_edges = self.graph.edges_directed(index, dir);
-        for edge in raw_edges {
-            let edge_w = edge.weight();
-            let triplet = (node, edge.target().index(), edge_w).to_object(py);
-            out_list.push(triplet)
-        }
-        Ok(PyList::new(py, out_list).into())
-    }
-
-    pub fn add_nodes_from(
-        &mut self,
-        obj_list: Vec<PyObject>,
-    ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
-        for obj in obj_list {
-            let node_index = self.graph.add_node(obj);
-            out_list.push(node_index.index());
-        }
-        Ok(out_list)
-    }
-
-    pub fn in_degree(&self, node: usize) -> usize {
-        let index = NodeIndex::new(node);
-        let dir = petgraph::Direction::Incoming;
-        let neighbors = self.graph.edges_directed(index, dir);
-        neighbors.count()
-    }
-
-    pub fn out_degree(&self, node: usize) -> usize {
-        let index = NodeIndex::new(node);
-        let dir = petgraph::Direction::Outgoing;
-        let neighbors = self.graph.edges_directed(index, dir);
-        neighbors.count()
-    }
-
-    pub fn find_adjacent_node_by_edge(
-        &self,
-        py: Python,
-        node: usize,
-        predicate: PyObject,
-    ) -> PyResult<&PyObject> {
-        let predicate_callable = |a: &PyObject| -> PyResult<PyObject> {
-            let res = predicate.call1(py, (a,))?;
-            Ok(res.to_object(py))
-        };
-        let index = NodeIndex::new(node);
-        let dir = petgraph::Direction::Outgoing;
-        let edges = self.graph.edges_directed(index, dir);
-        for edge in edges {
-            let edge_predicate_raw = predicate_callable(&edge.weight())?;
-            let edge_predicate: bool = edge_predicate_raw.extract(py)?;
-            if edge_predicate {
-                return Ok(self.graph.node_weight(edge.target()).unwrap());
-            }
-        }
-        Err(NoSuitableNeighbors::py_err("No suitable neighbor"))
-    }
-}
-
-#[pyproto]
-impl PyMappingProtocol for PyDAG {
-    fn __len__(&self) -> PyResult<usize> {
-        Ok(self.graph.node_count())
-    }
-}
-
-fn is_cycle_check_required(dag: &PyDAG, a: NodeIndex, b: NodeIndex) -> bool {
-    let mut parents_a = dag
-        .graph
-        .neighbors_directed(a, petgraph::Direction::Incoming);
-    let mut children_b = dag
-        .graph
-        .neighbors_directed(b, petgraph::Direction::Outgoing);
-    parents_a.next().is_some()
-        && children_b.next().is_some()
-        && dag.graph.find_edge(a, b).is_none()
-}
-
-fn longest_path(graph: &PyDAG) -> PyResult<Vec<usize>> {
+fn longest_path(graph: &digraph::PyDiGraph) -> PyResult<Vec<usize>> {
     let dag = &graph.graph;
     let mut path: Vec<usize> = Vec::new();
     let nodes = match algo::toposort(graph, None) {
@@ -766,13 +91,16 @@ fn longest_path(graph: &PyDAG) -> PyResult<Vec<usize>> {
 }
 
 #[pyfunction]
-fn dag_longest_path(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
+fn dag_longest_path(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+) -> PyResult<PyObject> {
     let path = longest_path(graph)?;
     Ok(PyList::new(py, path).into())
 }
 
 #[pyfunction]
-fn dag_longest_path_length(graph: &PyDAG) -> PyResult<usize> {
+fn dag_longest_path_length(graph: &digraph::PyDiGraph) -> PyResult<usize> {
     let path = longest_path(graph)?;
     if path.is_empty() {
         return Ok(0);
@@ -782,18 +110,21 @@ fn dag_longest_path_length(graph: &PyDAG) -> PyResult<usize> {
 }
 
 #[pyfunction]
-fn number_weakly_connected_components(graph: &PyDAG) -> usize {
+fn number_weakly_connected_components(graph: &digraph::PyDiGraph) -> usize {
     algo::connected_components(graph)
 }
 
 #[pyfunction]
-fn is_directed_acyclic_graph(graph: &PyDAG) -> bool {
+fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
     let cycle_detected = algo::is_cyclic_directed(graph);
     !cycle_detected
 }
 
 #[pyfunction]
-fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> PyResult<bool> {
+fn is_isomorphic(
+    first: &digraph::PyDiGraph,
+    second: &digraph::PyDiGraph,
+) -> PyResult<bool> {
     let res = dag_isomorphism::is_isomorphic(first, second)?;
     Ok(res)
 }
@@ -801,8 +132,8 @@ fn is_isomorphic(first: &PyDAG, second: &PyDAG) -> PyResult<bool> {
 #[pyfunction]
 fn is_isomorphic_node_match(
     py: Python,
-    first: &PyDAG,
-    second: &PyDAG,
+    first: &digraph::PyDiGraph,
+    second: &digraph::PyDiGraph,
     matcher: PyObject,
 ) -> PyResult<bool> {
     let compare_nodes = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
@@ -823,7 +154,10 @@ fn is_isomorphic_node_match(
 }
 
 #[pyfunction]
-fn topological_sort(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
+fn topological_sort(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+) -> PyResult<PyObject> {
     let nodes = match algo::toposort(graph, None) {
         Ok(nodes) => nodes,
         Err(_err) => {
@@ -840,7 +174,7 @@ fn topological_sort(py: Python, graph: &PyDAG) -> PyResult<PyObject> {
 #[pyfunction]
 fn bfs_successors(
     py: Python,
-    graph: &PyDAG,
+    graph: &digraph::PyDiGraph,
     node: usize,
 ) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
@@ -862,7 +196,11 @@ fn bfs_successors(
 }
 
 #[pyfunction]
-fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
+fn ancestors(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    node: usize,
+) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
@@ -876,7 +214,11 @@ fn ancestors(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
 }
 
 #[pyfunction]
-fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
+fn descendants(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    node: usize,
+) -> PyResult<PyObject> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
@@ -891,7 +233,7 @@ fn descendants(py: Python, graph: &PyDAG, node: usize) -> PyResult<PyObject> {
 #[pyfunction]
 fn lexicographical_topological_sort(
     py: Python,
-    dag: &PyDAG,
+    dag: &digraph::PyDiGraph,
     key: PyObject,
 ) -> PyResult<PyObject> {
     let key_callable = |a: &PyObject| -> PyResult<PyObject> {
@@ -965,7 +307,7 @@ fn lexicographical_topological_sort(
 // algorithm
 // Note: Edge weights are assumed to be 1
 #[pyfunction]
-fn floyd_warshall(py: Python, dag: &PyDAG) -> PyResult<PyObject> {
+fn floyd_warshall(py: Python, dag: &digraph::PyDiGraph) -> PyResult<PyObject> {
     let mut dist: HashMap<(usize, usize), usize> = HashMap::new();
     for node in dag.graph.node_indices() {
         // Distance from a node to itself is zero
@@ -1031,7 +373,7 @@ fn floyd_warshall(py: Python, dag: &PyDAG) -> PyResult<PyObject> {
 #[pyfunction]
 fn layers(
     py: Python,
-    dag: &PyDAG,
+    dag: &digraph::PyDiGraph,
     first_layer: Vec<usize>,
 ) -> PyResult<PyObject> {
     let mut output: Vec<Vec<&PyObject>> = Vec::new();
@@ -1099,7 +441,7 @@ fn layers(
 #[pyfunction]
 fn dag_adjacency_matrix(
     py: Python,
-    graph: &PyDAG,
+    graph: &digraph::PyDiGraph,
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
     let node_map: Option<HashMap<NodeIndex, usize>>;
@@ -1213,7 +555,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(layers))?;
     m.add_wrapped(wrap_pyfunction!(dag_adjacency_matrix))?;
     m.add_wrapped(wrap_pyfunction!(graph_adjacency_matrix))?;
-    m.add_class::<PyDAG>()?;
+    m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ fn layers(
 }
 
 #[pyfunction]
-fn dag_adjacency_matrix(
+fn digraph_adjacency_matrix(
     py: Python,
     graph: &digraph::PyDiGraph,
     weight_fn: PyObject,
@@ -553,7 +553,7 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(lexicographical_topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(floyd_warshall))?;
     m.add_wrapped(wrap_pyfunction!(layers))?;
-    m.add_wrapped(wrap_pyfunction!(dag_adjacency_matrix))?;
+    m.add_wrapped(wrap_pyfunction!(digraph_adjacency_matrix))?;
     m.add_wrapped(wrap_pyfunction!(graph_adjacency_matrix))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -22,7 +22,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         node_a = dag.add_node('a')
         dag.add_child(node_a, 'b', {'a': 1})
         dag.add_child(node_a, 'c', {'a': 2})
-        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        res = retworkx.digraph_adjacency_matrix(dag, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
             np.array(
@@ -34,7 +34,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         dag.add_child(node_a, 'b', 7.0)
-        res = retworkx.dag_adjacency_matrix(dag, lambda x: float(x))
+        res = retworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
             np.array([[0.0, 7.0], [0.0, 0.0]]), res))
@@ -44,29 +44,29 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', 7.0)
         dag.add_edge(node_a, node_b, 0.5)
-        res = retworkx.dag_adjacency_matrix(dag, lambda x: float(x))
+        res = retworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
             np.array([[0.0, 7.5], [0.0, 0.0]]), res))
 
-    def test_graph_to_dag_adjacency_matrix(self):
+    def test_graph_to_digraph_adjacency_matrix(self):
         graph = retworkx.PyGraph()
-        self.assertRaises(TypeError, retworkx.dag_adjacency_matrix, graph)
+        self.assertRaises(TypeError, retworkx.digraph_adjacency_matrix, graph)
 
-    def test_no_edge_dag_adjacency_matrix(self):
+    def test_no_edge_digraph_adjacency_matrix(self):
         dag = retworkx.PyDAG()
         for i in range(50):
             dag.add_node(i)
-        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        res = retworkx.digraph_adjacency_matrix(dag, lambda x: 1)
         self.assertTrue(np.array_equal(np.zeros([50, 50]), res))
 
-    def test_dag_with_index_holes(self):
+    def test_digraph_with_index_holes(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', 1)
         dag.add_child(node_a, 'c', 1)
         dag.remove_node(node_b)
-        res = retworkx.dag_adjacency_matrix(dag, lambda x: 1)
+        res = retworkx.digraph_adjacency_matrix(dag, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
             np.array([[0, 1], [0, 0]]), res))
@@ -113,7 +113,7 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         dag = retworkx.PyDAG()
         self.assertRaises(TypeError, retworkx.graph_adjacency_matrix, dag)
 
-    def test_no_edge_dag_adjacency_matrix(self):
+    def test_no_edge_graph_adjacency_matrix(self):
         graph = retworkx.PyGraph()
         for i in range(50):
             graph.add_node(i)

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -38,7 +38,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.dag_all_simple_paths(dag, 0, 5)
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5)
         expected = [
             [0, 1, 2, 3, 4, 5],
             [0, 1, 2, 4, 5],
@@ -56,7 +56,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=6)
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=6)
         expected = [
             [0, 1, 2, 3, 4, 5],
             [0, 1, 3, 2, 4, 5],
@@ -69,7 +69,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.dag_all_simple_paths(dag, 0, 5, cutoff=4)
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, cutoff=4)
         expected = [
             [0, 2, 4, 5],
             [0, 3, 4, 5]]
@@ -82,7 +82,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.dag_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=5,
+                                                  cutoff=5)
         expected = [
             [0, 3, 2, 4, 5],
             [0, 2, 3, 4, 5],
@@ -97,20 +98,20 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertEqual([], retworkx.dag_all_simple_paths(dag, 0, 1))
+        self.assertEqual([], retworkx.digraph_all_simple_paths(dag, 0, 1))
 
     def test_all_simple_path_invalid_node_index(self):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(Exception, retworkx.dag_all_simple_paths,
+        self.assertRaises(Exception, retworkx.digraph_all_simple_paths,
                           (dag, 0, 5))
 
-    def test_graph_dag_all_simple_paths(self):
+    def test_graph_digraph_all_simple_paths(self):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(TypeError, retworkx.dag_all_simple_paths,
+        self.assertRaises(TypeError, retworkx.digraph_all_simple_paths,
                           (dag, 0, 1))
 
 
@@ -267,7 +268,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         self.assertRaises(Exception, retworkx.graph_all_simple_paths,
                           (dag, 0, 5))
 
-    def test_dag_graph_all_simple_paths(self):
+    def test_digraph_graph_all_simple_paths(self):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)

--- a/tests/test_astar.py
+++ b/tests/test_astar.py
@@ -15,7 +15,7 @@ import unittest
 import retworkx
 
 
-class TestAstarDAG(unittest.TestCase):
+class TestAstarDigraph(unittest.TestCase):
 
     def test_astar_null_heuristic(self):
         g = retworkx.PyDAG()
@@ -34,10 +34,10 @@ class TestAstarDAG(unittest.TestCase):
         g.add_edge(b, f, 15)
         g.add_edge(c, f, 11)
         g.add_edge(e, f, 6)
-        path = retworkx.dag_astar_shortest_path(g, a,
-                                                lambda goal: goal == "E",
-                                                lambda x: float(x),
-                                                lambda y: 0)
+        path = retworkx.digraph_astar_shortest_path(g, a,
+                                                    lambda goal: goal == "E",
+                                                    lambda x: float(x),
+                                                    lambda y: 0)
         expected = [a, d, e]
         self.assertEqual(expected, path)
 
@@ -75,21 +75,21 @@ class TestAstarDAG(unittest.TestCase):
         ]
 
         for index, end in enumerate([a, b, c, d, e, f]):
-            path = retworkx.dag_astar_shortest_path(
+            path = retworkx.digraph_astar_shortest_path(
                 g, a, lambda finish: finish_func(end, finish),
                 lambda x: float(x), heuristic_func)
             self.assertEqual(expected[index], path)
 
-        self.assertRaises(Exception, retworkx.dag_astar_shortest_path,
+        self.assertRaises(Exception, retworkx.digraph_astar_shortest_path,
                           (g, a, lambda finish: finish_func(no_path, finish),
                            lambda x: float(x), heuristic_func))
 
-    def test_astar_dag_with_graph_input(self):
+    def test_astar_digraph_with_graph_input(self):
         g = retworkx.PyGraph()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.dag_astar_shortest_path(g, 0, lambda x: x,
-                                             lambda y: 1, lambda z: 0)
+            retworkx.digraph_astar_shortest_path(g, 0, lambda x: x,
+                                                 lambda y: 1, lambda z: 0)
 
 
 class TestAstarGraph(unittest.TestCase):
@@ -161,7 +161,7 @@ class TestAstarGraph(unittest.TestCase):
                           (g, a, lambda finish: finish_func(no_path, finish),
                            lambda x: float(x), heuristic_func))
 
-    def test_astar_graph_with_dag_input(self):
+    def test_astar_graph_with_digraph_input(self):
         g = retworkx.PyDAG()
         g.add_node(0)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This commit makes 2 changes, the first is that the rust class PyDAG is
renamed to be PyDiGraph. This makes it more clear that the class can be
used for any directed graph, not just a DAG. The PyDAG class is then
added as a subclass without any changes on the python side of the
module. This will enable a seamless transition for current users where
the only class exposed is PyDAG. Additionally, it will let users
differentiate between a PyDAG and PyDiGraph. Idealling we would want to
only have the cycle checking options exposed for the PyDAG class, but
there isn't any harm if PyDiGraph has it too.

Corresponding with this change the class code for PyDiGraph was moved
to a separate module to make it easier to follow. After this commit
lib.rs only contains the algorithms function code and the module configuration.
This makes it easier to follow as lib.rs has been growing as new
algorithms are added.

Fixes #20

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
