### PR TITLE
Attempt to fix readthedocs build

### DIFF
--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - rust=1.40.0=1
   - m2r=0.2.1=py_0
+  - sphinx=3.0.4=py_0

--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - rust=1.40.0=1
   - m2r=0.2.1=py_0
-  - sphinx=3.0.4=py_0
+  - sphinx=2.4.4=py_0

--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -4,5 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - rust=1.40.0=1
-  - m2r=0.2.1=py_0
-  - sphinx=2.4.4=py_0
+  - pip
+  - pip:
+    - m2r2

--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -1,0 +1,7 @@
+name: retworkx
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - rust=1.40.0=1
+  - m2r=0.2.1=py_0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+formats:
+  - epub
+  - pdf
+
+conda:
+  environment: .conda-rtd-environment.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.extlinks',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode',
-              'm2r',
+              'm2r2',
              ]
 html_static_path = ['_static']
 templates_path = ['_templates']

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,3 @@
-m2r
+m2r2
 sphinx<3
 sphinx_rtd_theme


### PR DESCRIPTION
Since #90 the docs are now autogenerated from the installed retworkx
package. However, the readthedocs builds are not working because they
do not have rustc installed in their build env so it is unable to build
retworkx. This commit attempts to configure readthedocs to install rust
via conda and then use that to build retworkx.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
