### PR TITLE
Actually export exception types

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -41,3 +41,16 @@ Algorithm Functions
    retworkx.graph_astar_shortest_path
    retworkx.digraph_astar_shortest_path
    retworkx.graph_greedy_color
+
+Exceptions
+----------
+
+.. autosummary::
+   :toctree: stubs
+
+   retworkx.InvalidNode
+   retworkx.DAGWouldCycle
+   retworkx.NoEdgeBetweenNodes
+   retworkx.DAGHasCycle
+   retworkx.NoSuitableNeighbors
+   retworkx.NoPathFound

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1061,9 +1061,28 @@ fn digraph_astar_shortest_path(
     Ok(out_path.to_object(py))
 }
 
+/// The provided node is invalid.
+create_exception!(retworkx, InvalidNode, Exception);
+/// Performing this operation would result in trying to add a cycle to a DAG.
+create_exception!(retworkx, DAGWouldCycle, Exception);
+/// There is no edge present between the provided nodes.
+create_exception!(retworkx, NoEdgeBetweenNodes, Exception);
+/// The specified Directed Graph has a cycle and can't be treated as a DAG.
+create_exception!(retworkx, DAGHasCycle, Exception);
+/// No neighbors found matching the provided predicate.
+create_exception!(retworkx, NoSuitableNeighbors, Exception);
+/// No path was found between the specified nodes.
+create_exception!(retworkx, NoPathFound, Exception);
+
 #[pymodule]
-fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("InvalidNode", py.get_type::<InvalidNode>())?;
+    m.add("DAGWouldCycle", py.get_type::<DAGWouldCycle>())?;
+    m.add("NoEdgeBetweenNodes", py.get_type::<NoEdgeBetweenNodes>())?;
+    m.add("DAGHasCycle", py.get_type::<DAGHasCycle>())?;
+    m.add("NoSuitableNeighbors", py.get_type::<NoSuitableNeighbors>())?;
+    m.add("NoPathFound", py.get_type::<NoPathFound>())?;
     m.add_wrapped(wrap_pyfunction!(bfs_successors))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
@@ -1088,13 +1107,6 @@ fn retworkx(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<graph::PyGraph>()?;
     Ok(())
 }
-
-create_exception!(retworkx, InvalidNode, Exception);
-create_exception!(retworkx, DAGWouldCycle, Exception);
-create_exception!(retworkx, NoEdgeBetweenNodes, Exception);
-create_exception!(retworkx, DAGHasCycle, Exception);
-create_exception!(retworkx, NoSuitableNeighbors, Exception);
-create_exception!(retworkx, NoPathFound, Exception);
 
 #[cfg(test)]
 mod tests {

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -39,14 +39,14 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')
         node_b = graph.add_node('b')
-        self.assertRaises(Exception, graph.get_edge_data,
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
                           node_a, node_b)
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')
         node_b = graph.add_node('b')
-        self.assertRaises(Exception, graph.get_all_edge_data,
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
                           node_a, node_b)
 
     def test_has_edge(self):
@@ -89,7 +89,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')
         node_b = graph.add_node('b')
-        self.assertRaises(Exception, graph.remove_edge,
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
                           node_a, node_b)
 
     def test_remove_edge_single(self):

--- a/tests/test_all_simple_paths.py
+++ b/tests/test_all_simple_paths.py
@@ -104,8 +104,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(Exception, retworkx.digraph_all_simple_paths,
-                          (dag, 0, 5))
+        with self.assertRaises(retworkx.InvalidNode):
+            retworkx.digraph_all_simple_paths(dag, 0, 5)
 
     def test_graph_digraph_all_simple_paths(self):
         dag = retworkx.PyGraph()
@@ -265,8 +265,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(Exception, retworkx.graph_all_simple_paths,
-                          (dag, 0, 5))
+        with self.assertRaises(retworkx.InvalidNode):
+            retworkx.graph_all_simple_paths(dag, 0, 5)
 
     def test_digraph_graph_all_simple_paths(self):
         dag = retworkx.PyDAG()

--- a/tests/test_astar.py
+++ b/tests/test_astar.py
@@ -80,9 +80,10 @@ class TestAstarDigraph(unittest.TestCase):
                 lambda x: float(x), heuristic_func)
             self.assertEqual(expected[index], path)
 
-        self.assertRaises(Exception, retworkx.digraph_astar_shortest_path,
-                          (g, a, lambda finish: finish_func(no_path, finish),
-                           lambda x: float(x), heuristic_func))
+        with self.assertRaises(retworkx.NoPathFound):
+            retworkx.digraph_astar_shortest_path(
+                g, a, lambda finish: finish_func(no_path, finish),
+                lambda x: float(x), heuristic_func)
 
     def test_astar_digraph_with_graph_input(self):
         g = retworkx.PyGraph()
@@ -157,9 +158,10 @@ class TestAstarGraph(unittest.TestCase):
                 lambda x: float(x), heuristic_func)
             self.assertEqual(expected[index], path)
 
-        self.assertRaises(Exception, retworkx.graph_astar_shortest_path,
-                          (g, a, lambda finish: finish_func(no_path, finish),
-                           lambda x: float(x), heuristic_func))
+        with self.assertRaises(retworkx.NoPathFound):
+            retworkx.graph_astar_shortest_path(
+                g, a, lambda finish: finish_func(no_path, finish),
+                lambda x: float(x), heuristic_func)
 
     def test_astar_graph_with_digraph_input(self):
         g = retworkx.PyDAG()

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -37,7 +37,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         node_b = dag.add_node('b')
-        self.assertRaises(Exception, dag.get_edge_data,
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.get_edge_data,
                           node_a, node_b)
 
     def test_has_edge(self):
@@ -75,7 +75,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')
         node_b = dag.add_node('b')
-        self.assertRaises(Exception, dag.remove_edge,
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.remove_edge,
                           node_a, node_b)
 
     def test_remove_edge_single(self):
@@ -111,7 +111,7 @@ class TestEdges(unittest.TestCase):
         dag.check_cycle = True
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
-        self.assertRaises(Exception, dag.add_edge, node_b,
+        self.assertRaises(retworkx.DAGWouldCycle, dag.add_edge, node_b,
                           node_a, {})
 
     def test_add_edge_with_cycle_check_enabled(self):
@@ -127,14 +127,14 @@ class TestEdges(unittest.TestCase):
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
         dag.add_edge(node_b, node_a, {})
-        with self.assertRaises(Exception):
+        with self.assertRaises(retworkx.DAGHasCycle):
             dag.check_cycle = True
 
     def test_cycle_checking_at_init(self):
         dag = retworkx.PyDAG(True)
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
-        with self.assertRaises(Exception):
+        with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edge(node_b, node_a, {})
 
     def test_find_adjacent_node_by_edge(self):
@@ -158,7 +158,7 @@ class TestEdges(unittest.TestCase):
         def compare_edges(edge):
             return 5 in edge['weights']
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(retworkx.NoSuitableNeighbors):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
 
     def test_add_edge_from(self):
@@ -186,7 +186,7 @@ class TestEdges(unittest.TestCase):
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
         node_c = dag.add_child(node_b, 'c', {})
-        with self.assertRaises(Exception):
+        with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edges_from([(node_a, node_c, {}), (node_c, node_b, {})])
 
     def test_add_edge_from_no_data(self):
@@ -214,5 +214,5 @@ class TestEdges(unittest.TestCase):
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
         node_c = dag.add_child(node_b, 'c', {})
-        with self.assertRaises(Exception):
+        with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edges_from_no_data([(node_a, node_c), (node_c, node_b)])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -58,7 +58,7 @@ class TestNodes(unittest.TestCase):
         node_a = dag.add_node('a')
         node_b = dag.add_child(node_a, 'b', {})
         dag.add_edge(node_b, node_a, {})
-        self.assertRaises(Exception, retworkx.topological_sort, dag)
+        self.assertRaises(retworkx.DAGHasCycle, retworkx.topological_sort, dag)
 
     def test_lexicographical_topo_sort(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
There were several custom extension classes being defined in retworkx
that were never being exported to the retworkx module. This left users
in a weird position where a custom exception would be raised from a
retworkx call but they would be unable to import that exception class
from retworkx to catch it. This commit fixes this issue by adding the
exceptions to the module so that python code can use the exceptions. The
tests and docs are updated accordingly to use the newly exported
exception classes instead of the base Exception class (which is the
parent for all of retworkx's exceptions).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
