### PR TITLE
Add *_gnp_random_graph functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ fixedbitset = "0.2.0"
 hashbrown = "0.7"
 numpy = "0.9.0"
 ndarray = "0.13.0"
+rand = "0.7"
+rand_pcg = "0.2"
 
 [dependencies.pyo3]
 version = "0.10.1"

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,13 +7,21 @@ Retworkx API Reference
 Graph Classes
 -------------
 
-
 .. autosummary::
    :toctree: stubs
 
     retworkx.PyGraph
     retworkx.PyDiGraph
     retworkx.PyDAG
+
+Random Circuit Functions
+------------------------
+
+.. autosummary::
+   :toctree: stubs
+
+    retworkx.directed_gnp_random_graph
+    retworkx.undirected_gnp_random_graph
 
 Algorithm Functions
 -------------------

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -77,7 +77,7 @@ use super::{
 #[text_signature = "(/, check_cycle=False)"]
 pub struct PyDiGraph {
     pub graph: StableDiGraph<PyObject, PyObject>,
-    cycle_state: algo::DfsSpace<
+    pub cycle_state: algo::DfsSpace<
         NodeIndex,
         <StableDiGraph<PyObject, PyObject> as Visitable>::Map,
     >,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1113,13 +1113,11 @@ pub fn directed_gnp_random_graph(
     }
     let mut v: isize = 0;
     let mut w: isize = -1;
-    let mut lp: f64 = 1.0 - probability;
-    lp = lp.ln();
+    let lp: f64 = (1.0 - probability).ln();
 
     while v < num_nodes {
         let random: f64 = rng.gen_range(0.0, 1.0);
-        let mut lr = 1.0 - random;
-        lr = lr.ln();
+        let lr: f64 = (1.0 - random).ln();
         let ratio: isize = (lr / lp) as isize;
         w = w + 1 + ratio;
         // avoid self loops
@@ -1199,13 +1197,11 @@ pub fn undirected_gnp_random_graph(
     }
     let mut v: isize = 1;
     let mut w: isize = -1;
-    let mut lp: f64 = 1.0 - probability;
-    lp = lp.ln();
+    let lp: f64 = (1.0 - probability).ln();
 
     while v < num_nodes {
         let random: f64 = rng.gen_range(0.0, 1.0);
-        let mut lr = 1.0 - random;
-        lr = lr.ln();
+        let lr = (1.0 - random).ln();
         let ratio: isize = (lr / lp) as isize;
         w = w + 1 + ratio;
         while w >= v && v < num_nodes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ extern crate ndarray;
 extern crate numpy;
 extern crate petgraph;
 extern crate pyo3;
+extern crate rand;
+extern crate rand_pcg;
 
 mod astar;
 mod dag_isomorphism;
@@ -28,7 +30,7 @@ use std::collections::{BinaryHeap, HashSet};
 use hashbrown::HashMap;
 
 use pyo3::create_exception;
-use pyo3::exceptions::Exception;
+use pyo3::exceptions::{Exception, IndexError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use pyo3::wrap_pyfunction;
@@ -41,6 +43,8 @@ use petgraph::visit::{Bfs, IntoEdgeReferences, NodeIndexable, Reversed};
 
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
+use rand::prelude::*;
+use rand_pcg::Pcg64;
 
 fn longest_path(graph: &digraph::PyDiGraph) -> PyResult<Vec<usize>> {
     let dag = &graph.graph;
@@ -1061,17 +1065,177 @@ fn digraph_astar_shortest_path(
     Ok(out_path.to_object(py))
 }
 
-/// The provided node is invalid.
+/// Return a :math:`G_{np}` directed random graph, also known as an
+/// Erdős-Rényi graph or a binomial graph.
+///
+/// The :math:`G_{n,p}` graph algorithm chooses each of the
+/// :math:`n (n - 1)` possible edges with probability :math:`p`.
+/// This algorithm [1]_ runs in :math:`O(n + m)` time, where :math:`m` is the
+/// expected number of edges, which equals :math:`p n (n - 1)/2`.
+///
+/// Based on the implementation of the networkx function
+/// ``fast_gnp_random_graph`` [2]_
+///
+/// :param int num_nodes: The number of nodes to create in the graph
+/// :param float probability: The probability of an edge
+/// :param int seed: An optional seed to use for the random number generator
+///
+/// :return: A PyDiGraph object
+/// :rtype: PyDiGraph
+///
+/// .. [1] Vladimir Batagelj and Ulrik Brandes,
+///    "Efficient generation of large random networks",
+///    Phys. Rev. E, 71, 036113, 2005.
+/// .. [2] https://github.com/networkx/networkx/blob/networkx-2.4/networkx/generators/random_graphs.py#L49-L120
+#[pyfunction]
+#[text_signature = "(num_nodes, probability, seed=None, /)"]
+pub fn directed_gnp_random_graph(
+    py: Python,
+    num_nodes: isize,
+    probability: f64,
+    seed: Option<u64>,
+) -> PyResult<digraph::PyDiGraph> {
+    if num_nodes <= 0 {
+        return Err(IndexError::py_err("num_nodes must be > 0"));
+    }
+    let mut rng: Pcg64 = match seed {
+        Some(seed) => Pcg64::seed_from_u64(seed),
+        None => Pcg64::from_entropy(),
+    };
+    let mut inner_graph = StableDiGraph::<PyObject, PyObject>::new();
+    for x in 0..num_nodes {
+        inner_graph.add_node(x.to_object(py));
+    }
+    if probability <= 0.0 || probability >= 1.0 {
+        return Err(IndexError::py_err(
+            "Probability out of range, must be 0 < p < 1",
+        ));
+    }
+    let mut v: isize = 0;
+    let mut w: isize = -1;
+    let mut lp: f64 = 1.0 - probability;
+    lp = lp.ln();
+
+    while v < num_nodes {
+        let random: f64 = rng.gen_range(0.0, 1.0);
+        let mut lr = 1.0 - random;
+        lr = lr.ln();
+        let ratio: isize = (lr / lp) as isize;
+        w = w + 1 + ratio;
+        // avoid self loops
+        if v == w {
+            w += 1;
+        }
+        while v < num_nodes && num_nodes <= w {
+            w -= v;
+            v += 1;
+            // avoid self loops
+            if v == w {
+                w -= v;
+                v += 1;
+            }
+        }
+        if v < num_nodes {
+            let v_index = NodeIndex::new(v as usize);
+            let w_index = NodeIndex::new(w as usize);
+            inner_graph.add_edge(v_index, w_index, py.None());
+        }
+    }
+
+    let graph = digraph::PyDiGraph {
+        graph: inner_graph,
+        cycle_state: algo::DfsSpace::default(),
+        check_cycle: false,
+        node_removed: false,
+    };
+    Ok(graph)
+}
+
+/// Return a :math:`G_{np}` random undirected graph, also known as an
+/// Erdős-Rényi graph or a binomial graph.
+///
+/// The :math:`G_{n,p}` graph algorithm chooses each of the
+/// :math:`[n (n - 1)]/2` possible edges with probability :math:`p`.
+/// This algorithm [1]_ runs in :math:`O(n + m)` time, where :math:`m` is the
+/// expected number of edges, which equals :math:`p n (n - 1)/2`.
+///
+/// Based on the implementation of the networkx function
+/// ``fast_gnp_random_graph`` [2]_
+///
+/// :param int num_nodes: The number of nodes to create in the graph
+/// :param float probability: The probability of an edge
+/// :param int seed: An optional seed to use for the random number generator
+///
+/// :return: A PyGraph object
+/// :rtype: PyGraph
+///
+/// .. [1] Vladimir Batagelj and Ulrik Brandes,
+///    "Efficient generation of large random networks",
+///    Phys. Rev. E, 71, 036113, 2005.
+/// .. [2] https://github.com/networkx/networkx/blob/networkx-2.4/networkx/generators/random_graphs.py#L49-L120
+#[pyfunction]
+#[text_signature = "(num_nodes, probability, seed=None, /)"]
+pub fn undirected_gnp_random_graph(
+    py: Python,
+    num_nodes: isize,
+    probability: f64,
+    seed: Option<u64>,
+) -> PyResult<graph::PyGraph> {
+    if num_nodes <= 0 {
+        return Err(IndexError::py_err("num_nodes must be > 0"));
+    }
+    let mut rng: Pcg64 = match seed {
+        Some(seed) => Pcg64::seed_from_u64(seed),
+        None => Pcg64::from_entropy(),
+    };
+    let mut inner_graph = StableUnGraph::<PyObject, PyObject>::default();
+    for x in 0..num_nodes {
+        inner_graph.add_node(x.to_object(py));
+    }
+    if probability <= 0.0 || probability >= 1.0 {
+        return Err(IndexError::py_err(
+            "Probability out of range, must be 0 < p < 1",
+        ));
+    }
+    let mut v: isize = 1;
+    let mut w: isize = -1;
+    let mut lp: f64 = 1.0 - probability;
+    lp = lp.ln();
+
+    while v < num_nodes {
+        let random: f64 = rng.gen_range(0.0, 1.0);
+        let mut lr = 1.0 - random;
+        lr = lr.ln();
+        let ratio: isize = (lr / lp) as isize;
+        w = w + 1 + ratio;
+        while w >= v && v < num_nodes {
+            w -= v;
+            v += 1;
+        }
+        if v < num_nodes {
+            let v_index = NodeIndex::new(v as usize);
+            let w_index = NodeIndex::new(w as usize);
+            inner_graph.add_edge(v_index, w_index, py.None());
+        }
+    }
+
+    let graph = graph::PyGraph {
+        graph: inner_graph,
+        node_removed: false,
+    };
+    Ok(graph)
+}
+// The provided node is invalid.
 create_exception!(retworkx, InvalidNode, Exception);
-/// Performing this operation would result in trying to add a cycle to a DAG.
+// Performing this operation would result in trying to add a cycle to a DAG.
 create_exception!(retworkx, DAGWouldCycle, Exception);
-/// There is no edge present between the provided nodes.
+// There is no edge present between the provided nodes.
 create_exception!(retworkx, NoEdgeBetweenNodes, Exception);
-/// The specified Directed Graph has a cycle and can't be treated as a DAG.
+// The specified Directed Graph has a cycle and can't be treated as a DAG.
 create_exception!(retworkx, DAGHasCycle, Exception);
-/// No neighbors found matching the provided predicate.
+// No neighbors found matching the provided predicate.
 create_exception!(retworkx, NoSuitableNeighbors, Exception);
-/// No path was found between the specified nodes.
+// No path was found between the specified nodes.
 create_exception!(retworkx, NoPathFound, Exception);
 
 #[pymodule]
@@ -1103,6 +1267,8 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(graph_astar_shortest_path))?;
     m.add_wrapped(wrap_pyfunction!(digraph_astar_shortest_path))?;
     m.add_wrapped(wrap_pyfunction!(graph_greedy_color))?;
+    m.add_wrapped(wrap_pyfunction!(directed_gnp_random_graph))?;
+    m.add_wrapped(wrap_pyfunction!(undirected_gnp_random_graph))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use std::collections::{BinaryHeap, HashSet};
 use hashbrown::HashMap;
 
 use pyo3::create_exception;
-use pyo3::exceptions::{Exception, IndexError};
+use pyo3::exceptions::{Exception, ValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use pyo3::wrap_pyfunction;
@@ -1096,7 +1096,7 @@ pub fn directed_gnp_random_graph(
     seed: Option<u64>,
 ) -> PyResult<digraph::PyDiGraph> {
     if num_nodes <= 0 {
-        return Err(IndexError::py_err("num_nodes must be > 0"));
+        return Err(ValueError::py_err("num_nodes must be > 0"));
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
@@ -1107,7 +1107,7 @@ pub fn directed_gnp_random_graph(
         inner_graph.add_node(x.to_object(py));
     }
     if probability <= 0.0 || probability >= 1.0 {
-        return Err(IndexError::py_err(
+        return Err(ValueError::py_err(
             "Probability out of range, must be 0 < p < 1",
         ));
     }
@@ -1182,7 +1182,7 @@ pub fn undirected_gnp_random_graph(
     seed: Option<u64>,
 ) -> PyResult<graph::PyGraph> {
     if num_nodes <= 0 {
-        return Err(IndexError::py_err("num_nodes must be > 0"));
+        return Err(ValueError::py_err("num_nodes must be > 0"));
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
@@ -1193,7 +1193,7 @@ pub fn undirected_gnp_random_graph(
         inner_graph.add_node(x.to_object(py));
     }
     if probability <= 0.0 || probability >= 1.0 {
-        return Err(IndexError::py_err(
+        return Err(ValueError::py_err(
             "Probability out of range, must be 0 < p < 1",
         ));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,7 +1077,7 @@ fn digraph_astar_shortest_path(
 /// ``fast_gnp_random_graph`` [2]_
 ///
 /// :param int num_nodes: The number of nodes to create in the graph
-/// :param float probability: The probability of an edge
+/// :param float probability: The probability of creating an edge between two nodes
 /// :param int seed: An optional seed to use for the random number generator
 ///
 /// :return: A PyDiGraph object
@@ -1153,7 +1153,7 @@ pub fn directed_gnp_random_graph(
 /// Erdős-Rényi graph or a binomial graph.
 ///
 /// The :math:`G_{n,p}` graph algorithm chooses each of the
-/// :math:`[n (n - 1)]/2` possible edges with probability :math:`p`.
+/// :math:`n (n - 1)/2` possible edges with probability :math:`p`.
 /// This algorithm [1]_ runs in :math:`O(n + m)` time, where :math:`m` is the
 /// expected number of edges, which equals :math:`p n (n - 1)/2`.
 ///
@@ -1161,7 +1161,7 @@ pub fn directed_gnp_random_graph(
 /// ``fast_gnp_random_graph`` [2]_
 ///
 /// :param int num_nodes: The number of nodes to create in the graph
-/// :param float probability: The probability of an edge
+/// :param float probability: The probability of creating an edge between two nodes
 /// :param int seed: An optional seed to use for the random number generator
 ///
 /// :return: A PyGraph object

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -42,21 +42,3 @@ class TestGNPRandomGraph(unittest.TestCase):
     def test_random_gnp_undirected_invalid_probability(self):
         with self.assertRaises(ValueError):
             retworkx.undirected_gnp_random_graph(23, 123.5)
-
-    def test_random_gnp_directed_edges_close_to_probability(self):
-        edges = 0
-        runs = 100
-        for i in range(runs):
-            edges += sum(1 for _ in retworkx.directed_gnp_random_graph(
-                10, 0.99999).edges())
-        self.assertGreaterEqual(abs(edges / float(runs) - 90),
-                                runs * 2.0 / 100)
-
-    def test_random_gnp_undirected_edges_close_to_probability(self):
-        edges = 0
-        runs = 100
-        for i in range(runs):
-            edges += sum(1 for _ in retworkx.undirected_gnp_random_graph(
-                10, 0.99999).edges())
-        self.assertGreaterEqual(abs(edges / float(runs) - 90),
-                                runs * 2.0 / 100)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -42,3 +42,21 @@ class TestGNPRandomGraph(unittest.TestCase):
     def test_random_gnp_undirected_invalid_probability(self):
         with self.assertRaises(IndexError):
             retworkx.undirected_gnp_random_graph(23, 123.5)
+
+    def test_random_gnp_directed_edges_close_to_probability(self):
+        edges = 0
+        runs = 100
+        for i in range(runs):
+            edges += sum(1 for _ in retworkx.directed_gnp_random_graph(
+                10, 0.99999).edges())
+        self.assertGreaterEqual(abs(edges / float(runs) - 90),
+                                runs * 2.0 / 100)
+
+    def test_random_gnp_undirected_edges_close_to_probability(self):
+        edges = 0
+        runs = 100
+        for i in range(runs):
+            edges += sum(1 for _ in retworkx.undirected_gnp_random_graph(
+                10, 0.99999).edges())
+        self.assertGreaterEqual(abs(edges / float(runs) - 90),
+                                runs * 2.0 / 100)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -23,11 +23,11 @@ class TestGNPRandomGraph(unittest.TestCase):
         self.assertEqual(len(graph.edges()), 104)
 
     def test_random_gnp_directed_invalid_num_nodes(self):
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             retworkx.directed_gnp_random_graph(-23, .5)
 
     def test_random_gnp_directed_invalid_probability(self):
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             retworkx.directed_gnp_random_graph(23, 123.5)
 
     def test_random_gnp_undirected(self):
@@ -36,11 +36,11 @@ class TestGNPRandomGraph(unittest.TestCase):
         self.assertEqual(len(graph.edges()), 105)
 
     def test_random_gnp_undirected_invalid_num_nodes(self):
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             retworkx.undirected_gnp_random_graph(-23, .5)
 
     def test_random_gnp_undirected_invalid_probability(self):
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ValueError):
             retworkx.undirected_gnp_random_graph(23, 123.5)
 
     def test_random_gnp_directed_edges_close_to_probability(self):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestGNPRandomGraph(unittest.TestCase):
+
+    def test_random_gnp_directed(self):
+        graph = retworkx.directed_gnp_random_graph(20, .5, 10)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 104)
+
+    def test_random_gnp_directed_invalid_num_nodes(self):
+        with self.assertRaises(IndexError):
+            retworkx.directed_gnp_random_graph(-23, .5)
+
+    def test_random_gnp_directed_invalid_probability(self):
+        with self.assertRaises(IndexError):
+            retworkx.directed_gnp_random_graph(23, 123.5)
+
+    def test_random_gnp_undirected(self):
+        graph = retworkx.undirected_gnp_random_graph(20, .5, 10)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 105)
+
+    def test_random_gnp_undirected_invalid_num_nodes(self):
+        with self.assertRaises(IndexError):
+            retworkx.undirected_gnp_random_graph(-23, .5)
+
+    def test_random_gnp_undirected_invalid_probability(self):
+        with self.assertRaises(IndexError):
+            retworkx.undirected_gnp_random_graph(23, 123.5)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -18,7 +18,7 @@ import retworkx
 class TestGNPRandomGraph(unittest.TestCase):
 
     def test_random_gnp_directed(self):
-        graph = retworkx.directed_gnp_random_graph(20, .5, 10)
+        graph = retworkx.directed_gnp_random_graph(20, .5, seed=10)
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 104)
 
@@ -31,7 +31,7 @@ class TestGNPRandomGraph(unittest.TestCase):
             retworkx.directed_gnp_random_graph(23, 123.5)
 
     def test_random_gnp_undirected(self):
-        graph = retworkx.undirected_gnp_random_graph(20, .5, 10)
+        graph = retworkx.undirected_gnp_random_graph(20, .5, seed=10)
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 105)
 


### PR DESCRIPTION
This commit adds 2 new functions directed_gnp_random_graph and
undirected_gnp_random_graph. These 2 functions are used for generating
a random Erdős-Rényi/binomial graph. The implementation of these 2
functions is based on the networkx function fast_gnp_random_graph. [1]

[1] https://github.com/networkx/networkx/blob/networkx-2.4/networkx/generators/random_graphs.py#L49

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
