### PR TITLE
Add s390x wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,3 +161,23 @@ jobs:
         - pip install -U twine cibuildwheel==1.2.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
+    - stage: deploy
+      arch: s390x
+      services:
+        - docker
+      before_install:
+        - echo ""
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_ALL="yum install -y wget && {package}/tools/install_rust_no_rustup.sh"
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
+        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - TWINE_USERNAME=retworkx-ci
+        - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
+      if: tag IS present
+      script:
+        - sudo pip install -U twine cibuildwheel==1.5.2
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS present
-  - name: Linux x86_64
-    if: tag IS present
-  - name: Linux non-x86_64
-    if: tag IS present
-  - name: macOS
-    if: tag IS present
-  - name: deploy
     if: tag IS blank
+  - name: Linux x86_64
+    if: tag IS blank
+  - name: Linux non-x86_64
+    if: tag IS blank
+  - name: macOS
+    if: tag IS blank
+  - name: deploy
+    if: tag IS present
 
 jobs:
   fast_finish: true
@@ -176,8 +176,8 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS blank
+      if: tag IS present
       script:
         - sudo pip install -U twine cibuildwheel==1.5.2
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,15 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Compile and lint
-    if: tag IS blank
-  - name: Linux x86_64
-    if: tag IS blank
-  - name: Linux non-x86_64
-    if: tag IS blank
-  - name: macOS
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: Linux x86_64
+    if: tag IS present
+  - name: Linux non-x86_64
+    if: tag IS present
+  - name: macOS
+    if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -176,8 +176,8 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+      if: tag IS blank
       script:
         - sudo pip install -U twine cibuildwheel==1.5.2
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
+#        - twine upload wheelhouse/*

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ it with the performance and safety that Rust provides.
 
 ## Installing retworkx
 
-retworkx is published on pypi so on x86\_64, i686, ppc64le, and aarch64
-Linux systems, x86\_64 on Mac OSX, and 32 and 64 bit Windows installing
-is as simple as running:
+retworkx is published on pypi so on x86\_64, i686, ppc64le, s390x, and
+aarch64 Linux systems, x86\_64 on Mac OSX, and 32 and 64 bit Windows
+installing is as simple as running:
 
 ```bash
 pip install retworkx

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,5 +1,10 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
+    uname -m
+    if [[ `uname -m` == "s390x" ]] ; then
+        export PATH=$PATH:/usr/local/lib
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+    fi
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh --default-toolchain nightly -y
 fi

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,10 +1,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
-    uname -m
-    if [[ `uname -m` == "s390x" ]] ; then
-        export PATH=$PATH:/usr/local/lib
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-    fi
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh --default-toolchain nightly -y
 fi

--- a/tools/install_rust_no_rustup.sh
+++ b/tools/install_rust_no_rustup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+wget https://static.rust-lang.org/dist/rust-nightly-s390x-unknown-linux-gnu.tar.gz
+yum clean packages
+yum clean headers
+yum clean metadata
+yum clean all
+rm -rf /var/cache/yum
+rm -rf /var/tmp/yum-*
+package-cleanup --oldkernels --count=1
+tar xzvf rust-nightly-s390x-unknown-linux-gnu.tar.gz
+rm -rf rust-nightly-s390x-unknown-linux-gnu.tar.gz
+pushd rust-nightly-s390x-unknown-linux-gnu
+./install.sh
+popd


### PR DESCRIPTION
This commit adds an s390x wheel job to CI that will run at release time
so we publish wheels for s390x too. We haven't been publishing or
building wheels for pypi since an issue with the manylinux2014 s390x
images and installing rust via rustup combined with disk size limits in
the s390x travis environment preventing use of the offline installer.
The travis issues have now been resolved so we now have enough space
to use the offline rust installer. For the next release we'll be
building s390x wheels.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->