### PR TITLE
Avoid use of Python in methods and functions

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -839,17 +839,17 @@ impl PyDiGraph {
     ///     ``(parent_index, node_index, edge_data)```
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn in_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+    pub fn in_edges(
+        &self,
+        node: usize,
+    ) -> PyResult<Vec<(usize, usize, &PyObject)>> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
-        let mut out_list: Vec<PyObject> = Vec::new();
         let raw_edges = self.graph.edges_directed(index, dir);
-        for edge in raw_edges {
-            let edge_w = edge.weight();
-            let triplet = (edge.source().index(), node, edge_w).to_object(py);
-            out_list.push(triplet)
-        }
-        Ok(PyList::new(py, out_list).into())
+        let out_list: Vec<(usize, usize, &PyObject)> = raw_edges
+            .map(|x| (x.source().index(), node, x.weight()))
+            .collect();
+        Ok(out_list)
     }
 
     /// Get the index and edge data for all children of a node.
@@ -863,17 +863,17 @@ impl PyDiGraph {
     ///     ```(node_index, child_index, edge_data)```
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn out_edges(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
+    pub fn out_edges(
+        &self,
+        node: usize,
+    ) -> PyResult<Vec<(usize, usize, &PyObject)>> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
-        let mut out_list: Vec<PyObject> = Vec::new();
         let raw_edges = self.graph.edges_directed(index, dir);
-        for edge in raw_edges {
-            let edge_w = edge.weight();
-            let triplet = (node, edge.target().index(), edge_w).to_object(py);
-            out_list.push(triplet)
-        }
-        Ok(PyList::new(py, out_list).into())
+        let out_list: Vec<(usize, usize, &PyObject)> = raw_edges
+            .map(|x| (node, x.target().index(), x.weight()))
+            .collect();
+        Ok(out_list)
     }
 
     /// Add new nodes to the graph.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -380,38 +380,30 @@ impl PyDiGraph {
     ///
     /// :returns: A list of all the edge data objects in the graph
     /// :rtype: list
-    pub fn edges(&self, py: Python) -> PyObject {
-        let raw_edges = self.graph.edge_indices();
-        let mut out: Vec<&PyObject> = Vec::new();
-        for edge in raw_edges {
-            out.push(self.graph.edge_weight(edge).unwrap());
-        }
-        PyList::new(py, out).into()
+    pub fn edges(&self) -> Vec<&PyObject> {
+        self.graph
+            .edge_indices()
+            .map(|edge| self.graph.edge_weight(edge).unwrap())
+            .collect()
     }
 
     /// Return a list of all node data.
     ///
     /// :returns: A list of all the node data objects in the graph
     /// :rtype: list
-    pub fn nodes(&self, py: Python) -> PyObject {
-        let raw_nodes = self.graph.node_indices();
-        let mut out: Vec<&PyObject> = Vec::new();
-        for node in raw_nodes {
-            out.push(self.graph.node_weight(node).unwrap());
-        }
-        PyList::new(py, out).into()
+    pub fn nodes(&self) -> Vec<&PyObject> {
+        self.graph
+            .node_indices()
+            .map(|node| self.graph.node_weight(node).unwrap())
+            .collect()
     }
 
     /// Return a list of all node indexes.
     ///
     /// :returns: A list of all the node indexes in the graph
     /// :rtype: list
-    pub fn node_indexes(&self, py: Python) -> PyObject {
-        let mut out_list: Vec<usize> = Vec::new();
-        for node_index in self.graph.node_indices() {
-            out_list.push(node_index.index());
-        }
-        PyList::new(py, out_list).into()
+    pub fn node_indexes(&self) -> Vec<usize> {
+        self.graph.node_indices().map(|node| node.index()).collect()
     }
 
     /// Return True if there is an edge from node_a to node_b.
@@ -435,7 +427,7 @@ impl PyDiGraph {
     /// :returns: A list of the node data for all the child neighbor nodes
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn successors(&self, py: Python, node: usize) -> PyResult<PyObject> {
+    pub fn successors(&self, node: usize) -> PyResult<Vec<&PyObject>> {
         let index = NodeIndex::new(node);
         let children = self
             .graph
@@ -448,7 +440,7 @@ impl PyDiGraph {
                 used_indexes.insert(succ);
             }
         }
-        Ok(PyList::new(py, succesors).into())
+        Ok(succesors)
     }
 
     /// Return a list of all the node predecessor data.
@@ -458,7 +450,7 @@ impl PyDiGraph {
     /// :returns: A list of the node data for all the parent neighbor nodes
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn predecessors(&self, py: Python, node: usize) -> PyResult<PyObject> {
+    pub fn predecessors(&self, node: usize) -> PyResult<Vec<&PyObject>> {
         let index = NodeIndex::new(node);
         let parents = self
             .graph
@@ -471,7 +463,7 @@ impl PyDiGraph {
                 used_indexes.insert(pred);
             }
         }
-        Ok(PyList::new(py, predec).into())
+        Ok(predec)
     }
 
     /// Return the edge data for an edge between 2 nodes.
@@ -529,25 +521,22 @@ impl PyDiGraph {
     #[text_signature = "(node_a, node_b, /)"]
     pub fn get_all_edge_data(
         &self,
-        py: Python,
         node_a: usize,
         node_b: usize,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Vec<&PyObject>> {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
         let raw_edges = self
             .graph
             .edges_directed(index_a, petgraph::Direction::Outgoing);
-        let mut out: Vec<&PyObject> = Vec::new();
-        for edge in raw_edges {
-            if edge.target() == index_b {
-                out.push(edge.weight());
-            }
-        }
+        let out: Vec<&PyObject> = raw_edges
+            .filter(|x| x.target() == index_b)
+            .map(|edge| edge.weight())
+            .collect();
         if out.is_empty() {
             Err(NoEdgeBetweenNodes::py_err("No edge found between nodes"))
         } else {
-            Ok(PyList::new(py, out).into())
+            Ok(out)
         }
     }
 
@@ -757,7 +746,7 @@ impl PyDiGraph {
     pub fn adj(&mut self, py: Python, node: usize) -> PyResult<PyObject> {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.neighbors(index);
-        let out_dict = PyDict::new(py);
+        let mut out_map: HashMap<usize, &PyObject> = HashMap::new();
         for neighbor in neighbors {
             let mut edge = self.graph.find_edge(index, neighbor);
             // If there is no edge then it must be a parent neighbor
@@ -765,7 +754,11 @@ impl PyDiGraph {
                 edge = self.graph.find_edge(neighbor, index);
             }
             let edge_w = self.graph.edge_weight(edge.unwrap());
-            out_dict.set_item(neighbor.index(), edge_w)?;
+            out_map.insert(neighbor.index(), edge_w.unwrap());
+        }
+        let out_dict = PyDict::new(py);
+        for (index, value) in out_map {
+            out_dict.set_item(index, value)?;
         }
         Ok(out_dict.into())
     }
@@ -800,7 +793,7 @@ impl PyDiGraph {
             petgraph::Direction::Outgoing
         };
         let neighbors = self.graph.neighbors_directed(index, dir);
-        let out_dict = PyDict::new(py);
+        let mut out_map: HashMap<usize, &PyObject> = HashMap::new();
         for neighbor in neighbors {
             let edge = if direction {
                 match self.graph.find_edge(neighbor, index) {
@@ -822,7 +815,11 @@ impl PyDiGraph {
                 }
             };
             let edge_w = self.graph.edge_weight(edge);
-            out_dict.set_item(neighbor.index(), edge_w)?;
+            out_map.insert(neighbor.index(), edge_w.unwrap());
+        }
+        let out_dict = PyDict::new(py);
+        for (index, value) in out_map {
+            out_dict.set_item(index, value)?;
         }
         Ok(out_dict.into())
     }
@@ -884,16 +881,13 @@ impl PyDiGraph {
     /// :returns: A list of int indices of the newly created nodes
     /// :rtype: list
     #[text_signature = "(obj_list, /)"]
-    pub fn add_nodes_from(
-        &mut self,
-        obj_list: Vec<PyObject>,
-    ) -> PyResult<Vec<usize>> {
+    pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> Vec<usize> {
         let mut out_list: Vec<usize> = Vec::new();
         for obj in obj_list {
             let node_index = self.graph.add_node(obj);
             out_list.push(node_index.index());
         }
-        Ok(out_list)
+        out_list
     }
 
     /// Remove nodes from the graph.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -427,7 +427,7 @@ impl PyDiGraph {
     /// :returns: A list of the node data for all the child neighbor nodes
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn successors(&self, node: usize) -> PyResult<Vec<&PyObject>> {
+    pub fn successors(&self, node: usize) -> Vec<&PyObject> {
         let index = NodeIndex::new(node);
         let children = self
             .graph
@@ -440,7 +440,7 @@ impl PyDiGraph {
                 used_indexes.insert(succ);
             }
         }
-        Ok(succesors)
+        succesors
     }
 
     /// Return a list of all the node predecessor data.
@@ -450,7 +450,7 @@ impl PyDiGraph {
     /// :returns: A list of the node data for all the parent neighbor nodes
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn predecessors(&self, node: usize) -> PyResult<Vec<&PyObject>> {
+    pub fn predecessors(&self, node: usize) -> Vec<&PyObject> {
         let index = NodeIndex::new(node);
         let parents = self
             .graph
@@ -463,7 +463,7 @@ impl PyDiGraph {
                 used_indexes.insert(pred);
             }
         }
-        Ok(predec)
+        predec
     }
 
     /// Return the edge data for an edge between 2 nodes.
@@ -839,14 +839,14 @@ impl PyDiGraph {
     pub fn in_edges(
         &self,
         node: usize,
-    ) -> PyResult<Vec<(usize, usize, &PyObject)>> {
+    ) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
         let raw_edges = self.graph.edges_directed(index, dir);
         let out_list: Vec<(usize, usize, &PyObject)> = raw_edges
             .map(|x| (x.source().index(), node, x.weight()))
             .collect();
-        Ok(out_list)
+        out_list
     }
 
     /// Get the index and edge data for all children of a node.
@@ -863,14 +863,14 @@ impl PyDiGraph {
     pub fn out_edges(
         &self,
         node: usize,
-    ) -> PyResult<Vec<(usize, usize, &PyObject)>> {
+    ) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
         let raw_edges = self.graph.edges_directed(index, dir);
         let out_list: Vec<(usize, usize, &PyObject)> = raw_edges
             .map(|x| (node, x.target().index(), x.weight()))
             .collect();
-        Ok(out_list)
+        out_list
     }
 
     /// Add new nodes to the graph.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -836,10 +836,7 @@ impl PyDiGraph {
     ///     ``(parent_index, node_index, edge_data)```
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn in_edges(
-        &self,
-        node: usize,
-    ) -> Vec<(usize, usize, &PyObject)> {
+    pub fn in_edges(&self, node: usize) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
         let raw_edges = self.graph.edges_directed(index, dir);
@@ -860,10 +857,7 @@ impl PyDiGraph {
     ///     ```(node_index, child_index, edge_data)```
     /// :rtype: list
     #[text_signature = "(node, /)"]
-    pub fn out_edges(
-        &self,
-        node: usize,
-    ) -> Vec<(usize, usize, &PyObject)> {
+    pub fn out_edges(&self, node: usize) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
         let raw_edges = self.graph.edges_directed(index, dir);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,12 +103,8 @@ fn longest_path(graph: &digraph::PyDiGraph) -> PyResult<Vec<usize>> {
 /// :raises DAGHasCycle: If the input PyDiGraph has a cycle
 #[pyfunction]
 #[text_signature = "(graph, /)"]
-fn dag_longest_path(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-) -> PyResult<PyObject> {
-    let path = longest_path(graph)?;
-    Ok(PyList::new(py, path).into())
+fn dag_longest_path(graph: &digraph::PyDiGraph) -> PyResult<Vec<usize>> {
+    longest_path(graph)
 }
 
 /// Find the length of the longest path in a DAG
@@ -237,21 +233,14 @@ fn is_isomorphic_node_match(
 /// :raises DAGHasCycle: if a cycle is encountered while sorting the graph
 #[pyfunction]
 #[text_signature = "(graph, /)"]
-fn topological_sort(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-) -> PyResult<PyObject> {
+fn topological_sort(graph: &digraph::PyDiGraph) -> PyResult<Vec<usize>> {
     let nodes = match algo::toposort(graph, None) {
         Ok(nodes) => nodes,
         Err(_err) => {
             return Err(DAGHasCycle::py_err("Sort encountered a cycle"))
         }
     };
-    let mut out: Vec<usize> = Vec::new();
-    for node in nodes {
-        out.push(node.index());
-    }
-    Ok(PyList::new(py, out).into())
+    Ok(nodes.iter().map(|node| node.index()).collect())
 }
 
 /// Return successors in a breadth-first-search from a source node.
@@ -303,11 +292,7 @@ fn bfs_successors(
 /// :rtype: list
 #[pyfunction]
 #[text_signature = "(graph, node, /)"]
-fn ancestors(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-    node: usize,
-) -> PyResult<PyObject> {
+fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
@@ -317,7 +302,7 @@ fn ancestors(
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    Ok(out_set.to_object(py))
+    out_set
 }
 
 /// Return the descendants of a node in a graph.
@@ -333,11 +318,7 @@ fn ancestors(
 /// :returns: A list of node indexes of descendants of provided node.
 /// :rtype: list
 #[pyfunction]
-fn descendants(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-    node: usize,
-) -> PyResult<PyObject> {
+fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
@@ -346,7 +327,7 @@ fn descendants(
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    Ok(out_set.to_object(py))
+    out_set
 }
 
 /// Get the lexicographical topological sorted nodes from the provided DAG
@@ -944,7 +925,7 @@ fn graph_astar_shortest_path(
     goal_fn: PyObject,
     edge_cost_fn: PyObject,
     estimate_cost_fn: PyObject,
-) -> PyResult<PyObject> {
+) -> PyResult<Vec<usize>> {
     let goal_fn_callable = |a: &PyObject| -> PyResult<bool> {
         let res = goal_fn.call1(py, (a,))?;
         let raw = res.to_object(py);
@@ -984,8 +965,7 @@ fn graph_astar_shortest_path(
             ))
         }
     };
-    let out_path: Vec<usize> = path.1.into_iter().map(|x| x.index()).collect();
-    Ok(out_path.to_object(py))
+    Ok(path.1.into_iter().map(|x| x.index()).collect())
 }
 
 /// Compute the A* shortest path for a PyDiGraph
@@ -1017,7 +997,7 @@ fn digraph_astar_shortest_path(
     goal_fn: PyObject,
     edge_cost_fn: PyObject,
     estimate_cost_fn: PyObject,
-) -> PyResult<PyObject> {
+) -> PyResult<Vec<usize>> {
     let goal_fn_callable = |a: &PyObject| -> PyResult<bool> {
         let res = goal_fn.call1(py, (a,))?;
         let raw = res.to_object(py);
@@ -1057,8 +1037,7 @@ fn digraph_astar_shortest_path(
             ))
         }
     };
-    let out_path: Vec<usize> = path.1.into_iter().map(|x| x.index()).collect();
-    Ok(out_path.to_object(py))
+    Ok(path.1.into_iter().map(|x| x.index()).collect())
 }
 
 /// The provided node is invalid.


### PR DESCRIPTION
This commit reworks the functions and methods that were using a `Python` input
parameter as part of their operation. Requiring Python as a parameter means
that function has a GIL lock for it's entire operation which can have unnecessary
overhead,. In addition everywhere that we use a `Python` object means we're
calling out to python which will have overhead even if there is no GIL contention
so we should try to minimize except where necessary.

For example, generation of the output list from the `out_edges()` and
`in_edges()` methods for `PyDiGraph`/`PyDAG`. Previously these
methods were manually looping over the edges and constructing a Vec of
PyObjects from a tuple. This ends up being a performance bottleneck
because we need to call out to python on each iteration to convert the
tuple to a python object. Then we call out to python again at the end of
the method to convert the Vec to to a PyList and return that. Instead
this changes the logic to just generate a Vec<(source, target, weight)>
using map() over the iterator and return that. This relies on PyO3 to do
the conversion for us which ends up being faster because it happens once
at the end instead of on every iteration of the loop.


<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
