### PR TITLE
Update coverage rustflags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,13 @@ jobs:
         - pip install -U setuptools-rust
         - gem install coveralls-lcov
         - export CARGO_INCREMENTAL=0
-        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
+        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        - export RUSTDOCFLAGS="-Cpanic=abort"
         - python setup.py develop
       script:
         - export CARGO_INCREMENTAL=0
-        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+        - export RUSTDOCFLAGS="-Cpanic=abort"
         - cd tests && python -m unittest discover . && cd ..
         - zip -0 ccov.zip `find . \( -name "retworkx*.gc*" \) -print`
         - ./grcov ccov.zip -s . -t lcov --ignore-not-existing --ignore "/*" -o coveralls.info


### PR DESCRIPTION
This commit updates the flags used for generating coverage data with
grcov based on the latest README for grcov. [1] The last time these were
updated in #72 was to remove a flag that was being removed from rust and
causing the job to fail. However, that commit failed to add equivalent
flags which would perform the same functionality. This commit fixes that
oversight so we should have more reliable coverage collection.

[1] https://github.com/mozilla/grcov/blob/master/README.md

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
