### PR TITLE
Bump hashbrown version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 [dependencies]
 petgraph = "0.5.1"
 fixedbitset = "0.2.0"
-hashbrown = "0.7"
+hashbrown = "0.8"
 numpy = "0.11.0"
 ndarray = "0.13.0"
 rand = "0.7"


### PR DESCRIPTION
There has a been a new minor version of hashbrown up for some time now.
This commit bumps the dependency version in the cargo.toml to keep the
dependency version up to date.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
