### PR TITLE
Configure dependabot to ignore fixedbitset for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "fixedbitset"


### PR DESCRIPTION
The fixedbitset dependency has to be kept in sync with the version
petgraph is using since we need to interoperate with pegraph using
fixedbitset objects a version mismatch will cause a compilation failure.
Right now dependabot is trying to update the fixedbitset verision
independently which will not pass CI. This commit sets fixedbitset as an
ignored package in the dependabot configuration.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
