### PR TITLE
Downgrade jupyter-sphinx to fix readthedocs build

### DIFF
--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -8,6 +8,6 @@ dependencies:
   - pip
   - pip:
     - m2r2
-    - jupyter-sphinx
+    - jupyter-sphinx==0.2.3
     - pydot
     - pillow

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,8 @@ python:
   install:
     - method: pip
       path: .
+
+sphinx:
+  builder: html
+  configuration: conf.py
+  fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,8 +20,3 @@ python:
   install:
     - method: pip
       path: .
-
-sphinx:
-  builder: html
-  configuration: conf.py
-  fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode',
               'm2r2',
-              'jupyter_sphinx',
+              'jupyter_sphinx.execute',
              ]
 html_static_path = ['_static']
 templates_path = ['_templates']

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,6 +1,6 @@
 m2r2
 sphinx
 sphinx_rtd_theme
-jupyter-sphinx
+jupyter-sphinx==0.2.3
 pydot
 pillow>=4.2.1


### PR DESCRIPTION
Since the introduction of the `to_dot()` methods in #103 and the use of
jupyter-sphinx in the docs, the read the docs builds have been failing.
It looks like this is due to:
https://github.com/jupyter/jupyter-sphinx/issues/126
This commit fixes this issue by pinning the jupyter sphinx version to
a version that is known working on read the docs.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
