### PR TITLE
Add option to set multigraph on PyGraph and PyDiGraph

### DIFF
--- a/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
+++ b/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
@@ -29,7 +29,7 @@ features:
           os.remove(tmp_path)
       image
 
-    Then trying to adding an edge between ``0`` and ``1`` again will update it's
+    Then trying to add an edge between ``0`` and ``1`` again will update its
     weight/payload.
 
     .. jupyter-execute::

--- a/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
+++ b/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
@@ -1,11 +1,12 @@
 ---
 features:
   - |
-    The :class:`~retworkx.PyGraph` constructor now has a new kwarg
-    ``multigraph`` which can optionally be set to ``False`` to disallow
-    adding parallel edges to the graph. If an edge is attempted to be added
-    where one already exists it will update the weight for the edge with the
-    new value. For example:
+    The :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph`
+    constructors now have a new kwarg ``multigraph`` which can optionally be
+    set to ``False`` to disallow adding parallel edges to the graph. With
+    ``multigraph=False`` if an edge is attempted to be added where one already
+    exists it will update the weight for the edge with the new value. For
+    example:
 
     .. jupyter-execute::
 

--- a/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
+++ b/releasenotes/notes/add-multigraph-pygraph-fc77ffd1b7812da3.yaml
@@ -1,0 +1,61 @@
+---
+features:
+  - |
+    The :class:`~retworkx.PyGraph` constructor now has a new kwarg
+    ``multigraph`` which can optionally be set to ``False`` to disallow
+    adding parallel edges to the graph. If an edge is attempted to be added
+    where one already exists it will update the weight for the edge with the
+    new value. For example:
+
+    .. jupyter-execute::
+
+      import os
+      import tempfile
+
+      import pydot
+      from PIL import Image
+
+      import retworkx as rx
+
+      graph = rx.PyGraph(multigraph=False)
+      graph.extend_from_weighted_edge_list([(0, 1, -1), (1, 2, 0), (2, 0, 1)])
+      dot = pydot.graph_from_dot_data(
+          graph.to_dot(edge_attr=lambda e:{'label': str(e)}))[0]
+
+      with tempfile.TemporaryDirectory() as tmpdirname:
+          tmp_path = os.path.join(tmpdirname, 'dag.png')
+          dot.write_png(tmp_path)
+          image = Image.open(tmp_path)
+          os.remove(tmp_path)
+      image
+
+    Then trying to adding an edge between ``0`` and ``1`` again will update it's
+    weight/payload.
+
+    .. jupyter-execute::
+
+      graph.add_edge(0, 1, 42)
+      dot = pydot.graph_from_dot_data(
+          graph.to_dot(edge_attr=lambda e:{'label': str(e)}))[0]
+
+      with tempfile.TemporaryDirectory() as tmpdirname:
+          tmp_path = os.path.join(tmpdirname, 'dag.png')
+          dot.write_png(tmp_path)
+          image = Image.open(tmp_path)
+          os.remove(tmp_path)
+      image
+
+    You can query whether a PyGraph allows multigraphs with the boolean
+    attribute :attr:`~retworkx.PyGraph.multigraph`. The attribute can not
+    be set outside of the constructor.
+  - |
+    The :mod:`retworkx.generators` module's functions
+    :func:`~retworkx.generators.cycle_graph`,
+    :func:`~retworkx.generators.path_graph`,
+    :func:`~retworkx.generators.star_graph`,
+    :func:`~retworkx.generators.mesh_graph`, and
+    :func:`~retworkx.generators.grid_graph` now have a new kwarg ``multigraph``
+    which takes a boolean and defaults to ``True``. When it is set to ``False``
+    the generated :class:`~retworkx.PyGraph` object will have the
+    :attr:`~retworkx.PyGraph.multigraph` attribute set to ``False`` meaning it
+    will disallow adding parallel edges.

--- a/src/dag_isomorphism.rs
+++ b/src/dag_isomorphism.rs
@@ -221,6 +221,7 @@ fn reindex_graph(py: Python, dag: &PyDiGraph) -> PyDiGraph {
         cycle_state: algo::DfsSpace::default(),
         check_cycle: dag.check_cycle,
         node_removed: false,
+        multigraph: true,
     }
 }
 

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1955,6 +1955,7 @@ impl PyDiGraph {
         crate::graph::PyGraph {
             graph: new_graph,
             node_removed: false,
+            multigraph: true,
         }
     }
 }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -135,6 +135,10 @@ pub fn directed_cycle_graph(
 /// :param list weights: A list of node weights, the first element in the list
 ///     will be the center node of the cycle graph. If both ``num_node`` and
 ///     ``weights`` are set this will be ignored and ``weights`` will be used.
+/// :param bool multigraph: When set to False the output
+///     :class:`~retworkx.PyGraph` object will not be not be a multigraph and
+///     won't  allow parallel edges to be added. Instead
+///     calls which would create a parallel edge will update the existing edge.
 ///
 /// :returns: The generated cycle graph
 /// :rtype: PyGraph
@@ -163,12 +167,13 @@ pub fn directed_cycle_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
-#[text_signature = "(/, num_nodes=None, weights=None)"]
+#[pyfunction(multigraph = true)]
+#[text_signature = "(/, num_nodes=None, weights=None, multigraph=True)"]
 pub fn cycle_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
+    multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
     let mut graph = StableUnGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
@@ -206,6 +211,7 @@ pub fn cycle_graph(
     Ok(graph::PyGraph {
         graph,
         node_removed: false,
+        multigraph,
     })
 }
 
@@ -303,6 +309,10 @@ pub fn directed_path_graph(
 /// :param list weights: A list of node weights, the first element in the list
 ///     will be the center node of the path graph. If both ``num_node`` and
 ///     ``weights`` are set this will be ignored and ``weights`` will be used.
+/// :param bool multigraph: When set to False the output
+///     :class:`~retworkx.PyGraph` object will not be not be a multigraph and
+///     won't  allow parallel edges to be added. Instead
+///     calls which would create a parallel edge will update the existing edge.
 ///
 /// :returns: The generated path graph
 /// :rtype: PyGraph
@@ -331,12 +341,13 @@ pub fn directed_path_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
-#[text_signature = "(/, num_nodes=None, weights=None)"]
+#[pyfunction(multigraph = true)]
+#[text_signature = "(/, num_nodes=None, weights=None, multigraph=True)"]
 pub fn path_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
+    multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
     let mut graph = StableUnGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
@@ -366,6 +377,7 @@ pub fn path_graph(
     Ok(graph::PyGraph {
         graph,
         node_removed: false,
+        multigraph,
     })
 }
 
@@ -488,6 +500,10 @@ pub fn directed_star_graph(
 /// :param list weights: A list of node weights, the first element in the list
 ///     will be the center node of the star graph. If both ``num_node`` and
 ///     ``weights`` are set this will be ignored and ``weights`` will be used.
+/// :param bool multigraph: When set to False the output
+///     :class:`~retworkx.PyGraph` object will not be not be a multigraph and
+///     won't  allow parallel edges to be added. Instead
+///     calls which would create a parallel edge will update the existing edge.
 ///
 /// :returns: The generated star graph
 /// :rtype: PyGraph
@@ -516,12 +532,13 @@ pub fn directed_star_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
-#[text_signature = "(/, num_nodes=None, weights=None)"]
+#[pyfunction(multigraph = true)]
+#[text_signature = "(/, num_nodes=None, weights=None, multigraph=True)"]
 pub fn star_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
+    multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
     let mut graph = StableUnGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
@@ -548,6 +565,7 @@ pub fn star_graph(
     Ok(graph::PyGraph {
         graph,
         node_removed: false,
+        multigraph,
     })
 }
 
@@ -558,6 +576,10 @@ pub fn star_graph(
 ///     ``weights`` are set this will be ignored and ``weights`` will be used.
 /// :param list weights: A list of node weights. If both ``num_node`` and
 ///     ``weights`` are set this will be ignored and ``weights`` will be used.
+/// :param bool multigraph: When set to False the output
+///     :class:`~retworkx.PyGraph` object will not be not be a multigraph and
+///     won't  allow parallel edges to be added. Instead
+///     calls which would create a parallel edge will update the existing edge.
 ///
 /// :returns: The generated mesh graph
 /// :rtype: PyGraph
@@ -586,12 +608,13 @@ pub fn star_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
-#[text_signature = "(/, num_nodes=None, weights=None)"]
+#[pyfunction(multigraph = true)]
+#[text_signature = "(/, num_nodes=None, weights=None, multigraph=True)"]
 pub fn mesh_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
+    multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
     let mut graph = StableUnGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
@@ -622,6 +645,7 @@ pub fn mesh_graph(
     Ok(graph::PyGraph {
         graph,
         node_removed: false,
+        multigraph,
     })
 }
 
@@ -715,6 +739,10 @@ pub fn directed_mesh_graph(
 ///     weights list, the trailing weights are ignored.
 ///     If number of nodes(rows*cols) is greater than length of
 ///     weights list, extra nodes with None weight are appended.
+/// :param bool multigraph: When set to False the output
+///     :class:`~retworkx.PyGraph` object will not be not be a multigraph and
+///     won't  allow parallel edges to be added. Instead
+///     calls which would create a parallel edge will update the existing edge.
 ///
 /// :returns: The generated grid graph
 /// :rtype: PyGraph
@@ -744,13 +772,14 @@ pub fn directed_mesh_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
-#[text_signature = "(/, rows=None, cols=None, weights=None)"]
+#[pyfunction(multigraph = true)]
+#[text_signature = "(/, rows=None, cols=None, weights=None, multigraph=True)"]
 pub fn grid_graph(
     py: Python,
     rows: Option<usize>,
     cols: Option<usize>,
     weights: Option<Vec<PyObject>>,
+    multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
     let mut graph = StableUnGraph::<PyObject, PyObject>::default();
     if weights.is_none() && (rows.is_none() || cols.is_none()) {
@@ -812,6 +841,7 @@ pub fn grid_graph(
     Ok(graph::PyGraph {
         graph,
         node_removed: false,
+        multigraph,
     })
 }
 

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -124,6 +124,7 @@ pub fn directed_cycle_graph(
         node_removed: false,
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
+        multigraph: true,
     })
 }
 
@@ -298,6 +299,7 @@ pub fn directed_path_graph(
         node_removed: false,
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
+        multigraph: true,
     })
 }
 
@@ -489,6 +491,7 @@ pub fn directed_star_graph(
         node_removed: false,
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
+        multigraph: true,
     })
 }
 
@@ -722,6 +725,7 @@ pub fn directed_mesh_graph(
         node_removed: false,
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
+        multigraph: true,
     })
 }
 
@@ -977,6 +981,7 @@ pub fn directed_grid_graph(
         node_removed: false,
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
+        multigraph: true,
     })
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -83,7 +83,7 @@ use petgraph::visit::{
 ///     method call will be used to update the existing edge in place.
 ///
 #[pyclass(module = "retworkx")]
-#[text_signature = "()"]
+#[text_signature = "(/, multigraph=True)"]
 pub struct PyGraph {
     pub graph: StableUnGraph<PyObject, PyObject>,
     pub node_removed: bool,
@@ -356,6 +356,12 @@ impl PyGraph {
         Ok(())
     }
 
+    /// Whether the graph is a multigraph (allows multiple edges between
+    /// nodes) or not
+    ///
+    /// If set to ``False`` multiple edges between nodes are not allowed and
+    /// calls that would add a parallel edge will instead update the existing
+    /// edge
     #[getter]
     fn multigraph(&self) -> bool {
         self.multigraph

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1198,6 +1198,7 @@ impl PyGraph {
         PyGraph {
             graph: out_graph,
             node_removed: false,
+            multigraph: true,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2148,6 +2148,7 @@ pub fn directed_gnp_random_graph(
         cycle_state: algo::DfsSpace::default(),
         check_cycle: false,
         node_removed: false,
+        multigraph: true,
     };
     Ok(graph)
 }
@@ -2321,6 +2322,7 @@ pub fn directed_gnm_random_graph(
         cycle_state: algo::DfsSpace::default(),
         check_cycle: false,
         node_removed: false,
+        multigraph: true,
     };
     Ok(graph)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2241,6 +2241,7 @@ pub fn undirected_gnp_random_graph(
     let graph = graph::PyGraph {
         graph: inner_graph,
         node_removed: false,
+        multigraph: true,
     };
     Ok(graph)
 }
@@ -2394,6 +2395,7 @@ pub fn undirected_gnm_random_graph(
     let graph = graph::PyGraph {
         graph: inner_graph,
         node_removed: false,
+        multigraph: true,
     };
     Ok(graph)
 }

--- a/src/union.rs
+++ b/src/union.rs
@@ -48,6 +48,7 @@ pub fn digraph_union(
         cycle_state: algo::DfsSpace::default(),
         check_cycle: false,
         node_removed: false,
+        multigraph: true,
     };
     let mut node_map = HashMap::with_capacity(second.node_count());
     let mut edge_map = HashSet::with_capacity(second.edge_count());

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -264,7 +264,7 @@ class TestEdges(unittest.TestCase):
                      (0, 3, 'e')]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-    
+
     def test_add_edges_from_parallel_edges(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from([0, 1])
@@ -297,8 +297,8 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph.add_edge(node_a, node_b, "Edgy")
         graph.add_edge(node_a, node_b, 'b')
         res = graph.get_all_edge_data(node_a, node_b)
-        self.assertNotIn('b', res)
-        self.assertIn('Edgy', res)
+        self.assertIn('b', res)
+        self.assertNotIn('Edgy', res)
 
     def test_no_edge(self):
         graph = retworkx.PyGraph(False)
@@ -348,7 +348,7 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         node_b = graph.add_node('a')
         graph.add_edge(node_a, node_b, 'a')
         graph.add_edge(node_a, node_b, 'b')
-        self.assertEqual(['a'], graph.edges())
+        self.assertEqual(['b'], graph.edges())
 
     def test_remove_no_edge(self):
         graph = retworkx.PyGraph(False)
@@ -439,12 +439,12 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         graph.add_nodes_from([0, 1])
         res = graph.add_edges_from([(0, 1, False), (1, 0, True)])
-        self.assertEqual([0], res)
-        self.assertEqual([False], graph.edges())
+        self.assertEqual([0, 0], res)
+        self.assertEqual([True], graph.edges())
 
     def test_add_edges_from_no_data_parallel_edges(self):
         graph = retworkx.PyGraph(False)
         graph.add_nodes_from([0, 1])
         res = graph.add_edges_from_no_data([(0, 1), (1, 0)])
-        self.assertEqual([0], res)
+        self.assertEqual([0, 0], res)
         self.assertEqual([None], graph.edges())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -204,6 +204,15 @@ class TestEdges(unittest.TestCase):
         self.assertEqual(len(graph), 4)
         self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
 
+    def test_extend_from_weighted_edge_list_edges_exist(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e'), (0, 1, 'not_a')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e', 'not_a'], graph.edges())
+
     def test_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
@@ -258,6 +267,15 @@ class TestEdges(unittest.TestCase):
         self.assertEqual(3, graph.degree(2))
         self.assertEqual(2, graph.degree(3))
 
+    def test_extend_from_edge_list_existing_edge(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3), (0, 1)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 6, graph.edges())
+
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyGraph()
         edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
@@ -279,8 +297,16 @@ class TestEdges(unittest.TestCase):
         self.assertEqual([0, 1], res)
         self.assertEqual([None, None], graph.edges())
 
+    def test_multigraph_attr(self):
+        graph = retworkx.PyGraph()
+        self.assertTrue(graph.multigraph)
+
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
+
+    def test_multigraph_attr(self):
+        graph = retworkx.PyGraph(multigraph=False)
+        self.assertFalse(graph.multigraph)
 
     def test_get_edge_data(self):
         graph = retworkx.PyGraph(False)
@@ -448,3 +474,69 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         res = graph.add_edges_from_no_data([(0, 1), (1, 0)])
         self.assertEqual([0, 0], res)
         self.assertEqual([None], graph.edges())
+
+    def test_extend_from_weighted_edge_list_empty(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([])
+        self.assertEqual(0, len(graph))
+
+    def test_extend_from_weighted_edge_list_nodes_exist(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+
+    def test_extend_from_weighted_edge_list_edges_exist(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e'), (0, 1, 'not_a')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['not_a', 'b', 'c', 'd', 'e'], graph.edges())
+
+    def test_extend_from_edge_list(self):
+        graph = retworkx.PyGraph(False)
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 5, graph.edges())
+
+    def test_extend_from_edge_list_empty(self):
+        graph = retworkx.PyGraph(False)
+        graph.extend_from_edge_list([])
+        self.assertEqual(0, len(graph))
+
+    def test_extend_from_edge_list_nodes_exist(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 5, graph.edges())
+        self.assertEqual(3, graph.degree(0))
+        self.assertEqual(2, graph.degree(1))
+        self.assertEqual(3, graph.degree(2))
+        self.assertEqual(2, graph.degree(3))
+
+    def test_extend_from_edge_list_existing_edge(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3), (0, 1)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 5, graph.edges())
+
+    def test_extend_from_weighted_edge_list(self):
+        graph = retworkx.PyGraph(False)
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -190,6 +190,20 @@ class TestEdges(unittest.TestCase):
         res = graph.add_edges_from_no_data([])
         self.assertEqual([], res)
 
+    def test_extend_from_weighted_edge_list_empty(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([])
+        self.assertEqual(0, len(graph))
+
+    def test_extend_from_weighted_edge_list_nodes_exist(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+
     def test_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
@@ -250,26 +264,159 @@ class TestEdges(unittest.TestCase):
                      (0, 3, 'e')]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
-        self.assertEqual(3, graph.degree(0))
-        self.assertEqual(2, graph.degree(1))
-        self.assertEqual(3, graph.degree(2))
-        self.assertEqual(2, graph.degree(3))
 
-    def test_extend_from_weighted_edge_list_empty(self):
-        graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([])
-        self.assertEqual(0, len(graph))
 
-    def test_extend_from_weighted_edge_list_nodes_exist(self):
+class TestEdgesMultigraphFalse(unittest.TestCase):
+
+    def test_get_edge_data(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        res = graph.get_edge_data(node_a, node_b)
+        self.assertEqual("Edgy", res)
+
+    def test_get_all_edge_data(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        graph.add_edge(node_a, node_b, 'b')
+        res = graph.get_all_edge_data(node_a, node_b)
+        self.assertNotIn('b', res)
+        self.assertIn('Edgy', res)
+
+    def test_no_edge(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
+                          node_a, node_b)
+
+    def test_no_edge_get_all_edge_data(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
+                          node_a, node_b)
+
+    def test_has_edge(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, {})
+        self.assertTrue(graph.has_edge(node_a, node_b))
+        self.assertTrue(graph.has_edge(node_b, node_a))
+
+    def test_has_edge_no_edge(self):
         graph = retworkx.PyGraph()
-        graph.add_nodes_from(list(range(4)))
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertFalse(graph.has_edge(node_a, node_b))
+
+    def test_edges(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, "Super edgy")
+        self.assertEqual(["Edgy", "Super edgy"], graph.edges())
+
+    def test_edges_empty(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_node('a')
+        self.assertEqual([], graph.edges())
+
+    def test_add_duplicates(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('a')
+        graph.add_edge(node_a, node_b, 'a')
+        graph.add_edge(node_a, node_b, 'b')
+        self.assertEqual(['a'], graph.edges())
+
+    def test_remove_no_edge(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
+                          node_a, node_b)
+
+    def test_remove_edge_single(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge(node_a, node_b)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_multiple(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_b, 'super_edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edge_from_index(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edge_no_edge(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_node('a')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_degree(self):
+        graph = retworkx.PyGraph(False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, "Super edgy")
+        self.assertEqual(2, graph.degree(node_b))
+
+    def test_add_edge_from(self):
+        graph = retworkx.PyGraph(False)
+        nodes = list(range(4))
+        graph.add_nodes_from(nodes)
         edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
                      (0, 3, 'e')]
-        graph.extend_from_weighted_edge_list(edge_list)
-        self.assertEqual(len(graph), 4)
+        res = graph.add_edges_from(edge_list)
+        self.assertEqual(len(res), 5)
         self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
         self.assertEqual(3, graph.degree(0))
         self.assertEqual(2, graph.degree(1))
         self.assertEqual(3, graph.degree(2))
         self.assertEqual(2, graph.degree(3))
+
+    def test_add_edge_from_empty(self):
+        graph = retworkx.PyGraph(False)
+        res = graph.add_edges_from([])
+        self.assertEqual([], res)
+
+    def test_add_edge_from_no_data(self):
+        graph = retworkx.PyGraph(False)
+        nodes = list(range(4))
+        graph.add_nodes_from(nodes)
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        res = graph.add_edges_from_no_data(edge_list)
+        self.assertEqual(len(res), 5)
+        self.assertEqual([None, None, None, None, None], graph.edges())
+        self.assertEqual(3, graph.degree(0))
+        self.assertEqual(2, graph.degree(1))
+        self.assertEqual(3, graph.degree(2))
+        self.assertEqual(2, graph.degree(3))
+
+    def test_add_edge_from_empty_no_data(self):
+        graph = retworkx.PyGraph(False)
+        res = graph.add_edges_from_no_data([])
+        self.assertEqual([], res)

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -264,6 +264,20 @@ class TestEdges(unittest.TestCase):
                      (0, 3, 'e')]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
+    
+    def test_add_edges_from_parallel_edges(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from([(0, 1, False), (1, 0, True)])
+        self.assertEqual([0, 1], res)
+        self.assertEqual([False, True], graph.edges())
+
+    def test_add_edges_from_no_data_parallel_edges(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from_no_data([(0, 1), (1, 0)])
+        self.assertEqual([0, 1], res)
+        self.assertEqual([None, None], graph.edges())
 
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
@@ -420,3 +434,17 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         res = graph.add_edges_from_no_data([])
         self.assertEqual([], res)
+
+    def test_add_edges_from_parallel_edges(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from([(0, 1, False), (1, 0, True)])
+        self.assertEqual([0], res)
+        self.assertEqual([False], graph.edges())
+
+    def test_add_edges_from_no_data_parallel_edges(self):
+        graph = retworkx.PyGraph(False)
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from_no_data([(0, 1), (1, 0)])
+        self.assertEqual([0], res)
+        self.assertEqual([None], graph.edges())

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -525,3 +525,192 @@ class TestEdges(unittest.TestCase):
         node_b = graph.add_node(None)
         graph.insert_node_on_out_edges_multiple(node_b, [node_a])
         self.assertEqual([], graph.edge_list())
+
+
+class TestEdgesMultigraphFalse(unittest.TestCase):
+
+    def test_multigraph_attr(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        self.assertFalse(graph.multigraph)
+
+    def test_get_edge_data(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        res = graph.get_edge_data(node_a, node_b)
+        self.assertEqual("Edgy", res)
+
+    def test_get_all_edge_data(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        graph.add_edge(node_a, node_b, 'b')
+        res = graph.get_all_edge_data(node_a, node_b)
+        self.assertIn('b', res)
+        self.assertNotIn('Edgy', res)
+
+    def test_no_edge(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
+                          node_a, node_b)
+
+    def test_no_edge_get_all_edge_data(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
+                          node_a, node_b)
+
+    def test_has_edge(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, {})
+        self.assertTrue(graph.has_edge(node_a, node_b))
+
+    def test_has_edge_no_edge(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertFalse(graph.has_edge(node_a, node_b))
+
+    def test_edges(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, "Edgy")
+        node_c = graph.add_node('c')
+        graph.add_edge(node_b, node_c, "Super edgy")
+        self.assertEqual(["Edgy", "Super edgy"], graph.edges())
+
+    def test_edges_empty(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_node('a')
+        self.assertEqual([], graph.edges())
+
+    def test_add_duplicates(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'a')
+        graph.add_edge(node_a, node_b, 'b')
+        self.assertEqual(['b'], graph.edges())
+
+    def test_remove_no_edge(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
+                          node_a, node_b)
+
+    def test_remove_edge_single(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge(node_a, node_b)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_multiple(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_b, 'super_edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edge_from_index(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edge_no_edge(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_node('a')
+        graph.remove_edge_from_index(0)
+        self.assertEqual([], graph.edges())
+
+    def test_add_edge_from_empty(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        res = graph.add_edges_from([])
+        self.assertEqual([], res)
+
+    def test_add_edge_from_empty_no_data(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        res = graph.add_edges_from_no_data([])
+        self.assertEqual([], res)
+
+    def test_add_edges_from_parallel_edges(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from([(0, 1, False), (0, 1, True)])
+        self.assertEqual([0, 0], res)
+        self.assertEqual([True], graph.edges())
+
+    def test_add_edges_from_no_data_parallel_edges(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_nodes_from([0, 1])
+        res = graph.add_edges_from_no_data([(0, 1), (0, 1)])
+        self.assertEqual([0, 0], res)
+        self.assertEqual([None], graph.edges())
+
+    def test_extend_from_weighted_edge_list_empty(self):
+        graph = retworkx.PyDiGraph()
+        graph.extend_from_weighted_edge_list([])
+        self.assertEqual(0, len(graph))
+
+    def test_extend_from_weighted_edge_list_nodes_exist(self):
+        graph = retworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+
+    def test_extend_from_weighted_edge_list_edges_exist(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e'), (0, 1, 'not_a')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['not_a', 'b', 'c', 'd', 'e'], graph.edges())
+
+    def test_extend_from_edge_list(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 5, graph.edges())
+
+    def test_extend_from_edge_list_empty(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.extend_from_edge_list([])
+        self.assertEqual(0, len(graph))
+
+    def test_extend_from_edge_list_existing_edge(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        graph.add_nodes_from(list(range(4)))
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
+                     (0, 3), (0, 1)]
+        graph.extend_from_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual([None] * 5, graph.edges())
+
+    def test_extend_from_weighted_edge_list(self):
+        graph = retworkx.PyDiGraph(multigraph=False)
+        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
+                     (0, 3, 'e')]
+        graph.extend_from_weighted_edge_list(edge_list)
+        self.assertEqual(len(graph), 4)
+        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())


### PR DESCRIPTION
This commit adds a new kwarg, multigraph, to the PyGraph and PyDiGraph
constructors. When this is set to `False` the created graph object will not be a
multigraph and only one edge will exist between nodes. If a parallel
edge is attempted to be added it will be ignored since the edge already
exists.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
