### PR TITLE
Add job testing the minimum supported rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "retworkx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "fixedbitset",
  "hashbrown",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,6 +89,33 @@ stages:
   - stage: "Python_37_Tests"
     condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
     jobs:
+    - job: 'MSRV'
+      pool: {vmImage: 'ubuntu-latest'}
+      condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+      strategy:
+        matrix:
+          Python37:
+            python.version: '3.7'
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Pyhon $(python.version)'
+        - bash: rustup default 1.39.0
+          displayName: 'Install Rust'
+        - bash: python -m pip install --upgrade pip setuptools virtualenv setuptools-rust
+          displayName: 'Install dependencies'
+        - bash: |
+            pip install .
+          displayName: 'Build retworkx'
+        - bash: |
+            set -e
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
+            cd tests
+            python -m unittest discover .
+          displayName: 'Run tests'
+
     - job: 'MacOS_Catalina_Tests'
       pool: {vmImage: 'macOS-10.15'}
       condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))


### PR DESCRIPTION
We document that the minimum rust version we can compile with is 1.39.0.
However, we only ever test with the latest stable release (and nightly in
the case of the coverage job) so it's not clear when/if we introduce a
dependency on a newer version of the rust compiler to build retworkx.
This commit adds a new minimum supported rust version job that builds
retworkx with the MSRV 1.39.0 and runs tests on it that way we can catch
when something changes.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
