### PR TITLE
Use HashSet from hashbrown instead of std::collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -131,6 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 dependencies = [
  "ahash",
+ "rayon",
 ]
 
 [[package]]
@@ -211,9 +212,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "lock_api"
@@ -383,9 +384,9 @@ checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["cdylib"]
 [dependencies]
 petgraph = "0.5.1"
 fixedbitset = "0.2.0"
-hashbrown = "0.9"
 numpy = "0.11.0"
 ndarray = "0.13.0"
 rand = "0.7"
@@ -28,3 +27,7 @@ rayon = "1.4"
 [dependencies.pyo3]
 version = "0.11.1"
 features = ["extension-module"]
+
+[dependencies.hashbrown]
+version = "0.9"
+features = ["rayon"]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -10,12 +10,12 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::ops::{Index, IndexMut};
 use std::str;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 
 use pyo3::class::PyMappingProtocol;
 use pyo3::exceptions::IndexError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,14 @@ mod generators;
 mod graph;
 
 use std::cmp::{Ordering, Reverse};
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::BinaryHeap;
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 
 use pyo3::create_exception;
 use pyo3::exceptions::{Exception, ValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PySet};
 use pyo3::wrap_pyfunction;
 use pyo3::wrap_pymodule;
 use pyo3::Python;
@@ -305,7 +305,7 @@ fn bfs_successors(
 /// :rtype: list
 #[pyfunction]
 #[text_signature = "(graph, node, /)"]
-fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
+fn ancestors(py: Python, graph: &digraph::PyDiGraph, node: usize) -> PyObject {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
@@ -315,7 +315,13 @@ fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    out_set
+    let set = PySet::empty(py).expect("Failed to construct empty set");
+    {
+        for val in out_set {
+            set.add(val).expect("Failed to add to set");
+        }
+    }
+    set.into()
 }
 
 /// Return the descendants of a node in a graph.
@@ -332,7 +338,11 @@ fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 /// :rtype: list
 #[pyfunction]
 #[text_signature = "(graph, node, /)"]
-fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
+fn descendants(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    node: usize,
+) -> PyObject {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
@@ -341,7 +351,13 @@ fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    out_set
+    let set = PySet::empty(py).expect("Failed to construct empty set");
+    {
+        for val in out_set {
+            set.add(val).expect("Failed to add to set");
+        }
+    }
+    set.into()
 }
 
 /// Get the lexicographical topological sorted nodes from the provided DAG


### PR DESCRIPTION
This commit switches the HashSet usage in retworkx to use hashbrown's
version of HashSet instead of the version in std::collections. This
provides a performance boost primarily from the use of the AHash default
hash algorithm. It also opens up potential future performance
improvements with hashbrown's rayon support to use parallel iterators.

At the same time since we're already listing rayon as a dependency
in #112 this adds the rayon feature to hashbrown in the cargo.toml
to expose the ParallelIterator traits for hashbrown's HashMap and
HashSet types. While this isn't being used yet it's potentially
useful in the future for #86.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
