### PR TITLE
Quote label strings in to_dot() output

### DIFF
--- a/src/dot_utils.rs
+++ b/src/dot_utils.rs
@@ -90,7 +90,13 @@ fn attr_map_to_string<'a>(
 
     let attr_string = attrs
         .iter()
-        .map(|(key, value)| format!("{}={}", key, value))
+        .map(|(key, value)| {
+            if key == "label" {
+                format!("{}=\"{}\"", key, value)
+            } else {
+                format!("{}={}", key, value)
+            }
+        })
         .collect::<Vec<String>>()
         .join(", ");
     Ok(format!("[{}]", attr_string))

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -31,9 +31,9 @@ class TestDot(unittest.TestCase):
                         'label': "a", 'style': 'filled'})
         graph.add_edge(0, 1, dict(label='1', name='1'))
         expected = (
-            "graph {\n0 [color=black, fillcolor=green, label=a, style=filled"
-            "];\n1 [color=black, fillcolor=red, label=a, style=filled];"
-            "\n0 -- 1 [label=1, name=1];\n}\n")
+            'graph {\n0 [color=black, fillcolor=green, label="a", style=filled'
+            '];\n1 [color=black, fillcolor=red, label="a", style=filled];'
+            '\n0 -- 1 [label="1", name=1];\n}\n')
         res = graph.to_dot(lambda node: node, lambda edge: edge)
         self.assertEqual(expected, res)
 
@@ -45,9 +45,9 @@ class TestDot(unittest.TestCase):
                         'label': "a", 'style': 'filled'})
         graph.add_edge(0, 1, dict(label='1', name='1'))
         expected = (
-            "digraph {\n0 [color=black, fillcolor=green, label=a, style=filled"
-            "];\n1 [color=black, fillcolor=red, label=a, style=filled];"
-            "\n0 -> 1 [label=1, name=1];\n}\n")
+            'digraph {\n0 [color=black, fillcolor=green, label="a", '
+            'style=filled];\n1 [color=black, fillcolor=red, label="a", '
+            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n')
         res = graph.to_dot(lambda node: node, lambda edge: edge)
         self.assertEqual(expected, res)
 
@@ -59,9 +59,9 @@ class TestDot(unittest.TestCase):
                         'label': "a", 'style': 'filled'})
         graph.add_edge(0, 1, dict(label='1', name='1'))
         expected = (
-            "graph {\n0 [color=black, fillcolor=green, label=a, style=filled"
-            "];\n1 [color=black, fillcolor=red, label=a, style=filled];"
-            "\n0 -- 1 [label=1, name=1];\n}\n")
+            'graph {\n0 [color=black, fillcolor=green, label="a", '
+            'style=filled];\n1 [color=black, fillcolor=red, label="a", '
+            'style=filled];\n0 -- 1 [label="1", name=1];\n}\n')
         res = graph.to_dot(lambda node: node, lambda edge: edge,
                            filename=self.path)
         self.addCleanup(os.remove, self.path)
@@ -78,9 +78,9 @@ class TestDot(unittest.TestCase):
                         'label': "a", 'style': 'filled'})
         graph.add_edge(0, 1, dict(label='1', name='1'))
         expected = (
-            "digraph {\n0 [color=black, fillcolor=green, label=a, style=filled"
-            "];\n1 [color=black, fillcolor=red, label=a, style=filled];"
-            "\n0 -> 1 [label=1, name=1];\n}\n")
+            'digraph {\n0 [color=black, fillcolor=green, label="a", '
+            'style=filled];\n1 [color=black, fillcolor=red, label="a", '
+            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n')
         res = graph.to_dot(lambda node: node, lambda edge: edge,
                            filename=self.path)
         self.addCleanup(os.remove, self.path)


### PR DESCRIPTION
This commit adds quotes around label attributes in the output from the
to_dot() methods. Previously the string was just passed raw to the
output, but this would cause issues in graphviz when trying to parse the
dot file if there were spaces or other restricted characters in the
string (eg having a label like '1 -> 2'. To fix this this commit puts a
quotes around a label string if its present to handle this case.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
