### PR TITLE
Add section to README about building in develop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ make to the rust code will not be reflected live in your python environment,
 you'll need to recompile retworkx by rerunning `pip install` to have any
 changes reflected in your python environment.
 
+### Develop Mode
+
+If you'd like to build retworkx in debug mode and use an interactive debugger
+while working on a change you can use `python setup.py develop` to build
+and install retworkx in develop mode. This will build retworkx without
+optimizations and include debuginfo which can be handy for debugging. Do note
+this installing retworkx this way will be significantly slower then using
+`pip install` and should only be used for debugging/development.
+
+It's worth noting that `pip install -e` does not work, it will link the python
+packaging shim to your python environment but not build the retworkx binary. If
+you want to build retworkx in debug mode you have to use
+`python setup.py develop`.
+
 ## Using retworkx
 
 Once you have retworkx installed you can use it by importing retworkx.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ If you'd like to build retworkx in debug mode and use an interactive debugger
 while working on a change you can use `python setup.py develop` to build
 and install retworkx in develop mode. This will build retworkx without
 optimizations and include debuginfo which can be handy for debugging. Do note
-this installing retworkx this way will be significantly slower then using
+that installing retworkx this way will be significantly slower then using
 `pip install` and should only be used for debugging/development.
 
-It's worth noting that `pip install -e` does not work, it will link the python
+It's worth noting that `pip install -e` does not work, as it will link the python
 packaging shim to your python environment but not build the retworkx binary. If
 you want to build retworkx in debug mode you have to use
 `python setup.py develop`.


### PR DESCRIPTION
This commit adds a section to the README about building retworkx from
source in develop mode. This can be useful while developing to enable
using an interactive debugger because it builds without optimizations
and including the debuginfo (for example its how we build retworkx to
collect coverage info in CI), However, because pip install -e doesn't
work having a description of how to build and install in develop mode
is useful to include in the README.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
