### PR TITLE
Add license to python package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     long_description_content_type='text/markdown',
     author="Matthew Treinish",
     author_email="mtreinish@kortar.org",
+    license="Apache 2.0",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The license was not set for the python package metadata directly. We
listed the trove classifier for the project being apache licensed but
without specifying the license field certain parsers don't know what the
library is licensed under. This commit fixes the oversight and sets the
license field to apache 2.0.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
