### PR TITLE
Handle invalid index in first_layer arg for layers() func

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,9 +624,9 @@ fn layers(
         let node_data = match dag.graph.node_weight(*layer_node) {
             Some(data) => data,
             None => {
-                return Err(InvalidNode::py_err(
-                    format!("An index input in 'first_layer' {} is not a valid node index in the graph",
-                            layer_node.index()),
+                return Err(InvalidNode::py_err(format!(
+                    "An index input in 'first_layer' {} is not a valid node index in the graph",
+                    layer_node.index()),
                 ))
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,8 @@ fn floyd_warshall(py: Python, dag: &digraph::PyDiGraph) -> PyResult<PyObject> {
 ///
 /// :returns: A list of layers, each layer is a list of node data
 /// :rtype: list
+///
+/// :raises InvalidNode: If a node index in ``first_layer`` is not in the graph
 #[pyfunction]
 #[text_signature = "(dag, first_layer, /)"]
 fn layers(
@@ -619,7 +621,16 @@ fn layers(
 
     let mut layer_node_data: Vec<&PyObject> = Vec::new();
     for layer_node in &cur_layer {
-        layer_node_data.push(&dag[*layer_node]);
+        let node_data = match dag.graph.node_weight(*layer_node) {
+            Some(data) => data,
+            None => {
+                return Err(InvalidNode::py_err(
+                    format!("An index input in 'first_layer' {} is not a valid node index in the graph",
+                            layer_node.index()),
+                ))
+            }
+        };
+        layer_node_data.push(node_data);
     }
     output.push(layer_node_data);
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -57,3 +57,8 @@ class TestLayers(unittest.TestCase):
             ['measure', 'measure'],
             ['cr[1]', 'qr[1]', 'cr[0]', 'qr[0]']]
         self.assertEqual(expected, res)
+
+    def test_first_layer_invalid_node(self):
+        dag = retworkx.PyDAG()
+        with self.assertRaises(retworkx.InvalidNode):
+            retworkx.layers(dag, [42])


### PR DESCRIPTION
This commit handles an error case in the retworkx.layers() algorithm
function when an invalid node index is part of the list passed in for
the 'first_layer' arg. Previously, this would result in a PanicException
being raised by PyO3 and include a backtrace from rust, this is because
the layers function was unconditionally pulling the node index from the
inner graph without checking whether it was a valid index or not. This
commit fixes this behavior and checks the data in the graph for that
index. If there is no data we raise an appropriate exception with an
exception message including the bad node index.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
