### PR TITLE
Add option to digraph_floyd_warshall to treat input as undirected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -825,7 +825,7 @@ fn graph_floyd_warshall_numpy(
 ///
 ///     to cast the edge object as a float as the weight.
 /// :param as_undirected: If set to true each directed edge will be treated as
-///     bidirection/undirected.
+///     bidirectional/undirected.
 ///
 /// :returns: A matrix of shortest path distances between nodes. If there is no
 ///     path between two nodes then the corresponding matrix entry will be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,17 +724,20 @@ fn graph_floyd_warshall_numpy(
 ///         graph_floyd_warshall_numpy(graph, weight_fn: lambda x: float(x))
 ///
 ///     to cast the edge object as a float as the weight.
+/// :param as_undirected: If set to true each directed edge will be treated as
+///     bidirection/undirected.
 ///
 /// :returns: A matrix of shortest path distances between nodes. If there is no
 ///     path between two nodes then the corresponding matrix entry will be
 ///     ``np.inf``.
 /// :rtype: numpy.ndarray
-#[pyfunction]
-#[text_signature = "(graph, weight_fn, /)"]
+#[pyfunction(as_undirected = "false")]
+#[text_signature = "(graph, weight_fn, /, as_undirected=False)"]
 fn digraph_floyd_warshall_numpy(
     py: Python,
     graph: &digraph::PyDiGraph,
     weight_fn: PyObject,
+    as_undirected: bool,
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
 
@@ -750,6 +753,9 @@ fn digraph_floyd_warshall_numpy(
     for (i, j, weight) in get_edge_iter_with_weights(graph) {
         let edge_weight = weight_callable(&weight)?;
         mat[[i, j]] = mat[[i, j]].min(edge_weight);
+        if as_undirected {
+            mat[[j, i]] = mat[[j, i]].min(edge_weight);
+        }
     }
     // 0 out the diagonal
     for x in mat.diag_mut() {

--- a/tests/test_floyd_warshall.py
+++ b/tests/test_floyd_warshall.py
@@ -127,6 +127,22 @@ class TestFloydWarshall(unittest.TestCase):
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 3)
 
+    def test_directed_floyd_warshall_numpy_cycle_as_undirected(self):
+        graph = retworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(7)))
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: 1,
+                                                     as_undirected=True)
+        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
+                                [1., 0., 1., 2., 3., 3., 2.],
+                                [2., 1., 0., 1., 2., 3., 3.],
+                                [3., 2., 1., 0., 1., 2., 3.],
+                                [3., 3., 2., 1., 0., 1., 2.],
+                                [2., 3., 3., 2., 1., 0., 1.],
+                                [1., 2., 3., 3., 2., 1., 0.]])
+        self.assertTrue(numpy.array_equal(dist, expected))
+
     def test_floyd_warshall_numpy_digraph_three_edges(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(6)))


### PR DESCRIPTION
This commit adds a new option to the digraph_floyd_warshall function to
treat the input directed graph as undirected. When set each edge in the
directed graph will be treated as bidirection/undirected for the
generated output distance matrix.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
