### PR TITLE
Use rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Qiskit/retworkx"
 keywords = ["python", "graph"]
+edition = "2018"
 
 [badges]
 travis-ci = {repository = "Qiskit/retworkx"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,6 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-extern crate fixedbitset;
-extern crate hashbrown;
-extern crate ndarray;
-extern crate numpy;
-extern crate petgraph;
-extern crate pyo3;
-extern crate rand;
-extern crate rand_pcg;
-extern crate rayon;
-
 mod astar;
 mod dag_isomorphism;
 mod digraph;
@@ -55,7 +45,7 @@ use rand::prelude::*;
 use rand_pcg::Pcg64;
 use rayon::prelude::*;
 
-use generators::PyInit_generators;
+use crate::generators::PyInit_generators;
 
 trait NodesRemoved {
     fn nodes_removed(&self) -> bool;
@@ -1642,12 +1632,4 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<graph::PyGraph>()?;
     m.add_wrapped(wrap_pymodule!(generators))?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
 }


### PR DESCRIPTION
Prior to this commit retworkx wasn't specifying an edition and was
implicitly using rust 2015. There wasn't any particular reason for this,
mainly just an ommision when the project was first created. This commit
updates the project to use the newer edition 2018 so we can get some
nice syntax features if needed.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
