### PR TITLE
Use contiguous C arrays instead of fortran layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
  "ahash",
  "rayon",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,7 +992,7 @@ fn digraph_adjacency_matrix(
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
-    let mut matrix = Array::<f64, _>::zeros((n, n));
+    let mut matrix = Array2::<f64>::zeros((n, n));
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;
@@ -1034,7 +1034,7 @@ fn graph_adjacency_matrix(
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
-    let mut matrix = Array::<f64, _>::zeros((n, n));
+    let mut matrix = Array2::<f64>::zeros((n, n));
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,7 +772,7 @@ fn graph_floyd_warshall_numpy(
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
     // Allocate empty matrix
-    let mut mat = Array2::<f64>::from_elem((n, n).f(), std::f64::INFINITY);
+    let mut mat = Array2::<f64>::from_elem((n, n), std::f64::INFINITY);
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;
@@ -839,7 +839,7 @@ fn digraph_floyd_warshall_numpy(
     let n = graph.node_count();
 
     // Allocate empty matrix
-    let mut mat = Array2::<f64>::from_elem((n, n).f(), std::f64::INFINITY);
+    let mut mat = Array2::<f64>::from_elem((n, n), std::f64::INFINITY);
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;
@@ -992,7 +992,7 @@ fn digraph_adjacency_matrix(
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
-    let mut matrix = Array::<f64, _>::zeros((n, n).f());
+    let mut matrix = Array::<f64, _>::zeros((n, n));
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;
@@ -1034,7 +1034,7 @@ fn graph_adjacency_matrix(
     weight_fn: PyObject,
 ) -> PyResult<PyObject> {
     let n = graph.node_count();
-    let mut matrix = Array::<f64, _>::zeros((n, n).f());
+    let mut matrix = Array::<f64, _>::zeros((n, n));
 
     let weight_callable = |a: &PyObject| -> PyResult<f64> {
         let res = weight_fn.call1(py, (a,))?;


### PR DESCRIPTION
This commit moves away from using a column-major fortran layout for the
ndarrays generated in library functions that return a numpy array. A
common use case for these arrays is to pass it from numpy (which is
how they're returned) to another C extension. While numpy can natively
handle all sorts of memory layouts for arrays, not everything accessing
the array in memory can. To make this easier and to avoid copying
in end user programs this removes the `.f()` used to tell ndarray to use
a fortran layout when allocating the array. There wasn't ever really a
reason for this besides sloppy copy and paste when we started using
ndarray with rust-numpy.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
