### PR TITLE
Improve graph class docs

### DIFF
--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -23,9 +23,12 @@ class PyDAG(PyDiGraph):
 
     The PyDAG class is used to create a directed graph. It can be a
     multigraph (have multiple edges between nodes). Each node and edge
-    (although rarely used for edges) is indexed by an integer id. Additionally
+    (although rarely used for edges) is indexed by an integer id. Additionally,
     each node and edge contains an arbitrary Python object as a weight/data
-    payload. You can use this integer for access the data payload for example:
+    payload. 
+    
+    You can use the index for access to the data payload as in the
+    following example:
 
     .. jupyter-execute::
 
@@ -37,7 +40,7 @@ class PyDAG(PyDiGraph):
         print("Node Index: %s" % node_index)
         print(graph[node_index])
 
-    The PyDAG implements the Python mapping protocol for nodes so in
+    The PyDAG class implements the Python mapping protocol for nodes so in
     addition to access you can also update the data payload with:
 
     .. jupyter-execute::
@@ -53,9 +56,8 @@ class PyDAG(PyDiGraph):
 
     The PyDAG class has an option for real time cycle checking which can
     be used to ensure any edges added to the graph does not introduce a cycle.
-    By default the real time cycle checking is disabled for performance,
-    however you can opt-in to having the PyDAG class ensure that no cycles are
-    added by setting the ``check_cycle`` attribute to True.
+    By default the real time cycle checking feature is disabled for performance,
+    however you can enable it by setting the ``check_cycle`` attribute to True.
     For example::
 
         import retworkx
@@ -73,9 +75,8 @@ class PyDAG(PyDiGraph):
     :meth:`~PyDAG.add_edge`, :meth:`~PyDigraph.add_edges_from`,
     :meth:`~PyDAG.add_edges_from_no_data`,
     :meth:`~PyDAG.extend_from_edge_list`,  and
-    :meth:`~PyDAG.extend_from_weighted_edge_list` comes with an increasing
-    performance penalty as the size of the graph grows. If you're adding a node
-    and edge at the same time leveraging :meth:`PyDAG.add_child` or
-    :meth:`PyDAG.add_parent` will avoid this overhead.
+    :meth:`~PyDAG.extend_from_weighted_edge_list` comes with a performance penalty
+    that grows as the graph does.  If you're adding a node and edge at the same time,
+    leveraging :meth:`PyDAG.add_child` or :meth:`PyDAG.add_parent` will avoid this overhead.
     """
     pass

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -15,15 +15,48 @@ sys.modules['retworkx.generators'] = generators
 class PyDAG(PyDiGraph):
     """A class for creating direct acyclic graphs.
 
-    The PyDAG class is constructed using the Rust library
-    `petgraph <https://github.com/petgraph/petgraph/>`___ around the
-    ``StableGraph`` type. The limitations and quirks with this library and
-    type dictate how this operates. The biggest thing to be aware of when using
-    the PyDAG class is that an integer node and edge index is used for accessing
-    elements on the DAG, not the data/weight of nodes and edges. By default the
-    PyDAG realtime cycle checking is disabled for performance, however you can
-    opt-in to having the PyDAG class ensure that no cycles are added by setting
-    the ``check_cycle`` attribute to True. For example::
+    PyDAG is just an alias of the PyDiGraph class and behaves identically to
+    the :class:`~retworkx.PyDiGraph` class and can be used interchangably
+    with ``PyDiGraph``. It currently exists solely as a backwards
+    compatibility alias for users of retworkx from prior to the
+    0.4.0 release when there was no PyDiGraph class.
+
+    The PyDAG class is used to create a directed graph. It can be a
+    multigraph (have multiple edges between nodes). Each node and edge
+    (although rarely used for edges) is indexed by an integer id. Additionally
+    each node and edge contains an arbitrary Python object as a weight/data
+    payload. You can use this integer for access the data payload for example:
+
+    .. jupyter-execute::
+
+        import retworkx
+
+        graph = retworkx.PyDAG()
+        data_payload = "An arbitrary Python object"
+        node_index = graph.add_node(data_payload)
+        print("Node Index: %s" % node_index)
+        print(graph[node_index])
+
+    The PyDAG implements the Python mapping protocol for nodes so in
+    addition to access you can also update the data payload with:
+
+    .. jupyter-execute::
+
+        import retworkx
+
+        graph = retworkx.PyDAG()
+        data_payload = "An arbitrary Python object"
+        node_index = graph.add_node(data_payload)
+        graph[node_index] = "New Payload"
+        print("Node Index: %s" % node_index)
+        print(graph[node_index])
+
+    The PyDAG class has an option for real time cycle checking which can
+    be used to ensure any edges added to the graph does not introduce a cycle.
+    By default the real time cycle checking is disabled for performance,
+    however you can opt-in to having the PyDAG class ensure that no cycles are
+    added by setting the ``check_cycle`` attribute to True.
+    For example::
 
         import retworkx
         dag = retworkx.PyDAG()
@@ -36,9 +69,13 @@ class PyDAG(PyDiGraph):
 
     With check_cycle set to true any calls to :meth:`PyDAG.add_edge` will
     ensure that no cycles are added, ensuring that the PyDAG class truly
-    represents a directed acyclic graph.
-
-    PyDAG is a subclass of the PyDiGraph class and behaves identically to
-    the :class:`~retworkx.PyDiGraph` class.
+    represents a directed acyclic graph. Do note that this cycle checking on
+    :meth:`~PyDAG.add_edge`, :meth:`~PyDigraph.add_edges_from`,
+    :meth:`~PyDAG.add_edges_from_no_data`,
+    :meth:`~PyDAG.extend_from_edge_list`,  and
+    :meth:`~PyDAG.extend_from_weighted_edge_list` comes with an increasing
+    performance penalty as the size of the graph grows. If you're adding a node
+    and edge at the same time leveraging :meth:`PyDAG.add_child` or
+    :meth:`PyDAG.add_parent` will avoid this overhead.
     """
     pass

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -25,8 +25,8 @@ class PyDAG(PyDiGraph):
     multigraph (have multiple edges between nodes). Each node and edge
     (although rarely used for edges) is indexed by an integer id. Additionally,
     each node and edge contains an arbitrary Python object as a weight/data
-    payload. 
-    
+    payload.
+
     You can use the index for access to the data payload as in the
     following example:
 
@@ -56,9 +56,9 @@ class PyDAG(PyDiGraph):
 
     The PyDAG class has an option for real time cycle checking which can
     be used to ensure any edges added to the graph does not introduce a cycle.
-    By default the real time cycle checking feature is disabled for performance,
-    however you can enable it by setting the ``check_cycle`` attribute to True.
-    For example::
+    By default the real time cycle checking feature is disabled for
+    performance, however you can enable it by setting the ``check_cycle``
+    attribute to True. For example::
 
         import retworkx
         dag = retworkx.PyDAG()
@@ -75,8 +75,9 @@ class PyDAG(PyDiGraph):
     :meth:`~PyDAG.add_edge`, :meth:`~PyDigraph.add_edges_from`,
     :meth:`~PyDAG.add_edges_from_no_data`,
     :meth:`~PyDAG.extend_from_edge_list`,  and
-    :meth:`~PyDAG.extend_from_weighted_edge_list` comes with a performance penalty
-    that grows as the graph does.  If you're adding a node and edge at the same time,
-    leveraging :meth:`PyDAG.add_child` or :meth:`PyDAG.add_parent` will avoid this overhead.
+    :meth:`~PyDAG.extend_from_weighted_edge_list` comes with a performance
+    penalty that grows as the graph does.  If you're adding a node and edge at
+    the same time, leveraging :meth:`PyDAG.add_child` or
+    :meth:`PyDAG.add_parent` will avoid this overhead.
     """
     pass

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -49,7 +49,8 @@ use super::{
 /// multigraph (have multiple edges between nodes). Each node and edge
 /// (although rarely used for edges) is indexed by an integer id. Additionally
 /// each node and edge contains an arbitrary Python object as a weight/data
-/// payload. You can use this integer for access the data payload for example:
+/// payload. You can use the index for access to the data payload as in the
+/// following example:
 ///
 /// .. jupyter-execute::
 ///
@@ -77,9 +78,8 @@ use super::{
 ///
 /// The PyDiGraph class has an option for real time cycle checking which can
 /// be used to ensure any edges added to the graph does not introduce a cycle.
-/// By default the real time cycle checking is disabled for performance,
-/// however you can opt-in to having the PyDiGraph class ensure
-/// that no cycles are added by setting the ``check_cycle`` attribute to True.
+/// By default the real time cycle checking feature is disabled for performance,
+/// however you can enable it by setting the ``check_cycle`` attribute to True.
 /// For example::
 ///
 ///     import retworkx
@@ -97,10 +97,10 @@ use super::{
 /// :meth:`~PyDiGraph.add_edge`, :meth:`~PyDiGraph.add_edges_from`,
 /// :meth:`~PyDiGraph.add_edges_from_no_data`,
 /// :meth:`~PyDiGraph.extend_from_edge_list`,  and
-/// :meth:`~PyDiGraph.extend_from_weighted_edge_list` comes with an increasing
-/// performance penalty as the size of the graph grows. If you're adding a node
-/// and edge at the same time leveraging :meth:`PyDiGraph.add_child` or
-/// :meth:`PyDiGraph.add_parent` will avoid this overhead.
+/// :meth:`~PyDiGraph.extend_from_weighted_edge_list` comes with a performance
+/// penalty that grows as the graph does. If you're adding a node and edge at the 
+/// same time leveraging :meth:`PyDiGraph.add_child` or :meth:`PyDiGraph.add_parent` 
+/// will avoid this overhead.
 #[pyclass(module = "retworkx", subclass)]
 #[text_signature = "(/, check_cycle=False)"]
 pub struct PyDiGraph {

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -45,15 +45,42 @@ use super::{
 
 /// A class for creating directed graphs
 ///
-/// The PyDigraph class is constructed using the Rust library
-/// `petgraph <https://github.com/petgraph/petgraph>`__ around the
-/// ``StableGraph`` type. The limitations and quirks with this library and
-/// type dictate how this operates. The biggest thing to be aware of when using
-/// the PyDiGraph class is that an integer node and edge index is used for
-/// accessing elements on the graph, not the data/weight of nodes and edges. By
-/// default the PyDiGraph realtime cycle checking is disabled for performance,
-/// however you can opt-in to having the PyDiGraph class ensure that no cycles
-/// are added by setting the ``check_cycle`` attribute to True. For example::
+/// The PyDiGraph class is used to create a directed graph. It can be a
+/// multigraph (have multiple edges between nodes). Each node and edge
+/// (although rarely used for edges) is indexed by an integer id. Additionally
+/// each node and edge contains an arbitrary Python object as a weight/data
+/// payload. You can use this integer for access the data payload for example:
+///
+/// .. jupyter-execute::
+///
+///     import retworkx
+///
+///     graph = retworkx.PyDiGraph()
+///     data_payload = "An arbitrary Python object"
+///     node_index = graph.add_node(data_payload)
+///     print("Node Index: %s" % node_index)
+///     print(graph[node_index])
+///
+/// The PyDiGraph implements the Python mapping protocol for nodes so in
+/// addition to access you can also update the data payload with:
+///
+/// .. jupyter-execute::
+///
+///     import retworkx
+///
+///     graph = retworkx.PyDiGraph()
+///     data_payload = "An arbitrary Python object"
+///     node_index = graph.add_node(data_payload)
+///     graph[node_index] = "New Payload"
+///     print("Node Index: %s" % node_index)
+///     print(graph[node_index])
+///
+/// The PyDiGraph class has an option for real time cycle checking which can
+/// be used to ensure any edges added to the graph does not introduce a cycle.
+/// By default the real time cycle checking is disabled for performance,
+/// however you can opt-in to having the PyDiGraph class ensure
+/// that no cycles are added by setting the ``check_cycle`` attribute to True.
+/// For example::
 ///
 ///     import retworkx
 ///     dag = retworkx.PyDiGraph()
@@ -66,7 +93,14 @@ use super::{
 ///
 /// With check_cycle set to true any calls to :meth:`PyDiGraph.add_edge` will
 /// ensure that no cycles are added, ensuring that the PyDiGraph class truly
-/// represents a directed acyclic graph.
+/// represents a directed acyclic graph. Do note that this cycle checking on
+/// :meth:`~PyDiGraph.add_edge`, :meth:`~PyDiGraph.add_edges_from`,
+/// :meth:`~PyDiGraph.add_edges_from_no_data`,
+/// :meth:`~PyDiGraph.extend_from_edge_list`,  and
+/// :meth:`~PyDiGraph.extend_from_weighted_edge_list` comes with an increasing
+/// performance penalty as the size of the graph grows. If you're adding a node
+/// and edge at the same time leveraging :meth:`PyDiGraph.add_child` or
+/// :meth:`PyDiGraph.add_parent` will avoid this overhead.
 #[pyclass(module = "retworkx", subclass)]
 #[text_signature = "(/, check_cycle=False)"]
 pub struct PyDiGraph {

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -98,9 +98,9 @@ use super::{
 /// :meth:`~PyDiGraph.add_edges_from_no_data`,
 /// :meth:`~PyDiGraph.extend_from_edge_list`,  and
 /// :meth:`~PyDiGraph.extend_from_weighted_edge_list` comes with a performance
-/// penalty that grows as the graph does. If you're adding a node and edge at the 
-/// same time leveraging :meth:`PyDiGraph.add_child` or :meth:`PyDiGraph.add_parent` 
-/// will avoid this overhead.
+/// penalty that grows as the graph does. If you're adding a node and edge at
+/// the same time leveraging :meth:`PyDiGraph.add_child` or
+/// :meth:`PyDiGraph.add_parent` will avoid this overhead.
 #[pyclass(module = "retworkx", subclass)]
 #[text_signature = "(/, check_cycle=False)"]
 pub struct PyDiGraph {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -44,7 +44,8 @@ use petgraph::visit::{
 /// multigraph (have multiple edges between nodes). Each node and edge
 /// (although rarely used for edges) is indexed by an integer id. Additionally,
 /// each node and edge contains an arbitrary Python object as a weight/data
-/// payload. You can use this integer for access the data payload for example:
+/// payload. You can use the index for access to the data payload as in the
+/// following example:
 ///
 /// .. jupyter-execute::
 ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,15 +38,38 @@ use petgraph::visit::{
     Visitable,
 };
 
-/// A class for creating undirected graphs.
+/// A class for creating undirected graphs
 ///
-/// The PyGraph class is constructed using the Rust library
-/// `petgraph <https://github.com/petgraph/petgraph>`__ around the
-/// ``StableGraph`` type. The limitations and quirks with this library and
-/// type dictate how this operates. The biggest thing to be aware of when using
-/// The PyGraph class is that an integer node and edge index is used for
-/// Accessing elements on the graph, it doesn't support associative access via
-/// The data/weight of nodes and edges.
+/// The PyGraph class is used to create an undirected graph. It can be a
+/// multigraph (have multiple edges between nodes). Each node and edge
+/// (although rarely used for edges) is indexed by an integer id. Additionally,
+/// each node and edge contains an arbitrary Python object as a weight/data
+/// payload. You can use this integer for access the data payload for example:
+///
+/// .. jupyter-execute::
+///
+///     import retworkx
+///
+///     graph = retworkx.PyGraph()
+///     data_payload = "An arbitrary Python object"
+///     node_index = graph.add_node(data_payload)
+///     print("Node Index: %s" % node_index)
+///     print(graph[node_index])
+///
+/// The PyDiGraph implements the Python mapping protocol for nodes so in
+/// addition to access you can also update the data payload with:
+///
+/// .. jupyter-execute::
+///
+///     import retworkx
+///
+///     graph = retworkx.PyGraph()
+///     data_payload = "An arbitrary Python object"
+///     node_index = graph.add_node(data_payload)
+///     graph[node_index] = "New Payload"
+///     print("Node Index: %s" % node_index)
+///     print(graph[node_index])
+///
 #[pyclass(module = "retworkx")]
 #[text_signature = "()"]
 pub struct PyGraph {


### PR DESCRIPTION
This commit improves the documentation for the graph class. THe previous
class documentation didn't really include any details on the usage of
the classes or how they work. Instead it was just pointing people to
petgraph saying retworkx's classes are built around petgraph assuming
that was enough for users to figure out how to use the class. This
commit reworks the documentation to better explain how the classes are
used and provide examples on how to use it.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
