### PR TITLE
Fix unpickling on empty graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
+checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
  "quote",
  "syn",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -178,9 +178,12 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "inventory"
@@ -212,9 +215,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "lock_api"
@@ -242,9 +245,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memoffset"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg",
 ]
@@ -384,9 +387,9 @@ checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -527,7 +530,7 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "retworkx"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "fixedbitset",
  "hashbrown",
@@ -554,9 +557,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -376,6 +376,9 @@ impl PyDiGraph {
             let tmp_index = raw_index.downcast::<PyLong>()?;
             node_indices.push(tmp_index.extract()?);
         }
+        if node_indices.is_empty() {
+            return Ok(());
+        }
         let max_index: usize = *node_indices.iter().max().unwrap();
         if max_index + 1 != node_indices.len() {
             self.node_removed = true;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -292,6 +292,9 @@ impl PyGraph {
             let tmp_index = raw_index.downcast::<PyLong>()?;
             node_indices.push(tmp_index.extract()?);
         }
+        if node_indices.is_empty() {
+            return Ok(());
+        }
         let max_index: usize = *node_indices.iter().max().unwrap();
         let mut tmp_nodes: Vec<NodeIndex> = Vec::new();
         let mut node_count: usize = 0;

--- a/tests/graph/test_deepcopy.py
+++ b/tests/graph/test_deepcopy.py
@@ -39,3 +39,8 @@ class TestDeepcopy(unittest.TestCase):
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyGraph)
         self.assertEqual([node_a, node_c], dag_b.node_indexes())
+
+    def test_deepcopy_empty(self):
+        dag = retworkx.PyGraph()
+        empty_copy = copy.deepcopy(dag)
+        self.assertEqual(len(empty_copy), 0)

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -39,3 +39,8 @@ class TestDeepcopy(unittest.TestCase):
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyDAG)
         self.assertEqual([node_a, node_c], dag_b.node_indexes())
+
+    def test_deepcopy_empty(self):
+        dag = retworkx.PyDAG()
+        empty_copy = copy.deepcopy(dag)
+        self.assertEqual(len(empty_copy), 0)


### PR DESCRIPTION
In `__setstate__` for PyDiGraph and PyGraph there was an implicit
assumption that there was always a node in the graph. However if an
empty graph object was being unpickled it would cause a panic because
at one point we tried to find the maximum node index which returns None
if there is no maximum and we unconditionally unwrapped it instead of
handling a None. This commit fixes this issue by returning early if the
list of node indices is empty.

Fixes #164

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
