### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_SKIP: cp27-* cp34-* cp39-* pp* *win32
+          CIBW_SKIP: cp27-* cp34-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.0 twine
+          python -m pip install cibuildwheel==1.6.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -82,7 +82,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.0 twine
+          python -m pip install cibuildwheel==1.6.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.2 twine
+          python -m pip install cibuildwheel==1.6.3 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -82,7 +82,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.2 twine
+          python -m pip install cibuildwheel==1.6.3 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.5.2
+        - pip install -U twine cibuildwheel==1.6.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -78,7 +78,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.5.2
+        - pip install -U twine cibuildwheel==1.6.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -98,6 +98,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.5.2
+        - sudo pip install -U twine cibuildwheel==1.6.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.2
+        - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -78,7 +78,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.2
+        - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -98,6 +98,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.6.2
+        - sudo pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.1
+        - pip install -U twine cibuildwheel==1.6.2
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -78,7 +78,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.1
+        - pip install -U twine cibuildwheel==1.6.2
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -98,6 +98,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.6.1
+        - sudo pip install -U twine cibuildwheel==1.6.2
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Python 3.9.0 was released on 10-05-2020, this commits marks the support
of Python 3.9 in qiskit-ignis. It adds the supported python version in
the package metadata and updates the CI configuration to run test jobs
on Python 3.9 and build wheels for Python 3.9.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
