### PR TITLE
Rely on PyO3 type conversion for HashMap and HashSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b90d637542bbf29b140fdd38fa308424073fd2cdf641a5680aed8020145e3c"
 dependencies = [
  "ctor",
+ "hashbrown",
  "indoc",
  "inventory",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rayon = "1.4"
 
 [dependencies.pyo3]
 version = "0.12.3"
-features = ["extension-module"]
+features = ["extension-module", "hashbrown"]
 
 [dependencies.hashbrown]
 version = "0.9"

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1473,7 +1473,7 @@ impl PyDiGraph {
         node_map: HashMap<usize, (usize, PyObject)>,
         node_map_func: Option<PyObject>,
         edge_map_func: Option<PyObject>,
-    ) -> PyResult<HashMap<usize, usize>> {
+    ) -> PyResult<PyObject> {
         let mut new_node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
 
         // TODO: Reimplement this without looping over the graphs
@@ -1504,10 +1504,11 @@ impl PyDiGraph {
                 weight.clone_ref(py),
             );
         }
-        Ok(new_node_map
-            .iter()
-            .map(|(old, new)| (old.index(), new.index()))
-            .collect())
+        let out_dict = PyDict::new(py);
+        for (orig_node, new_node) in new_node_map.iter() {
+            out_dict.set_item(orig_node.index(), new_node.index())?;
+        }
+        Ok(out_dict.into())
     }
 
     /// Check if the graph is symmetric

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1587,14 +1587,14 @@ fn is_cycle_check_required(
 
 fn weight_transform_callable(
     py: Python,
-    edge_map: &Option<PyObject>,
-    edge: &PyObject,
+    map_fn: &Option<PyObject>,
+    value: &PyObject,
 ) -> PyResult<PyObject> {
-    match edge_map {
-        Some(edge_map) => {
-            let res = edge_map.call1(py, (edge,))?;
+    match map_fn {
+        Some(map_fn) => {
+            let res = map_fn.call1(py, (value,))?;
             Ok(res.to_object(py))
         }
-        None => Ok(edge.clone_ref(py)),
+        None => Ok(value.clone_ref(py)),
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1045,7 +1045,7 @@ impl PyGraph {
         node_map: HashMap<usize, (usize, PyObject)>,
         node_map_func: Option<PyObject>,
         edge_map_func: Option<PyObject>,
-    ) -> PyResult<HashMap<usize, usize>> {
+    ) -> PyResult<PyObject> {
         let mut new_node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
 
         fn node_weight_callable(
@@ -1108,10 +1108,7 @@ impl PyGraph {
         for (orig_node, new_node) in new_node_map.iter() {
             out_dict.set_item(orig_node.index(), new_node.index())?;
         }
-        Ok(new_node_map
-            .iter()
-            .map(|(old, new)| (old.index(), new.index()))
-            .collect())
+        Ok(out_dict.into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,8 +440,9 @@ fn lexicographical_topological_sort(
 #[pyfunction]
 #[text_signature = "(graph, /)"]
 fn graph_greedy_color(
+    py: Python,
     graph: &graph::PyGraph,
-) -> PyResult<HashMap<usize, usize>> {
+) -> PyResult<PyObject> {
     let mut colors: HashMap<usize, usize> = HashMap::new();
     let mut node_vec: Vec<NodeIndex> = graph.graph.node_indices().collect();
     let mut sort_map: HashMap<NodeIndex, usize> = HashMap::new();
@@ -468,7 +469,11 @@ fn graph_greedy_color(
         }
         colors.insert(u_index.index(), count);
     }
-    Ok(colors)
+    let out_dict = PyDict::new(py);
+    for (index, color) in colors {
+        out_dict.set_item(index, color)?;
+    }
+    Ok(out_dict.into())
 }
 
 /// Compute the length of the kth shortest path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use hashbrown::{HashMap, HashSet};
 use pyo3::create_exception;
 use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PySet};
+use pyo3::types::{PyDict, PyList};
 use pyo3::wrap_pyfunction;
 use pyo3::wrap_pymodule;
 use pyo3::Python;
@@ -305,7 +305,7 @@ fn bfs_successors(
 /// :rtype: list
 #[pyfunction]
 #[text_signature = "(graph, node, /)"]
-fn ancestors(py: Python, graph: &digraph::PyDiGraph, node: usize) -> PyObject {
+fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
@@ -315,13 +315,7 @@ fn ancestors(py: Python, graph: &digraph::PyDiGraph, node: usize) -> PyObject {
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    let set = PySet::empty(py).expect("Failed to construct empty set");
-    {
-        for val in out_set {
-            set.add(val).expect("Failed to add to set");
-        }
-    }
-    set.into()
+    out_set
 }
 
 /// Return the descendants of a node in a graph.
@@ -338,11 +332,7 @@ fn ancestors(py: Python, graph: &digraph::PyDiGraph, node: usize) -> PyObject {
 /// :rtype: list
 #[pyfunction]
 #[text_signature = "(graph, node, /)"]
-fn descendants(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-    node: usize,
-) -> PyObject {
+fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
     let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
@@ -351,13 +341,7 @@ fn descendants(
         out_set.insert(n_int);
     }
     out_set.remove(&node);
-    let set = PySet::empty(py).expect("Failed to construct empty set");
-    {
-        for val in out_set {
-            set.add(val).expect("Failed to add to set");
-        }
-    }
-    set.into()
+    out_set
 }
 
 /// Get the lexicographical topological sorted nodes from the provided DAG
@@ -456,9 +440,8 @@ fn lexicographical_topological_sort(
 #[pyfunction]
 #[text_signature = "(graph, /)"]
 fn graph_greedy_color(
-    py: Python,
     graph: &graph::PyGraph,
-) -> PyResult<PyObject> {
+) -> PyResult<HashMap<usize, usize>> {
     let mut colors: HashMap<usize, usize> = HashMap::new();
     let mut node_vec: Vec<NodeIndex> = graph.graph.node_indices().collect();
     let mut sort_map: HashMap<NodeIndex, usize> = HashMap::new();
@@ -485,11 +468,7 @@ fn graph_greedy_color(
         }
         colors.insert(u_index.index(), count);
     }
-    let out_dict = PyDict::new(py);
-    for (index, color) in colors {
-        out_dict.set_item(index, color)?;
-    }
-    Ok(out_dict.into())
+    Ok(colors)
 }
 
 /// Compute the length of the kth shortest path


### PR DESCRIPTION
Since PyO3 0.12.0 the trait implementations for converting from
hashbrown's HashMap and HashSet types. [1] This commit leverage
this so we do not have to internally convert these objects to and from
python types.

[1] https://github.com/PyO3/pyo3/pull/1114

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
