### PR TITLE
Change G(n,p) to accept exact 0 or 1 probabilities 

### DIFF
--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -22,6 +22,16 @@ class TestGNPRandomGraph(unittest.TestCase):
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 104)
 
+    def test_random_gnp_directed_empty_graph(self):
+        graph = retworkx.directed_gnp_random_graph(20, 0)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 0)
+
+    def test_random_gnp_directed_complete_graph(self):
+        graph = retworkx.directed_gnp_random_graph(20, 1)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 20 * (20 - 1))
+
     def test_random_gnp_directed_invalid_num_nodes(self):
         with self.assertRaises(ValueError):
             retworkx.directed_gnp_random_graph(-23, .5)
@@ -34,6 +44,16 @@ class TestGNPRandomGraph(unittest.TestCase):
         graph = retworkx.undirected_gnp_random_graph(20, .5, seed=10)
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 105)
+
+    def test_random_gnp_undirected_empty_graph(self):
+        graph = retworkx.undirected_gnp_random_graph(20, 0)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 0)
+
+    def test_random_gnp_undirected_complete_graph(self):
+        graph = retworkx.undirected_gnp_random_graph(20, 1)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 20 * (20 - 1) / 2)
 
     def test_random_gnp_undirected_invalid_num_nodes(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When p=0, we'll have an empty graph with n nodes and zero edges.
When p=1, we'll have a complete graph with n n(n-1) edges
for directed graphs and n(n-1)/2 edges for undirected graphs.
The time complexity stays the same. Let m be the max number of edges,
then run time is O(n+p*m), which reduces to O(n) when p=0 and, when
p=1 becomes O(n+n(n-1)) = O(n^2).
Fixes  #172
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
