### PR TITLE
Fix cargo clippy errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1479,7 +1479,7 @@ pub fn directed_gnp_random_graph(
         ));
     }
     if probability > 0.0 {
-        if probability == 1.0 {
+        if (probability - 1.0).abs() < std::f64::EPSILON {
             for u in 0..num_nodes {
                 for v in 0..num_nodes {
                     if u != v {
@@ -1585,7 +1585,7 @@ pub fn undirected_gnp_random_graph(
         ));
     }
     if probability > 0.0 {
-        if probability == 1.0 {
+        if (probability - 1.0).abs() < std::f64::EPSILON {
             for u in 0..num_nodes {
                 for v in u + 1..num_nodes {
                     let u_index = NodeIndex::new(u as usize);


### PR DESCRIPTION
In #174 the gnp random functions were extended to support values of 0
and 1 for the probability representing either empty of full graphs. In
that change comparisons between the value of probability and 1 were used
to check if it's a full graph and we should just fast path adding an
edge between every node. However, when running `cargo clippy` on this it
rightfully points out that we should probably check for equality to 1
within an error margin (given that floating point is never exact).
Clippy suggested replacing using `std::f64::EPSILON` as the error value,
which is ~2.2e-16 [1] and replacing the comparison with:
```rust
(probability - 1.0).abs() < error
```
This commit just makes that change. While this is unlikely to cause any
issues in practice, because probability is a parameter and if someone is
going to want a full graph they'll likely call the function with
`probability=1` in python. It's better to be safe just in case someone is
computing the probability value and could have some error on the value.

[1] https://doc.rust-lang.org/std/f64/constant.EPSILON.html

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
