### PR TITLE
Switch gen_range() to Uniform in random graph functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use petgraph::visit::{
 
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
+use rand::distributions::{Distribution, Uniform};
 use rand::prelude::*;
 use rand_pcg::Pcg64;
 use rayon::prelude::*;
@@ -1479,8 +1480,9 @@ pub fn directed_gnp_random_graph(
             let mut w: isize = -1;
             let lp: f64 = (1.0 - probability).ln();
 
+            let between = Uniform::new(0.0, 1.0);
             while v < num_nodes {
-                let random: f64 = rng.gen_range(0.0, 1.0);
+                let random: f64 = between.sample(&mut rng);
                 let lr: f64 = (1.0 - random).ln();
                 let ratio: isize = (lr / lp) as isize;
                 w = w + 1 + ratio;
@@ -1582,8 +1584,9 @@ pub fn undirected_gnp_random_graph(
             let mut w: isize = -1;
             let lp: f64 = (1.0 - probability).ln();
 
+            let between = Uniform::new(0.0, 1.0);
             while v < num_nodes {
-                let random: f64 = rng.gen_range(0.0, 1.0);
+                let random: f64 = between.sample(&mut rng);
                 let lr = (1.0 - random).ln();
                 let ratio: isize = (lr / lp) as isize;
                 w = w + 1 + ratio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1667,9 +1667,10 @@ pub fn directed_gnm_random_graph(
         }
     } else {
         let mut created_edges: isize = 0;
+        let between = Uniform::new(0, num_nodes);
         while created_edges < num_edges {
-            let u = rng.gen_range(0, num_nodes);
-            let v = rng.gen_range(0, num_nodes);
+            let u = between.sample(&mut rng);
+            let v = between.sample(&mut rng);
             let u_index = NodeIndex::new(u as usize);
             let v_index = NodeIndex::new(v as usize);
             // avoid self-loops and multi-graphs
@@ -1742,9 +1743,10 @@ pub fn undirected_gnm_random_graph(
         }
     } else {
         let mut created_edges: isize = 0;
+        let between = Uniform::new(0, num_nodes);
         while created_edges < num_edges {
-            let u = rng.gen_range(0, num_nodes);
-            let v = rng.gen_range(0, num_nodes);
+            let u = between.sample(&mut rng);
+            let v = between.sample(&mut rng);
             let u_index = NodeIndex::new(u as usize);
             let v_index = NodeIndex::new(v as usize);
             // avoid self-loops and multi-graphs


### PR DESCRIPTION
This commit updates the gnp random graph functions to internally use
Uniform.sample() instead of rng.gen_range(). The rand docs for
gen_range() recommend the use of Uniform if you're going to getting
random values in a range more than once, as the gen_range() function is
optimized for the single sample case. [1][2]

[1] https://docs.rs/rand/0.7.3/rand/trait.Rng.html#method.gen_range
[2] https://docs.rs/rand/0.7.3/rand/distributions/uniform/struct.Uniform.html

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
