### PR TITLE
Add remove_edges_from method to PyGraph

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -897,6 +897,35 @@ impl PyDiGraph {
         Ok(())
     }
 
+    /// Remove edges from the graph.
+    ///
+    /// Note if there are multiple edges between the specified nodes only one
+    /// will be removed.
+    ///
+    /// :param list index_list: A list of node index pairs to remove from
+    ///     the graph
+    #[text_signature = "(index_list, /)"]
+    pub fn remove_edges_from(
+        &mut self,
+        index_list: Vec<(usize, usize)>,
+    ) -> PyResult<()> {
+        for (p_index, c_index) in index_list
+            .iter()
+            .map(|(x, y)| (NodeIndex::new(*x), NodeIndex::new(*y)))
+        {
+            let edge_index = match self.graph.find_edge(p_index, c_index) {
+                Some(edge_index) => edge_index,
+                None => {
+                    return Err(NoEdgeBetweenNodes::new_err(
+                        "No edge found between nodes",
+                    ))
+                }
+            };
+            self.graph.remove_edge(edge_index);
+        }
+        Ok(())
+    }
+
     /// Add a new node to the graph.
     ///
     /// :param obj: The python object to attach to the node

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -673,6 +673,35 @@ impl PyGraph {
         Ok(())
     }
 
+    /// Remove edges from the graph.
+    ///
+    /// Note if there are multiple edges between the specified nodes only one
+    /// will be removed.
+    ///
+    /// :param list index_list: A list of node index pairs to remove from
+    ///     the graph
+    #[text_signature = "(index_list, /)"]
+    pub fn remove_edges_from(
+        &mut self,
+        index_list: Vec<(usize, usize)>,
+    ) -> PyResult<()> {
+        for (p_index, c_index) in index_list
+            .iter()
+            .map(|(x, y)| (NodeIndex::new(*x), NodeIndex::new(*y)))
+        {
+            let edge_index = match self.graph.find_edge(p_index, c_index) {
+                Some(edge_index) => edge_index,
+                None => {
+                    return Err(NoEdgeBetweenNodes::new_err(
+                        "No edge found between nodes",
+                    ))
+                }
+            };
+            self.graph.remove_edge(edge_index);
+        }
+        Ok(())
+    }
+
     /// Add a new node to the graph.
     ///
     /// :param obj: The python object to attach to the node

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -123,6 +123,16 @@ class TestEdges(unittest.TestCase):
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
+    def test_remove_edges_from(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_c, 'super_edgy')
+        graph.remove_edges_from([(node_a, node_b), (node_a, node_c)])
+        self.assertEqual([], graph.edges())
+
     def test_degree(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')


### PR DESCRIPTION
This commit adds a new method remove_edges_from() to remove multiple edges in a single call.
Fixes #177

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->
