### PR TITLE
Expand test coverage for remove_edges_from

### DIFF
--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -133,6 +133,16 @@ class TestEdges(unittest.TestCase):
         graph.remove_edges_from([(node_a, node_b), (node_a, node_c)])
         self.assertEqual([], graph.edges())
 
+    def test_remove_edges_from_invalid(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_c, 'super_edgy')
+        with self.assertRaises(retworkx.NoEdgeBetweenNodes):
+            graph.remove_edges_from([(node_b, node_c), (node_a, node_c)])
+
     def test_degree(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node('a')

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -93,6 +93,26 @@ class TestEdges(unittest.TestCase):
         dag.remove_edge_from_index(0)
         self.assertEqual(['super_edgy'], dag.edges())
 
+    def test_remove_edges_from(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_c, 'super_edgy')
+        graph.remove_edges_from([(node_a, node_b), (node_a, node_c)])
+        self.assertEqual([], graph.edges())
+
+    def test_remove_edges_from_invalid(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node('a')
+        node_b = graph.add_node('b')
+        node_c = graph.add_node('c')
+        graph.add_edge(node_a, node_b, 'edgy')
+        graph.add_edge(node_a, node_c, 'super_edgy')
+        with self.assertRaises(retworkx.NoEdgeBetweenNodes):
+            graph.remove_edges_from([(node_b, node_c), (node_a, node_c)])
+
     def test_remove_edge_from_index(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node('a')


### PR DESCRIPTION
This commit adds some additional unit test coverage for
remove_edges_from which was recently added in #179. There are a couple
of coverage holes for the method, while manually testing works as
expected making sure we have coverage to avoid future regressions is
useful.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
