### PR TITLE
Add insert_node_on_in_edges and insert_node_on_out_edges methods

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -910,97 +910,99 @@ impl PyDiGraph {
         Ok(())
     }
 
-    /// Insert a node between multiple parents and all their children nodes
+    /// Insert a node between a list of reference nodes and all their predecessors
     ///
-    /// This essentially iterates over all edges into the nodes specified in
-    /// the ``nodes_between`` parameter removes those edges and then adds 2
-    /// edges, one from the parent or child of that edge to ``node`` and the
-    /// other to or from ``node`` to ``node_between``. The edge payloads for
+    /// This essentially iterates over all edges into the reference node
+    /// specified in the ``ref_nodes`` parameter removes those edges and then
+    /// adds 2 edges, one from the predecessor of ``ref_node`` to ``node``
+    /// and the other from ``node`` to ``ref_node``. The edge payloads for
     /// the newly created edges are copied by reference from the original
     /// edge that gets removed.
     ///
     /// :param int node: The node index to insert between
-    /// :param int nodes_between: The list of node indices to insert ``node``
-    ///     between
-    #[text_signature = "(node, nodes_between, /)"]
+    /// :param int ref_node: The reference node index to insert ``node``
+    /// between
+    #[text_signature = "(node, ref_nodes, /)"]
     pub fn insert_node_on_in_edges_multiple(
         &mut self,
         py: Python,
         node: usize,
-        nodes_between: Vec<usize>,
+        ref_nodes: Vec<usize>,
     ) -> PyResult<()> {
-        for node_between in nodes_between {
-            self.insert_between(py, node, node_between, false)?;
+        for ref_node in ref_nodes {
+            self.insert_between(py, node, ref_node, false)?;
         }
         Ok(())
     }
 
-    /// Insert a node between multiple children and all their parent nodes
+    /// Insert a node between a list of reference nodes and all their successors
     ///
-    /// This essentially iterates over all edges into the nodes specified in
-    /// the ``nodes_between`` parameter removes those edges and then adds 2
-    /// edges, one from the parent or child of that edge to ``node`` and the
-    /// other to or from ``node`` to ``node_between``. The edge payloads for
-    /// the newly created edges are copied by reference from the original
-    /// edge that gets removed.
+    /// This essentially iterates over all edges out of the reference node
+    /// specified in the ``ref_node`` parameter removes those edges and then
+    /// adds 2 edges, one from ``ref_node`` to ``node`` and the other from
+    /// ``node`` to the successor of ``ref_node``. The edge payloads for the
+    /// newly created edges are copied by reference from the original edge that
+    /// gets removed.
     ///
     /// :param int node: The node index to insert between
-    /// :param int nodes_between: The list of node indices to insert ``node``
+    /// :param int ref_nodes: The list of node indices to insert ``node``
     ///     between
-    #[text_signature = "(node, nodes_between, /)"]
+    #[text_signature = "(node, ref_nodes, /)"]
     pub fn insert_node_on_out_edges_multiple(
         &mut self,
         py: Python,
         node: usize,
-        nodes_between: Vec<usize>,
+        ref_nodes: Vec<usize>,
     ) -> PyResult<()> {
-        for node_between in nodes_between {
-            self.insert_between(py, node, node_between, true)?;
+        for ref_node in ref_nodes {
+            self.insert_between(py, node, ref_node, true)?;
         }
         Ok(())
     }
 
-    /// Insert a node between a child node and all it's parents
+    /// Insert a node between a reference node and all its predecessor nodes
     ///
-    /// This essentially iterates over all edges into the node specified in the
-    /// ``node_between`` parameter removes those edges and then adds 2 edges,
-    /// one from the parent or child of that edge to ``node`` and the other to
-    /// or from ``node`` to ``node_between``. The edge payloads for the newly
-    /// created edges are copied by reference from the original edge that gets
-    /// removed.
+    /// This essentially iterates over all edges into the reference node
+    /// specified in the ``ref_node`` parameter removes those edges and then
+    /// adds 2 edges, one from the predecessor of ``ref_node`` to ``node`` and
+    /// the other from ``node`` to ``ref_node``. The edge payloads for the
+    /// newly created edges are copied by reference from the original edge that
+    /// gets removed.
     ///
     /// :param int node: The node index to insert between
-    /// :param int node_between: The node index to insert ``node`` between
-    #[text_signature = "(node, node_between, /)"]
+    /// :param int ref_node: The reference node index to insert ``node``
+    ///     between
+    #[text_signature = "(node, ref_node, /)"]
     pub fn insert_node_on_in_edges(
         &mut self,
         py: Python,
         node: usize,
-        node_between: usize,
+        ref_node: usize,
     ) -> PyResult<()> {
-        self.insert_between(py, node, node_between, false)?;
+        self.insert_between(py, node, ref_node, false)?;
         Ok(())
     }
 
-    /// Insert a node between a parent node and all it's children
+    /// Insert a node between a reference node and all its successor nodes
     ///
-    /// This essentially iterates over all edges out of the node specified in
-    /// the ``node_between`` parameter removes those edges and then adds 2
-    /// edges, one from the parent or child of that edge to ``node`` and the
-    /// other to or from ``node`` to ``node_between``. The edge payloads for
-    /// the newly created edges are copied by reference from the original edge
+    /// This essentially iterates over all edges out of the reference node
+    /// specified in the ``ref_node`` parameter removes those edges and then
+    /// adds 2 edges, one from ``ref_node`` to ``node`` and the other from
+    /// ``node`` to the successor of ``ref_node``. The edge payloads for the
+    /// newly created edges are copied by reference from the original edge
     /// that gets removed.
     ///
     /// :param int node: The node index to insert between
-    /// :param int node_between: The node index to insert ``node`` between
-    #[text_signature = "(node, node_between, /)"]
+    /// :param int ref_node: The reference node index to insert ``node``
+    ///     between
+    #[text_signature = "(node, ref_node, /)"]
     pub fn insert_node_on_out_edges(
         &mut self,
         py: Python,
         node: usize,
-        node_between: usize,
+        ref_node: usize,
     ) -> PyResult<()> {
-        self.insert_between(py, node, node_between, true)?;
+        self.insert_between(py, node, ref_node, true)?;
         Ok(())
     }
 

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -910,41 +910,59 @@ impl PyDiGraph {
         Ok(())
     }
 
-    /// Insert a node between multiple child node and its neighbors
+    /// Insert a node between multiple parents and all their children nodes
     ///
-    /// This essentially iterates over all edges into or out of (as
-    /// dictated by the ``direction`` parameter) the nodes specified in the
-    /// ``nodes_between`` parameter removes those edges and then adds 2 edges,
-    /// one from the parent or child of that edge to ``node`` and the other to
-    /// or from ``node`` to ``node_between``. The edge payloads for the newly
-    /// created edges are copied by reference from the original edge that gets
-    /// removed.
+    /// This essentially iterates over all edges into the nodes specified in
+    /// the ``nodes_between`` parameter removes those edges and then adds 2
+    /// edges, one from the parent or child of that edge to ``node`` and the
+    /// other to or from ``node`` to ``node_between``. The edge payloads for
+    /// the newly created edges are copied by reference from the original
+    /// edge that gets removed.
     ///
     /// :param int node: The node index to insert between
     /// :param int nodes_between: The list of node indices to insert ``node``
     ///     between
-    /// :param bool direction: The direction relative to node_between to insert
-    ///     node. If ``False`` (the default) it will use incoming edges, if
-    ///     ``True`` it will use outgoing.
-    #[args(direction = "false")]
-    #[text_signature = "(node, nodes_between, /, direction=False)"]
-    pub fn insert_node_between_multiple(
+    #[text_signature = "(node, nodes_between, /)"]
+    pub fn insert_node_on_in_edges_multiple(
         &mut self,
         py: Python,
         node: usize,
         nodes_between: Vec<usize>,
-        direction: bool,
     ) -> PyResult<()> {
         for node_between in nodes_between {
-            self.insert_between(py, node, node_between, direction)?;
+            self.insert_between(py, node, node_between, false)?;
+        }
+        Ok(())
+    }
+
+    /// Insert a node between multiple children and all their parent nodes
+    ///
+    /// This essentially iterates over all edges into the nodes specified in
+    /// the ``nodes_between`` parameter removes those edges and then adds 2
+    /// edges, one from the parent or child of that edge to ``node`` and the
+    /// other to or from ``node`` to ``node_between``. The edge payloads for
+    /// the newly created edges are copied by reference from the original
+    /// edge that gets removed.
+    ///
+    /// :param int node: The node index to insert between
+    /// :param int nodes_between: The list of node indices to insert ``node``
+    ///     between
+    #[text_signature = "(node, nodes_between, /)"]
+    pub fn insert_node_on_out_edges_multiple(
+        &mut self,
+        py: Python,
+        node: usize,
+        nodes_between: Vec<usize>,
+    ) -> PyResult<()> {
+        for node_between in nodes_between {
+            self.insert_between(py, node, node_between, true)?;
         }
         Ok(())
     }
 
     /// Insert a node between a child node and all it's parents
     ///
-    /// This essentially iterates over all edges into or out of (as
-    /// dictated by the ``direction`` parameter) the node specified in the
+    /// This essentially iterates over all edges into the node specified in the
     /// ``node_between`` parameter removes those edges and then adds 2 edges,
     /// one from the parent or child of that edge to ``node`` and the other to
     /// or from ``node`` to ``node_between``. The edge payloads for the newly
@@ -953,19 +971,36 @@ impl PyDiGraph {
     ///
     /// :param int node: The node index to insert between
     /// :param int node_between: The node index to insert ``node`` between
-    /// :param bool direction: The direction relative to node_between to insert
-    ///     node. If ``False`` (the default) it will use incoming edges, if
-    ///     ``True`` it will use outgoing.
-    #[args(direction = "false")]
-    #[text_signature = "(node, node_between, /, direction=False)"]
-    pub fn insert_node_between(
+    #[text_signature = "(node, node_between, /)"]
+    pub fn insert_node_on_in_edges(
         &mut self,
         py: Python,
         node: usize,
         node_between: usize,
-        direction: bool,
     ) -> PyResult<()> {
-        self.insert_between(py, node, node_between, direction)?;
+        self.insert_between(py, node, node_between, false)?;
+        Ok(())
+    }
+
+    /// Insert a node between a parent node and all it's children
+    ///
+    /// This essentially iterates over all edges out of the node specified in
+    /// the ``node_between`` parameter removes those edges and then adds 2
+    /// edges, one from the parent or child of that edge to ``node`` and the
+    /// other to or from ``node`` to ``node_between``. The edge payloads for
+    /// the newly created edges are copied by reference from the original edge
+    /// that gets removed.
+    ///
+    /// :param int node: The node index to insert between
+    /// :param int node_between: The node index to insert ``node`` between
+    #[text_signature = "(node, node_between, /)"]
+    pub fn insert_node_on_out_edges(
+        &mut self,
+        py: Python,
+        node: usize,
+        node_between: usize,
+    ) -> PyResult<()> {
+        self.insert_between(py, node, node_between, true)?;
         Ok(())
     }
 

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -921,7 +921,7 @@ impl PyDiGraph {
     ///
     /// :param int node: The node index to insert between
     /// :param int ref_node: The reference node index to insert ``node``
-    /// between
+    ///     between
     #[text_signature = "(node, ref_nodes, /)"]
     pub fn insert_node_on_in_edges_multiple(
         &mut self,

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -342,43 +342,44 @@ class TestEdges(unittest.TestCase):
         self.assertEqual(1, dag.out_degree(2))
         self.assertEqual(2, dag.in_degree(3))
 
-    def test_insert_node_between(self):
+    def test_insert_node_on_in_edges(self):
         graph = retworkx.PyDiGraph()
         in_node = graph.add_node('qr[0]')
         out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
         h_gate = graph.add_node('h')
-        graph.insert_node_between(h_gate, out_node)
+        graph.insert_node_on_in_edges(h_gate, out_node)
         self.assertEqual(
             [(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')],
             graph.weighted_edge_list())
 
-    def test_insert_node_between_multiple(self):
+    def test_insert_node_on_in_edges_multiple(self):
         graph = retworkx.PyDiGraph()
         in_node_0 = graph.add_node('qr[0]')
         out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
         in_node_1 = graph.add_node('qr[1]')
         out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
         cx_gate = graph.add_node('cx')
-        graph.insert_node_between_multiple(cx_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(cx_gate,
+                                               [out_node_0, out_node_1])
         self.assertEqual(
             {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
              (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_double(self):
+    def test_insert_node_on_in_edges_double(self):
         graph = retworkx.PyDiGraph()
         in_node = graph.add_node('qr[0]')
         out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
         h_gate = graph.add_node('h')
         z_gate = graph.add_node('z')
-        graph.insert_node_between(h_gate, out_node)
-        graph.insert_node_between(z_gate, out_node)
+        graph.insert_node_on_in_edges(h_gate, out_node)
+        graph.insert_node_on_in_edges(z_gate, out_node)
         self.assertEqual(
             {(in_node, h_gate, 'qr[0]'), (h_gate, z_gate, 'qr[0]'),
              (z_gate, out_node, 'qr[0]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_multiple_double(self):
+    def test_insert_node_on_in_edges_multiple_double(self):
         graph = retworkx.PyDiGraph()
         in_node_0 = graph.add_node('qr[0]')
         out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
@@ -386,52 +387,54 @@ class TestEdges(unittest.TestCase):
         out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
         cx_gate = graph.add_node('cx')
         cz_gate = graph.add_node('cz')
-        graph.insert_node_between_multiple(cx_gate, [out_node_0, out_node_1])
-        graph.insert_node_between_multiple(cz_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(cx_gate,
+                                               [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(cz_gate,
+                                               [out_node_0, out_node_1])
         self.assertEqual(
             {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, cz_gate, 'qr[0]'),
              (in_node_1, cx_gate, 'qr[1]'), (cx_gate, cz_gate, 'qr[1]'),
              (cz_gate, out_node_0, 'qr[0]'), (cz_gate, out_node_1, 'qr[1]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_outgoing(self):
+    def test_insert_node_on_out_edges(self):
         graph = retworkx.PyDiGraph()
         in_node = graph.add_node('qr[0]')
         out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
         h_gate = graph.add_node('h')
-        graph.insert_node_between(h_gate, in_node, direction=True)
+        graph.insert_node_on_out_edges(h_gate, in_node)
         self.assertEqual(
             {(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_multiple_outgoing(self):
+    def test_insert_node_on_out_edges_multiple(self):
         graph = retworkx.PyDiGraph()
         in_node_0 = graph.add_node('qr[0]')
         out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
         in_node_1 = graph.add_node('qr[1]')
         out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
         cx_gate = graph.add_node('cx')
-        graph.insert_node_between_multiple(cx_gate, [in_node_0, in_node_1],
-                                           direction=True)
+        graph.insert_node_on_out_edges_multiple(cx_gate,
+                                                [in_node_0, in_node_1])
         self.assertEqual(
             {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
              (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_double_outgoing(self):
+    def test_insert_node_on_out_edges_double(self):
         graph = retworkx.PyDiGraph()
         in_node = graph.add_node('qr[0]')
         out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
         h_gate = graph.add_node('h')
         z_gate = graph.add_node('z')
-        graph.insert_node_between(h_gate, in_node, direction=True)
-        graph.insert_node_between(z_gate, in_node, direction=True)
+        graph.insert_node_on_out_edges(h_gate, in_node)
+        graph.insert_node_on_out_edges(z_gate, in_node)
         self.assertEqual(
             {(in_node, z_gate, 'qr[0]'), (z_gate, h_gate, 'qr[0]'),
              (h_gate, out_node, 'qr[0]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_multiple_double_outgoing(self):
+    def test_insert_node_on_out_edges_multiple_double(self):
         graph = retworkx.PyDiGraph()
         in_node_0 = graph.add_node('qr[0]')
         out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
@@ -439,26 +442,40 @@ class TestEdges(unittest.TestCase):
         out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
         cx_gate = graph.add_node('cx')
         cz_gate = graph.add_node('cz')
-        graph.insert_node_between_multiple(cx_gate, [in_node_0, in_node_1],
-                                           direction=True)
-        graph.insert_node_between_multiple(cz_gate, [in_node_0, in_node_1],
-                                           direction=True)
+        graph.insert_node_on_out_edges_multiple(cx_gate,
+                                                [in_node_0, in_node_1])
+        graph.insert_node_on_out_edges_multiple(cz_gate,
+                                                [in_node_0, in_node_1])
         self.assertEqual(
             {(in_node_0, cz_gate, 'qr[0]'), (cz_gate, cx_gate, 'qr[0]'),
              (in_node_1, cz_gate, 'qr[1]'), (cz_gate, cx_gate, 'qr[1]'),
              (cx_gate, out_node_0, 'qr[0]'), (cx_gate, out_node_1, 'qr[1]')},
             set(graph.weighted_edge_list()))
 
-    def test_insert_node_between_no_edges(self):
+    def test_insert_node_on_in_edges_no_edges(self):
         graph = retworkx.PyDiGraph()
         node_a = graph.add_node(None)
         node_b = graph.add_node(None)
-        graph.insert_node_between(node_b, node_a)
+        graph.insert_node_on_in_edges(node_b, node_a)
         self.assertEqual([], graph.edge_list())
 
-    def test_insert_node_between_multiple_no_edges(self):
+    def test_insert_node_on_in_edges_multiple_no_edges(self):
         graph = retworkx.PyDiGraph()
         node_a = graph.add_node(None)
         node_b = graph.add_node(None)
-        graph.insert_node_between_multiple(node_b, [node_a])
+        graph.insert_node_on_in_edges_multiple(node_b, [node_a])
+        self.assertEqual([], graph.edge_list())
+
+    def test_insert_node_on_out_edges_no_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(None)
+        node_b = graph.add_node(None)
+        graph.insert_node_on_out_edges(node_b, node_a)
+        self.assertEqual([], graph.edge_list())
+
+    def test_insert_node_on_out_edges_multiple_no_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(None)
+        node_b = graph.add_node(None)
+        graph.insert_node_on_out_edges_multiple(node_b, [node_a])
         self.assertEqual([], graph.edge_list())

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -364,3 +364,101 @@ class TestEdges(unittest.TestCase):
             {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
              (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
             set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_double(self):
+        graph = retworkx.PyDiGraph()
+        in_node = graph.add_node('qr[0]')
+        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
+        h_gate = graph.add_node('h')
+        z_gate = graph.add_node('z')
+        graph.insert_node_between(h_gate, out_node)
+        graph.insert_node_between(z_gate, out_node)
+        self.assertEqual(
+            {(in_node, h_gate, 'qr[0]'), (h_gate, z_gate, 'qr[0]'),
+             (z_gate, out_node, 'qr[0]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_multiple_double(self):
+        graph = retworkx.PyDiGraph()
+        in_node_0 = graph.add_node('qr[0]')
+        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
+        in_node_1 = graph.add_node('qr[1]')
+        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
+        cx_gate = graph.add_node('cx')
+        cz_gate = graph.add_node('cz')
+        graph.insert_node_between_multiple(cx_gate, [out_node_0, out_node_1])
+        graph.insert_node_between_multiple(cz_gate, [out_node_0, out_node_1])
+        self.assertEqual(
+            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, cz_gate, 'qr[0]'),
+             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, cz_gate, 'qr[1]'),
+             (cz_gate, out_node_0, 'qr[0]'), (cz_gate, out_node_1, 'qr[1]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_outgoing(self):
+        graph = retworkx.PyDiGraph()
+        in_node = graph.add_node('qr[0]')
+        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
+        h_gate = graph.add_node('h')
+        graph.insert_node_between(h_gate, in_node, direction=True)
+        self.assertEqual(
+            {(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_multiple_outgoing(self):
+        graph = retworkx.PyDiGraph()
+        in_node_0 = graph.add_node('qr[0]')
+        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
+        in_node_1 = graph.add_node('qr[1]')
+        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
+        cx_gate = graph.add_node('cx')
+        graph.insert_node_between_multiple(cx_gate, [in_node_0, in_node_1],
+                                           direction=True)
+        self.assertEqual(
+            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
+             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_double_outgoing(self):
+        graph = retworkx.PyDiGraph()
+        in_node = graph.add_node('qr[0]')
+        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
+        h_gate = graph.add_node('h')
+        z_gate = graph.add_node('z')
+        graph.insert_node_between(h_gate, in_node, direction=True)
+        graph.insert_node_between(z_gate, in_node, direction=True)
+        self.assertEqual(
+            {(in_node, z_gate, 'qr[0]'), (z_gate, h_gate, 'qr[0]'),
+             (h_gate, out_node, 'qr[0]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_multiple_double_outgoing(self):
+        graph = retworkx.PyDiGraph()
+        in_node_0 = graph.add_node('qr[0]')
+        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
+        in_node_1 = graph.add_node('qr[1]')
+        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
+        cx_gate = graph.add_node('cx')
+        cz_gate = graph.add_node('cz')
+        graph.insert_node_between_multiple(cx_gate, [in_node_0, in_node_1],
+                                           direction=True)
+        graph.insert_node_between_multiple(cz_gate, [in_node_0, in_node_1],
+                                           direction=True)
+        self.assertEqual(
+            {(in_node_0, cz_gate, 'qr[0]'), (cz_gate, cx_gate, 'qr[0]'),
+             (in_node_1, cz_gate, 'qr[1]'), (cz_gate, cx_gate, 'qr[1]'),
+             (cx_gate, out_node_0, 'qr[0]'), (cx_gate, out_node_1, 'qr[1]')},
+            set(graph.weighted_edge_list()))
+
+    def test_insert_node_between_no_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(None)
+        node_b = graph.add_node(None)
+        graph.insert_node_between(node_b, node_a)
+        self.assertEqual([], graph.edge_list())
+
+    def test_insert_node_between_multiple_no_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(None)
+        node_b = graph.add_node(None)
+        graph.insert_node_between_multiple(node_b, [node_a])
+        self.assertEqual([], graph.edge_list())

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -341,3 +341,26 @@ class TestEdges(unittest.TestCase):
         self.assertEqual(1, dag.out_degree(1))
         self.assertEqual(1, dag.out_degree(2))
         self.assertEqual(2, dag.in_degree(3))
+
+    def test_insert_node_between(self):
+        graph = retworkx.PyDiGraph()
+        in_node = graph.add_node('qr[0]')
+        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
+        h_gate = graph.add_node('h')
+        graph.insert_node_between(h_gate, out_node)
+        self.assertEqual(
+            [(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')],
+            graph.weighted_edge_list())
+
+    def test_insert_node_between_multiple(self):
+        graph = retworkx.PyDiGraph()
+        in_node_0 = graph.add_node('qr[0]')
+        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
+        in_node_1 = graph.add_node('qr[1]')
+        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
+        cx_gate = graph.add_node('cx')
+        graph.insert_node_between_multiple(cx_gate, [out_node_0, out_node_1])
+        self.assertEqual(
+            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
+             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
+            set(graph.weighted_edge_list()))


### PR DESCRIPTION
This commit adds 2 new methods to the PyDiGraph class,
insert_node_between() and insert_node_between_multiple. These methods
are for inserting edges between a node and another node that has edges.
You specify a node and which node to insert it between and it will loop
over either the incoming or outgoing edges and add edges between the
existing edges.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
