### PR TITLE
DNM: Test wheel builds with new cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,7 +63,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_SKIP: cp27-* cp34-* cp39-* pp* *amd64
+          CIBW_SKIP: cp27-* cp34-* pp* *amd64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,30 +2,10 @@
 name: Wheel Builds
 on:
   push:
-    tags:
-      - '*'
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
-  sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install deps
-        run: pip install -U twine setuptools-rust
-      - name: Build sdist
-        run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -58,11 +38,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -94,8 +69,3 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Linux non-x86_64
-    if: tag IS present
   - name: deploy
-    if: tag IS blank
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Linux non-x86_64
+    if: tag IS present
   - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ script:
   - cd tests && ../test-venv/bin/python -m unittest discover .
 stages:
   - name: Linux non-x86_64
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -60,7 +60,6 @@ jobs:
       script:
         - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
       services:
@@ -80,7 +79,6 @@ jobs:
       script:
         - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
       services:
@@ -100,4 +98,3 @@ jobs:
       script:
         - sudo pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
       script:
         - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
@@ -75,7 +74,6 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
       script:
         - pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse
@@ -94,7 +92,6 @@ jobs:
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
       script:
         - sudo pip install -U twine cibuildwheel==1.6.3
         - cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
This commit just triggers a build of the release wheels to verify that
everythin still works with the new cibuildwheel version and python 3.9.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
