### PR TITLE
Unskip Python 3.9 win32 wheel job

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,7 +88,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_SKIP: cp27-* cp34-* cp39-* pp* *amd64
+          CIBW_SKIP: cp27-* cp34-* pp* *amd64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
In #168 we added support for 3.9 which included the CI config to publish
Python 3.9 wheels. However as was caught in #186 it neglected to remove
the Python 3.9 skip for the win32 wheel job. This commit corrects the
oversight so when we push a release we build a Python 3.9 wheel for
win32.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
