### PR TITLE
Cap Sphinx to avoid docs build failure

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 m2r2
-sphinx
+sphinx<3.3.0
 sphinx_rtd_theme
 jupyter-sphinx==0.2.3
 pydot


### PR DESCRIPTION
The recent sphinx 3.3.0 release today has started causing doc build
failures in CI. This is being caused by an issue with the m2r2 extension
used to render the README in the docs builds (see CrossNox/m2r2#13).
This commit caps the sphinx version until there is a new m2r2 release
fixing compatibility with sphinx >=3.3.0.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
