### PR TITLE
Added Bidirectional parameters for directed graph generators

### DIFF
--- a/src/generators.rs
+++ b/src/generators.rs
@@ -70,20 +70,14 @@ where
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
+#[pyfunction(bidirectional = "false")]
 #[text_signature = "(/, num_nodes=None, weights=None, bidirectional=False)"]
 pub fn directed_cycle_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
-    bidirectional: Option<bool>,
+    bidirectional: bool,
 ) -> PyResult<digraph::PyDiGraph> {
-    // boolean flag to indicate if edges should be added in both directions
-    let bidirection = match bidirectional {
-        Some(x) => bidirectional.unwrap(),
-        None => false,
-    };
-
     let mut graph = StableDiGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
         return Err(PyIndexError::new_err(
@@ -111,7 +105,7 @@ pub fn directed_cycle_graph(
     for (node_a, node_b) in pairwise(nodes) {
         match node_a {
             Some(node_a) => {
-                if bidirection {
+                if bidirectional {
                     graph.add_edge(node_b, node_a, py.None());
                 }
                 graph.add_edge(node_a, node_b, py.None());
@@ -122,7 +116,7 @@ pub fn directed_cycle_graph(
     let last_node_index = NodeIndex::new(node_len - 1);
     let first_node_index = NodeIndex::new(0);
     graph.add_edge(last_node_index, first_node_index, py.None());
-    if bidirection {
+    if bidirectional {
         graph.add_edge(first_node_index, last_node_index, py.None());
     }
     Ok(digraph::PyDiGraph {
@@ -253,20 +247,14 @@ pub fn cycle_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction]
+#[pyfunction(bidirectional = "false")]
 #[text_signature = "(/, num_nodes=None, weights=None, bidirectional=False)"]
 pub fn directed_path_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
-    bidirectional: Option<bool>,
+    bidirectional: bool,
 ) -> PyResult<digraph::PyDiGraph> {
-    // boolean variable to store if there should be an edge in both directions
-    let bidirection = match bidirectional {
-        Some(x) => bidirectional.unwrap(),
-        None => false,
-    };
-
     let mut graph = StableDiGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
         return Err(PyIndexError::new_err(
@@ -289,7 +277,7 @@ pub fn directed_path_graph(
     for (node_a, node_b) in pairwise(nodes) {
         match node_a {
             Some(node_a) => {
-                if bidirection {
+                if bidirectional {
                     graph.add_edge(node_a, node_b, py.None());
                     graph.add_edge(node_b, node_a, py.None());
                 } else {
@@ -445,26 +433,15 @@ pub fn path_graph(
 ///       os.remove(tmp_path)
 ///   image
 ///
-#[pyfunction(inward = "false")]
+#[pyfunction(inward = "false", bidirectional = "false")]
 #[text_signature = "(/, num_nodes=None, weights=None, inward=False, bidirectional=False)"]
 pub fn directed_star_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
-    bidirectional: Option<bool>,
-    inward: Option<bool>,
+    bidirectional: bool,
+    inward: bool,
 ) -> PyResult<digraph::PyDiGraph> {
-    // boolean variable to store if there should be an edge in both directions
-    let bidirection = match bidirectional {
-        Some(x) => bidirectional.unwrap(),
-        None => false,
-    };
-    //alias for inward parameter
-    let direction = match inward {
-        Some(x) => inward.unwrap(),
-        None => false,
-    };
-
     let mut graph = StableDiGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
         return Err(PyIndexError::new_err(
@@ -486,11 +463,11 @@ pub fn directed_star_graph(
     };
     for node in nodes[1..].iter() {
         //Add edges in both directions if bidirection is True
-        if bidirection {
+        if bidirectional {
             graph.add_edge(*node, nodes[0], py.None());
             graph.add_edge(nodes[0], *node, py.None());
         } else {
-            if direction {
+            if inward {
                 graph.add_edge(*node, nodes[0], py.None());
             } else {
                 graph.add_edge(nodes[0], *node, py.None());

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -439,8 +439,8 @@ pub fn directed_star_graph(
     py: Python,
     num_nodes: Option<usize>,
     weights: Option<Vec<PyObject>>,
-    bidirectional: bool,
     inward: bool,
+    bidirectional: bool,
 ) -> PyResult<digraph::PyDiGraph> {
     let mut graph = StableDiGraph::<PyObject, PyObject>::default();
     if weights.is_none() && num_nodes.is_none() {
@@ -466,12 +466,10 @@ pub fn directed_star_graph(
         if bidirectional {
             graph.add_edge(*node, nodes[0], py.None());
             graph.add_edge(nodes[0], *node, py.None());
+        } else if inward {
+            graph.add_edge(*node, nodes[0], py.None());
         } else {
-            if inward {
-                graph.add_edge(*node, nodes[0], py.None());
-            } else {
-                graph.add_edge(nodes[0], *node, py.None());
-            }
+            graph.add_edge(nodes[0], *node, py.None());
         }
     }
     Ok(digraph::PyDiGraph {

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -35,6 +35,16 @@ class TestCycleGraph(unittest.TestCase):
             self.assertEqual(graph.out_edges(i), [(i, i + 1, None)])
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
+    def test_directed_cycle_graph_bidirectional(self):
+        graph = retworkx.generators.directed_cycle_graph(20, bidirectional = True)
+        self.assertEqual(graph.out_edges(0), [(0, 19, None),(0, 1, None)])
+        self.assertEqual(graph.in_edges(0), [(19, 0, None),(1, 0, None)])
+        for i in range(1, 19):
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None),(i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None),(i - 1, i, None)])
+        self.assertEqual(graph.out_edges(19), [(19, 0, None),(19, 18, None)])
+        self.assertEqual(graph.in_edges(19), [(0, 19, None),(18, 19, None)])
+
     def test_cycle_directed_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.directed_cycle_graph()

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -36,14 +36,17 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
     def test_directed_cycle_graph_bidirectional(self):
-        graph = retworkx.generators.directed_cycle_graph(20, bidirectional = True)
-        self.assertEqual(graph.out_edges(0), [(0, 19, None),(0, 1, None)])
-        self.assertEqual(graph.in_edges(0), [(19, 0, None),(1, 0, None)])
+        graph = retworkx.generators.directed_cycle_graph(
+            20, bidirectional=True)
+        self.assertEqual(graph.out_edges(0), [(0, 19, None), (0, 1, None)])
+        self.assertEqual(graph.in_edges(0), [(19, 0, None), (1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(graph.out_edges(i), [(i, i + 1, None),(i, i - 1, None)])
-            self.assertEqual(graph.in_edges(i), [(i + 1, i, None),(i - 1, i, None)])
-        self.assertEqual(graph.out_edges(19), [(19, 0, None),(19, 18, None)])
-        self.assertEqual(graph.in_edges(19), [(0, 19, None),(18, 19, None)])
+            self.assertEqual(
+                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(
+                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
+        self.assertEqual(graph.out_edges(19), [(19, 0, None), (19, 18, None)])
+        self.assertEqual(graph.in_edges(19), [(0, 19, None), (18, 19, None)])
 
     def test_cycle_directed_no_weights_or_num(self):
         with self.assertRaises(IndexError):

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -35,6 +35,16 @@ class TestPathGraph(unittest.TestCase):
             self.assertEqual(graph.out_edges(i), [(i, i + 1, None)])
         self.assertEqual(graph.out_edges(19), [])
 
+    def test_directed_path_graph_bidirectional(self):
+        graph = retworkx.generators.directed_path_graph(20, bidirectional = True)
+        self.assertEqual(graph.out_edges(0), [(0, 1, None)])
+        self.assertEqual(graph.in_edges(0), [(1, 0, None)])
+        for i in range(1, 19):
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None),(i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None),(i - 1, i, None)])
+        self.assertEqual(graph.out_edges(19), [(19, 18, None)])
+        self.assertEqual(graph.in_edges(19), [(18, 19, None)])
+
     def test_path_directed_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.directed_path_graph()

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -36,12 +36,15 @@ class TestPathGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [])
 
     def test_directed_path_graph_bidirectional(self):
-        graph = retworkx.generators.directed_path_graph(20, bidirectional = True)
+        graph = retworkx.generators.directed_path_graph(
+            20, bidirectional=True)
         self.assertEqual(graph.out_edges(0), [(0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(graph.out_edges(i), [(i, i + 1, None),(i, i - 1, None)])
-            self.assertEqual(graph.in_edges(i), [(i + 1, i, None),(i - 1, i, None)])
+            self.assertEqual(
+                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(
+                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
         self.assertEqual(graph.out_edges(19), [(19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(18, 19, None)])
 

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -41,7 +41,8 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(sorted(graph.out_edges(0)), expected_edges)
 
     def test_directed_star_graph_bidirectional(self):
-        graph = retworkx.generators.directed_star_graph(20, bidirectional = True)
+        graph = retworkx.generators.directed_star_graph(
+            20, bidirectional=True)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -53,7 +54,8 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_directed_star_graph_bidirectional_inward(self):
-        graph = retworkx.generators.directed_star_graph(20, bidirectional = True, inward = True)
+        graph = retworkx.generators.directed_star_graph(
+            20, bidirectional=True, inward=True)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -63,7 +65,8 @@ class TestStarGraph(unittest.TestCase):
             self.assertEqual(graph.in_edges(i), [(0, i, None)])
         self.assertEqual(graph.out_edges(0), outw[::-1])
         self.assertEqual(graph.in_edges(0), inw[::-1])
-        graph = retworkx.generators.directed_star_graph(20, bidirectional = True, inward = False)
+        graph = retworkx.generators.directed_star_graph(
+            20, bidirectional=True, inward=False)
         outw = []
         inw = []
         for i in range(1, 20):

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -40,6 +40,40 @@ class TestStarGraph(unittest.TestCase):
         expected_edges = sorted([(0, i, None) for i in range(1, 20)])
         self.assertEqual(sorted(graph.out_edges(0)), expected_edges)
 
+    def test_directed_star_graph_bidirectional(self):
+        graph = retworkx.generators.directed_star_graph(20, bidirectional = True)
+        outw = []
+        inw = []
+        for i in range(1, 20):
+            outw.append((0, i, None))
+            inw.append((i, 0, None))
+            self.assertEqual(graph.out_edges(i), [(i, 0, None)])
+            self.assertEqual(graph.in_edges(i), [(0, i, None)])
+        self.assertEqual(graph.out_edges(0), outw[::-1])
+        self.assertEqual(graph.in_edges(0), inw[::-1])
+
+    def test_directed_star_graph_bidirectional_inward(self):
+        graph = retworkx.generators.directed_star_graph(20, bidirectional = True, inward = True)
+        outw = []
+        inw = []
+        for i in range(1, 20):
+            outw.append((0, i, None))
+            inw.append((i, 0, None))
+            self.assertEqual(graph.out_edges(i), [(i, 0, None)])
+            self.assertEqual(graph.in_edges(i), [(0, i, None)])
+        self.assertEqual(graph.out_edges(0), outw[::-1])
+        self.assertEqual(graph.in_edges(0), inw[::-1])
+        graph = retworkx.generators.directed_star_graph(20, bidirectional = True, inward = False)
+        outw = []
+        inw = []
+        for i in range(1, 20):
+            outw.append((0, i, None))
+            inw.append((i, 0, None))
+            self.assertEqual(graph.out_edges(i), [(i, 0, None)])
+            self.assertEqual(graph.in_edges(i), [(0, i, None)])
+        self.assertEqual(graph.out_edges(0), outw[::-1])
+        self.assertEqual(graph.in_edges(0), inw[::-1])
+
     def test_star_directed_graph_weights_inward(self):
         graph = retworkx.generators.directed_star_graph(
             weights=list(range(20)), inward=True)


### PR DESCRIPTION
Fixes #184 .
> Allows users to pass optional parameter 'bidirectional' to add edges in both directions
> For directed_star_graph generator if 'bidirectional' is set to 'True', the 'inward' parameter is ignored.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
