### PR TITLE
Cap setuptools-rust version for python 3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,4 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "wheel",
+            "setuptools-rust<0.11.4;python_version=='3.5'",
+            "setuptools-rust;python_version>'3.5'"]

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,14 @@ try:
 except ImportError:
     import sys
     import subprocess
+
+    if sys.version_info[1] == 5:
+        setuptools_rust = 'setuptools-rust<0.11.4'
+    else:
+        setuptools_rust = 'setuptools-rust'
+
     subprocess.call([sys.executable, '-m', 'pip', 'install',
-                     'setuptools-rust'])
+                     setuptools_rust])
     from setuptools_rust import Binding, RustExtension
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   ARGS="-V"
-deps = setuptools-rust
+deps =
+   setuptools-rust<0.11.4;python_version=='3.5'
+   setuptools-rust;python_version>'3.5'
 changedir = {toxinidir}/tests
 commands =
   python -m unittest discover .


### PR DESCRIPTION
The recent setuptools-rust 0.11.4 release dropped support for python
3.5, but didn't expose a minimum python version when doing so. This
means that on python3.5 pip will install the latest incompatible version
and fail to build retworkx (see PyO3/setuptools-rust#85). To workaround
this issue this commit sets a version cap for setuptools-rust when using
python 3.5. After the upcoming 0.6.0 release we will drop support for
python 3.5 so this can be removed then.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
