### PR TITLE
Implement rich comparison for BFSSuccessors

### DIFF
--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -29,6 +29,10 @@ class TestCustomReturnTypeComparisons(unittest.TestCase):
         self.assertFalse(retworkx.bfs_successors(
             self.dag, 0) == [('b', ['c'])])
 
+    def test_eq_not_match_inner(self):
+        self.assertFalse(retworkx.bfs_successors(
+            self.dag, 0) == [('a', ['c'])])
+
     def test__eq__different_length(self):
         self.assertFalse(retworkx.bfs_successors(
             self.dag, 0) == [('a', ['b']), ('b', ['c'])])
@@ -43,6 +47,9 @@ class TestCustomReturnTypeComparisons(unittest.TestCase):
 
     def test__ne__not_match(self):
         self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [('b', ['c'])])
+
+    def test_ne_not_match_inner(self):
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [('a', ['c'])])
 
     def test__ne__different_length(self):
         self.assertTrue(retworkx.bfs_successors(

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestCustomReturnTypeComparisons(unittest.TestCase):
+
+    def setUp(self):
+        self.dag = retworkx.PyDAG()
+        node_a = self.dag.add_node('a')
+        self.dag.add_child(node_a, 'b', "Edgy")
+
+    def test__eq__match(self):
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) == [('a', ['b'])])
+
+    def test__eq__not_match(self):
+        self.assertFalse(retworkx.bfs_successors(
+            self.dag, 0) == [('b', ['c'])])
+
+    def test__eq__different_length(self):
+        self.assertFalse(retworkx.bfs_successors(
+            self.dag, 0) == [('a', ['b']), ('b', ['c'])])
+
+    def test__eq__invalid_type(self):
+        with self.assertRaises(TypeError):
+            retworkx.bfs_successors(self.dag, 0) == ['a']
+
+    def test__ne__match(self):
+        self.assertFalse(retworkx.bfs_successors(
+            self.dag, 0) != [('a', ['b'])])
+
+    def test__ne__not_match(self):
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [('b', ['c'])])
+
+    def test__ne__different_length(self):
+        self.assertTrue(retworkx.bfs_successors(
+            self.dag, 0) != [('a', ['b']), ('b', ['c'])])
+
+    def test__ne__invalid_type(self):
+        with self.assertRaises(TypeError):
+            retworkx.bfs_successors(self.dag, 0) != ['a']
+
+    def test__gt__not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            retworkx.bfs_successors(self.dag, 0) > [('b', ['c'])]

--- a/tests/test_pred_succ.py
+++ b/tests/test_pred_succ.py
@@ -85,7 +85,7 @@ class TestBfsSuccessors(unittest.TestCase):
         node_c = dag.add_child(node_b, 'c', {'a': 2})
         dag.add_child(node_c, 'd', {'a': 1})
         res = retworkx.bfs_successors(dag, node_b)
-        self.assertEqual([('b', ['c']), ('c', ['d'])], list(res))
+        self.assertEqual([('b', ['c']), ('c', ['d'])], res)
 
     def test_many_children(self):
         dag = retworkx.PyDAG()
@@ -96,7 +96,7 @@ class TestBfsSuccessors(unittest.TestCase):
         self.assertEqual([('a', [{'numeral': 9}, {'numeral': 8},
                           {'numeral': 7}, {'numeral': 6}, {'numeral': 5},
                           {'numeral': 4}, {'numeral': 3}, {'numeral': 2},
-                          {'numeral': 1}, {'numeral': 0}])], list(res))
+                          {'numeral': 1}, {'numeral': 0}])], res)
 
     def test_bfs_succesors(self):
         dag = retworkx.PyDAG()
@@ -124,7 +124,7 @@ class TestBfsSuccessors(unittest.TestCase):
         }
         self.assertEqual(expected, res)
         self.assertEqual([(7, [8]), (8, [9]), (9, [10])],
-                         list(retworkx.bfs_successors(dag, node_h)))
+                         retworkx.bfs_successors(dag, node_h))
 
     def test_bfs_successors_sequence(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
This commit implements the rich comparison method of the python object
protocol for the BFSSuccessors class. This enables doing an equals and
not equals comparison between a BFSSuccessors object and any other
python sequence. If will compare all the elements of the 2 and return
appropriate result. Previously this was not implemented so you would
have to cast a BFSSuccessors object as a list first to compare it which
would iterate over the object. Implementing the method avoids the need
to do this.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
