### PR TITLE
Fix non-x86 release jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.3
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -78,7 +78,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine cibuildwheel==1.6.3
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -98,6 +98,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine cibuildwheel==1.6.3
+        - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*

--- a/tools/install_rust_no_rustup.sh
+++ b/tools/install_rust_no_rustup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-wget https://static.rust-lang.org/dist/rust-1.44.1-s390x-unknown-linux-gnu.tar.gz
+wget https://static.rust-lang.org/dist/rust-1.47.0-s390x-unknown-linux-gnu.tar.gz
 yum clean packages
 yum clean headers
 yum clean metadata
@@ -7,8 +7,8 @@ yum clean all
 rm -rf /var/cache/yum
 rm -rf /var/tmp/yum-*
 package-cleanup --oldkernels --count=1
-tar xzvf rust-1.44.1-s390x-unknown-linux-gnu.tar.gz
-rm -rf rust-1.44.1-s390x-unknown-linux-gnu.tar.gz
-pushd rust-1.44.1-s390x-unknown-linux-gnu
+tar xzvf rust-1.47.0-s390x-unknown-linux-gnu.tar.gz
+rm -rf rust-1.47.0-s390x-unknown-linux-gnu.tar.gz
+pushd rust-1.47.0-s390x-unknown-linux-gnu
 ./install.sh
 popd


### PR DESCRIPTION
During the 0.6.0 release the travis jobs for building the release wheels
on aarch64, ppc64le, and s390x all failed because of some requirements
conflicts between the travis python environment and the requirements for
twine. The wheels were built successfully but the upload to PyPi failed
because of this requirements issue. This commit fixes that so future
releases should be able to upload the wheels. At the same time the rust
version used for the s390x jobs are updated is updated to the latest
stable release to keep the compiled binaries using the same version of
rustc.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
