### PR TITLE
Add EdgeList and WeightedEdgeList return types

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -109,3 +109,5 @@ Return Iterator Types
 
    retworkx.BFSSuccessors
    retworkx.NodeIndices
+   retworkx.EdgeList
+   retworkx.WeightedEdgeList

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -41,7 +41,7 @@ use petgraph::visit::{
 };
 
 use super::dot_utils::build_dot;
-use super::iterators::NodeIndices;
+use super::iterators::{EdgeList, NodeIndices, WeightedEdgeList};
 use super::{
     is_directed_acyclic_graph, DAGHasCycle, DAGWouldCycle, NoEdgeBetweenNodes,
     NoSuitableNeighbors, NodesRemoved,
@@ -661,11 +661,14 @@ impl PyDiGraph {
     /// ``source`` and ``target`` are the node indices.
     ///
     /// :returns: An edge list with weights
-    /// :rtype: list
-    pub fn edge_list(&self) -> Vec<(usize, usize)> {
-        self.edge_references()
-            .map(|edge| (edge.source().index(), edge.target().index()))
-            .collect()
+    /// :rtype: EdgeList
+    pub fn edge_list(&self) -> EdgeList {
+        EdgeList {
+            edges: self
+                .edge_references()
+                .map(|edge| (edge.source().index(), edge.target().index()))
+                .collect(),
+        }
     }
 
     /// Get edge list with weights
@@ -675,20 +678,20 @@ impl PyDiGraph {
     /// payload of the edge.
     ///
     /// :returns: An edge list with weights
-    /// :rtype: list
-    pub fn weighted_edge_list(
-        &self,
-        py: Python,
-    ) -> Vec<(usize, usize, PyObject)> {
-        self.edge_references()
-            .map(|edge| {
-                (
-                    edge.source().index(),
-                    edge.target().index(),
-                    edge.weight().clone_ref(py),
-                )
-            })
-            .collect()
+    /// :rtype: WeightedEdgeList
+    pub fn weighted_edge_list(&self, py: Python) -> WeightedEdgeList {
+        WeightedEdgeList {
+            edges: self
+                .edge_references()
+                .map(|edge| {
+                    (
+                        edge.source().index(),
+                        edge.target().index(),
+                        edge.weight().clone_ref(py),
+                    )
+                })
+                .collect(),
+        }
     }
 
     /// Remove a node from the graph.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -27,7 +27,7 @@ use pyo3::types::{PyDict, PyList, PyLong, PyString, PyTuple};
 use pyo3::Python;
 
 use super::dot_utils::build_dot;
-use super::iterators::NodeIndices;
+use super::iterators::{EdgeList, NodeIndices, WeightedEdgeList};
 use super::{NoEdgeBetweenNodes, NodesRemoved};
 
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -465,11 +465,14 @@ impl PyGraph {
     /// ``source`` and ``target`` are the node indices.
     ///
     /// :returns: An edge list with weights
-    /// :rtype: list
-    pub fn edge_list(&self) -> Vec<(usize, usize)> {
-        self.edge_references()
-            .map(|edge| (edge.source().index(), edge.target().index()))
-            .collect()
+    /// :rtype: EdgeList
+    pub fn edge_list(&self) -> EdgeList {
+        EdgeList {
+            edges: self
+                .edge_references()
+                .map(|edge| (edge.source().index(), edge.target().index()))
+                .collect(),
+        }
     }
 
     /// Get edge list with weights
@@ -479,20 +482,20 @@ impl PyGraph {
     /// payload of the edge.
     ///
     /// :returns: An edge list with weights
-    /// :rtype: list
-    pub fn weighted_edge_list(
-        &self,
-        py: Python,
-    ) -> Vec<(usize, usize, PyObject)> {
-        self.edge_references()
-            .map(|edge| {
-                (
-                    edge.source().index(),
-                    edge.target().index(),
-                    edge.weight().clone_ref(py),
-                )
-            })
-            .collect()
+    /// :rtype: WeightedEdgeList
+    pub fn weighted_edge_list(&self, py: Python) -> WeightedEdgeList {
+        WeightedEdgeList {
+            edges: self
+                .edge_references()
+                .map(|edge| {
+                    (
+                        edge.source().index(),
+                        edge.target().index(),
+                        edge.weight().clone_ref(py),
+                    )
+                })
+                .collect(),
+        }
     }
 
     /// Remove a node from the graph.

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -187,7 +187,7 @@ impl PySequenceProtocol for NodeIndices {
 /// A custom class for the return of edge lists
 ///
 /// This class is a container class for the results of functions that
-/// return a list of node indices. It implements the Python sequence
+/// return a list of edges. It implements the Python sequence
 /// protocol. So you can treat the return as a read-only sequence/list
 /// that is integer indexed. If you want to use it as an iterator you
 /// can by wrapping it in an ``iter()`` that will yield the results in
@@ -198,7 +198,7 @@ impl PySequenceProtocol for NodeIndices {
 ///     import retworkx
 ///
 ///     graph = retworkx.generators.directed_path_graph(5)
-///     edges = retworkx.edge_list()
+///     edges = graph.edge_list()
 ///     # Index based access
 ///     third_element = edges[2]
 ///     # Use as iterator
@@ -262,7 +262,7 @@ impl PySequenceProtocol for EdgeList {
 /// A custom class for the return of edge lists
 ///
 /// This class is a container class for the results of functions that
-/// return a list of node indices. It implements the Python sequence
+/// return a list of edges. It implements the Python sequence
 /// protocol. So you can treat the return as a read-only sequence/list
 /// that is integer indexed. If you want to use it as an iterator you
 /// can by wrapping it in an ``iter()`` that will yield the results in

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -259,10 +259,10 @@ impl PySequenceProtocol for EdgeList {
     }
 }
 
-/// A custom class for the return of edge lists
+/// A custom class for the return of edge lists with weights
 ///
 /// This class is a container class for the results of functions that
-/// return a list of edges. It implements the Python sequence
+/// return a list of edges with weights. It implements the Python sequence
 /// protocol. So you can treat the return as a read-only sequence/list
 /// that is integer indexed. If you want to use it as an iterator you
 /// can by wrapping it in an ``iter()`` that will yield the results in
@@ -273,7 +273,7 @@ impl PySequenceProtocol for EdgeList {
 ///     import retworkx
 ///
 ///     graph = retworkx.generators.directed_path_graph(5)
-///     edges = retworkx.edge_list()
+///     edges = graph.weighted_edge_list()
 ///     # Index based access
 ///     third_element = edges[2]
 ///     # Use as iterator

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -183,3 +183,160 @@ impl PySequenceProtocol for NodeIndices {
         }
     }
 }
+
+/// A custom class for the return of edge lists
+///
+/// This class is a container class for the results of functions that
+/// return a list of node indices. It implements the Python sequence
+/// protocol. So you can treat the return as a read-only sequence/list
+/// that is integer indexed. If you want to use it as an iterator you
+/// can by wrapping it in an ``iter()`` that will yield the results in
+/// order.
+///
+/// For example::
+///
+///     import retworkx
+///
+///     graph = retworkx.generators.directed_path_graph(5)
+///     edges = retworkx.edge_list()
+///     # Index based access
+///     third_element = edges[2]
+///     # Use as iterator
+///     edges_iter = iter(edges)
+///     first_element = next(edges_iter)
+///     second_element = next(edges_iter)
+///
+#[pyclass(module = "retworkx")]
+pub struct EdgeList {
+    pub edges: Vec<(usize, usize)>,
+}
+
+#[pyproto]
+impl<'p> PyObjectProtocol<'p> for EdgeList {
+    fn __richcmp__(
+        &self,
+        other: &'p PySequence,
+        op: pyo3::basic::CompareOp,
+    ) -> PyResult<bool> {
+        let compare = |other: &PySequence| -> PyResult<bool> {
+            if other.len()? as usize != self.edges.len() {
+                return Ok(false);
+            }
+            for i in 0..self.edges.len() {
+                let other_raw = other.get_item(i.try_into().unwrap())?;
+                let other_value: (usize, usize) = other_raw.extract()?;
+                if other_value != self.edges[i] {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        };
+        match op {
+            pyo3::basic::CompareOp::Eq => compare(other),
+            pyo3::basic::CompareOp::Ne => match compare(other) {
+                Ok(res) => Ok(!res),
+                Err(err) => Err(err),
+            },
+            _ => Err(PyNotImplementedError::new_err(
+                "Comparison not implemented",
+            )),
+        }
+    }
+}
+
+#[pyproto]
+impl PySequenceProtocol for EdgeList {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.edges.len())
+    }
+
+    fn __getitem__(&'p self, idx: isize) -> PyResult<(usize, usize)> {
+        if idx >= self.edges.len().try_into().unwrap() {
+            Err(PyIndexError::new_err(format!("Invalid index, {}", idx)))
+        } else {
+            Ok(self.edges[idx as usize])
+        }
+    }
+}
+
+/// A custom class for the return of edge lists
+///
+/// This class is a container class for the results of functions that
+/// return a list of node indices. It implements the Python sequence
+/// protocol. So you can treat the return as a read-only sequence/list
+/// that is integer indexed. If you want to use it as an iterator you
+/// can by wrapping it in an ``iter()`` that will yield the results in
+/// order.
+///
+/// For example::
+///
+///     import retworkx
+///
+///     graph = retworkx.generators.directed_path_graph(5)
+///     edges = retworkx.edge_list()
+///     # Index based access
+///     third_element = edges[2]
+///     # Use as iterator
+///     edges_iter = iter(edges)
+///     first_element = next(edges_iter)
+///     second_element = next(edges_iter)
+///
+#[pyclass(module = "retworkx")]
+pub struct WeightedEdgeList {
+    pub edges: Vec<(usize, usize, PyObject)>,
+}
+
+#[pyproto]
+impl<'p> PyObjectProtocol<'p> for WeightedEdgeList {
+    fn __richcmp__(
+        &self,
+        other: &'p PySequence,
+        op: pyo3::basic::CompareOp,
+    ) -> PyResult<bool> {
+        let compare = |other: &PySequence| -> PyResult<bool> {
+            if other.len()? as usize != self.edges.len() {
+                return Ok(false);
+            }
+            let gil = Python::acquire_gil();
+            let py = gil.python();
+            for i in 0..self.edges.len() {
+                let other_raw = other.get_item(i.try_into().unwrap())?;
+                let other_value: (usize, usize, PyObject) =
+                    other_raw.extract()?;
+                if other_value.0 != self.edges[i].0
+                    || other_value.1 != self.edges[i].1
+                    || self.edges[i].2.as_ref(py).compare(other_value.2)?
+                        != std::cmp::Ordering::Equal
+                {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        };
+        match op {
+            pyo3::basic::CompareOp::Eq => compare(other),
+            pyo3::basic::CompareOp::Ne => match compare(other) {
+                Ok(res) => Ok(!res),
+                Err(err) => Err(err),
+            },
+            _ => Err(PyNotImplementedError::new_err(
+                "Comparison not implemented",
+            )),
+        }
+    }
+}
+
+#[pyproto]
+impl PySequenceProtocol for WeightedEdgeList {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.edges.len())
+    }
+
+    fn __getitem__(&'p self, idx: isize) -> PyResult<(usize, usize, PyObject)> {
+        if idx >= self.edges.len().try_into().unwrap() {
+            Err(PyIndexError::new_err(format!("Invalid index, {}", idx)))
+        } else {
+            Ok(self.edges[idx as usize].clone())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2433,7 +2433,7 @@ pub fn strongly_connected_components(
 ///
 /// :returns: A list describing the cycle. The index of node ids which
 ///     forms a cycle (loop) in the input graph
-/// :rtype: list
+/// :rtype: EdgeList
 #[pyfunction]
 #[text_signature = "(graph, /, source=None)"]
 pub fn digraph_find_cycle(

--- a/src/union.rs
+++ b/src/union.rs
@@ -62,7 +62,7 @@ pub fn digraph_union(
         node_map.insert(node.index(), node_index);
     }
 
-    for edge in b.weighted_edge_list(py) {
+    for edge in b.weighted_edge_list(py).edges {
         let source = edge.0;
         let target = edge.1;
         let edge_weight = edge.2;

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -100,3 +100,77 @@ class TestNodeIndicesComparisons(unittest.TestCase):
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
             self.dag.node_indexes() > [2, 1]
+
+
+class TestEdgeListComparisons(unittest.TestCase):
+
+    def setUp(self):
+        self.dag = retworkx.PyDAG()
+        node_a = self.dag.add_node('a')
+        self.dag.add_child(node_a, 'b', "Edgy")
+
+    def test__eq__match(self):
+        self.assertTrue(self.dag.edge_list() == [(0, 1)])
+
+    def test__eq__not_match(self):
+        self.assertFalse(self.dag.edge_list() == [(1, 2)])
+
+    def test__eq__different_length(self):
+        self.assertFalse(self.dag.edge_list() == [(0, 1), (2, 3)])
+
+    def test__eq__invalid_type(self):
+        self.assertFalse(self.dag.edge_list() == ['a', None])
+
+    def test__ne__match(self):
+        self.assertFalse(self.dag.edge_list() != [(0, 1)])
+
+    def test__ne__not_match(self):
+        self.assertTrue(self.dag.edge_list() != [(1, 2)])
+
+    def test__ne__different_length(self):
+        self.assertTrue(self.dag.edge_list() != [(0, 1), (2, 3)])
+
+    def test__ne__invalid_type(self):
+        self.assertTrue(self.dag.edge_list() != ['a', None])
+
+    def test__gt__not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.dag.edge_list() > [(2, 1)]
+
+
+class TestWeightedEdgeListComparisons(unittest.TestCase):
+
+    def setUp(self):
+        self.dag = retworkx.PyDAG()
+        node_a = self.dag.add_node('a')
+        self.dag.add_child(node_a, 'b', "Edgy")
+
+    def test__eq__match(self):
+        self.assertTrue(self.dag.weighted_edge_list() == [(0, 1, 'Edgy')])
+
+    def test__eq__not_match(self):
+        self.assertFalse(self.dag.weighted_edge_list() == [(1, 2, None)])
+
+    def test__eq__different_length(self):
+        self.assertFalse(
+            self.dag.weighted_edge_list() == [
+                (0, 1, 'Edgy'), (2, 3, 'Not Edgy')])
+
+    def test__eq__invalid_type(self):
+        self.assertFalse(self.dag.weighted_edge_list() == ['a', None])
+
+    def test__ne__match(self):
+        self.assertFalse(self.dag.weighted_edge_list() != [(0, 1, 'Edgy')])
+
+    def test__ne__not_match(self):
+        self.assertTrue(self.dag.weighted_edge_list() != [(1, 2, 'Not Edgy')])
+
+    def test__ne__different_length(self):
+        self.assertTrue(self.dag.node_indexes() != [0, 1, 2, 3])
+
+    def test__ne__invalid_type(self):
+        self.assertTrue(self.dag.weighted_edge_list() != ['a', None])
+
+    def test__gt__not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            self.dag.weighted_edge_list() > [(2, 1, 'Not Edgy')]


### PR DESCRIPTION
This commit adds 2 new return types `EdgeList` and `WeightedEdgeList`
that are used as the return type for functions that return
`Vec<(usize, usize)>` and `Vec<(usize, usize, PyObject)>` respectively.
This custom type implements the Python sequence protocol and can be
used as the list which was previously returned except for where
explicit type checking was used. Just as in #185 and #198 the
advantage here is that for large edge lists the conversion from
Rust to a Python type becomes a large bottleneck. This avoids that
conversion and only does it per element on access.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
