### PR TITLE
Switch HashMap implementation in astar to use hashbrown

### DIFF
--- a/src/astar.rs
+++ b/src/astar.rs
@@ -19,10 +19,11 @@
 // and return any exceptions raised in Python instead of panicking
 
 use std::cmp::Ordering;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
-
+use std::collections::BinaryHeap;
 use std::hash::Hash;
+
+use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::HashMap;
 
 use petgraph::visit::{EdgeRef, GraphBase, IntoEdges, VisitMap, Visitable};
 


### PR DESCRIPTION
In the astar.rs module it keeps a couple of HashMaps to track the path
and scores as the algorithm is going through the graph. Those HashMaps
were using the std collections HashMap type. However, in the rest of
retworkx the hashbrown HashMap is used. This is because the hashbrown
version is faster by default (because it uses a non-DOS resistant hash
function which is faster) and also supports parallelism. This commit
updates the astar.rs module to be consistent with the rest of retworkx
and use hashbrown, which will improve performance of the function.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
