### PR TITLE
Fix documentation and signature issues

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -488,7 +488,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of all the edge data objects in the graph
     /// :rtype: list
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn edges(&self) -> Vec<&PyObject> {
         self.graph
             .edge_indices()
@@ -500,7 +500,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of all the node data objects in the graph
     /// :rtype: list
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn nodes(&self) -> Vec<&PyObject> {
         self.graph
             .node_indices()
@@ -512,7 +512,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of all the node indexes in the graph
     /// :rtype: NodeIndices
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn node_indexes(&self) -> NodeIndices {
         NodeIndices {
             nodes: self.graph.node_indices().map(|node| node.index()).collect(),
@@ -526,7 +526,7 @@ impl PyDiGraph {
     ///
     /// :returns: True if there is an edge false if there is no edge
     /// :rtype: bool
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
@@ -539,7 +539,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the node data for all the child neighbor nodes
     /// :rtype: list
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn successors(&self, node: usize) -> Vec<&PyObject> {
         let index = NodeIndex::new(node);
         let children = self
@@ -562,7 +562,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the node data for all the parent neighbor nodes
     /// :rtype: list
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn predecessors(&self, node: usize) -> Vec<&PyObject> {
         let index = NodeIndex::new(node);
         let parents = self
@@ -586,7 +586,7 @@ impl PyDiGraph {
     ///
     /// :returns: The data object set for the edge
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn get_edge_data(
         &self,
         node_a: usize,
@@ -613,7 +613,7 @@ impl PyDiGraph {
     ///
     /// :returns: The data object set for that node
     /// :raises IndexError: when an invalid node index is provided
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
         let index = NodeIndex::new(node);
         let node = match self.graph.node_weight(index) {
@@ -633,7 +633,7 @@ impl PyDiGraph {
     /// :returns: A list with all the data objects for the edges between nodes
     /// :rtype: list
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn get_all_edge_data(
         &self,
         node_a: usize,
@@ -696,7 +696,7 @@ impl PyDiGraph {
     /// :param int node: The index of the node to remove. If the index is not
     ///     present in the graph it will be ignored and this function will have
     ///     no effect.
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
         let index = NodeIndex::new(node);
         self.graph.remove_node(index);
@@ -725,7 +725,7 @@ impl PyDiGraph {
     ///
     ///     would only retain edges if the input edge to ``node`` had the same
     ///     data payload as the outgoing edge.
-    #[text_signature = "(node, /, use_outgoing=None, condition=None)"]
+    #[text_signature = "(self, node, /, use_outgoing=None, condition=None)"]
     #[args(use_outgoing = "false")]
     pub fn remove_node_retain_edges(
         &mut self,
@@ -792,7 +792,7 @@ impl PyDiGraph {
     /// :rtype: int
     ///
     /// :raises: When the new edge will create a cycle
-    #[text_signature = "(parent, child, edge, /)"]
+    #[text_signature = "(self, parent, child, edge, /)"]
     pub fn add_edge(
         &mut self,
         parent: usize,
@@ -814,7 +814,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of int indices of the newly created edges
     /// :rtype: list
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_edges_from(
         &mut self,
         obj_list: Vec<(usize, usize, PyObject)>,
@@ -839,7 +839,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of int indices of the newly created edges
     /// :rtype: list
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_edges_from_no_data(
         &mut self,
         py: Python,
@@ -864,7 +864,7 @@ impl PyDiGraph {
     ///     where source and target are integer node indices. If the node index
     ///     is not present in the graph, nodes will be added (with a node
     ///     weight of ``None``) to that index.
-    #[text_signature = "(edge_list, /)"]
+    #[text_signature = "(self, edge_list, /)"]
     pub fn extend_from_edge_list(
         &mut self,
         py: Python,
@@ -893,7 +893,7 @@ impl PyDiGraph {
     ///     ``(source, target, weight)`` where source and target are integer
     ///     node indices. If the node index is not present in the graph
     ///     nodes will be added (with a node weight of ``None``) to that index.
-    #[text_signature = "(edge_lsit, /)"]
+    #[text_signature = "(self, edge_lsit, /)"]
     pub fn extend_from_weighted_edge_list(
         &mut self,
         py: Python,
@@ -925,7 +925,7 @@ impl PyDiGraph {
     /// :param int node: The node index to insert between
     /// :param int ref_node: The reference node index to insert ``node``
     ///     between
-    #[text_signature = "(node, ref_nodes, /)"]
+    #[text_signature = "(self, node, ref_nodes, /)"]
     pub fn insert_node_on_in_edges_multiple(
         &mut self,
         py: Python,
@@ -950,7 +950,7 @@ impl PyDiGraph {
     /// :param int node: The node index to insert between
     /// :param int ref_nodes: The list of node indices to insert ``node``
     ///     between
-    #[text_signature = "(node, ref_nodes, /)"]
+    #[text_signature = "(self, node, ref_nodes, /)"]
     pub fn insert_node_on_out_edges_multiple(
         &mut self,
         py: Python,
@@ -975,7 +975,7 @@ impl PyDiGraph {
     /// :param int node: The node index to insert between
     /// :param int ref_node: The reference node index to insert ``node``
     ///     between
-    #[text_signature = "(node, ref_node, /)"]
+    #[text_signature = "(self, node, ref_node, /)"]
     pub fn insert_node_on_in_edges(
         &mut self,
         py: Python,
@@ -998,7 +998,7 @@ impl PyDiGraph {
     /// :param int node: The node index to insert between
     /// :param int ref_node: The reference node index to insert ``node``
     ///     between
-    #[text_signature = "(node, ref_node, /)"]
+    #[text_signature = "(self, node, ref_node, /)"]
     pub fn insert_node_on_out_edges(
         &mut self,
         py: Python,
@@ -1019,7 +1019,7 @@ impl PyDiGraph {
     ///
     /// :raises NoEdgeBetweenNodes: If there are no edges between the nodes
     ///     specified
-    #[text_signature = "(parent, child, /)"]
+    #[text_signature = "(self, parent, child, /)"]
     pub fn remove_edge(&mut self, parent: usize, child: usize) -> PyResult<()> {
         let p_index = NodeIndex::new(parent);
         let c_index = NodeIndex::new(child);
@@ -1038,7 +1038,7 @@ impl PyDiGraph {
     /// Remove an edge identified by the provided index
     ///
     /// :param int edge: The index of the edge to remove
-    #[text_signature = "(edge, /)"]
+    #[text_signature = "(self, edge, /)"]
     pub fn remove_edge_from_index(&mut self, edge: usize) -> PyResult<()> {
         let edge_index = EdgeIndex::new(edge);
         self.graph.remove_edge(edge_index);
@@ -1052,7 +1052,7 @@ impl PyDiGraph {
     ///
     /// :param list index_list: A list of node index pairs to remove from
     ///     the graph
-    #[text_signature = "(index_list, /)"]
+    #[text_signature = "(self, index_list, /)"]
     pub fn remove_edges_from(
         &mut self,
         index_list: Vec<(usize, usize)>,
@@ -1080,7 +1080,7 @@ impl PyDiGraph {
     ///
     /// :returns: The index of the newly created node
     /// :rtype: int
-    #[text_signature = "(obj, /)"]
+    #[text_signature = "(self, obj, /)"]
     pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
         let index = self.graph.add_node(obj);
         Ok(index.index())
@@ -1126,7 +1126,7 @@ impl PyDiGraph {
     ///
     /// :param int u: The source node that is going to be merged
     /// :param int v: The target node that is going to be the new node
-    #[text_signature = "(u, v /)"]
+    #[text_signature = "(self, u, v /)"]
     pub fn merge_nodes(
         &mut self,
         py: Python,
@@ -1198,7 +1198,7 @@ impl PyDiGraph {
     ///
     /// :returns: The index of the newly created child node
     /// :rtype: int
-    #[text_signature = "(parent, obj, edge, /)"]
+    #[text_signature = "(self, parent, obj, edge, /)"]
     pub fn add_child(
         &mut self,
         parent: usize,
@@ -1222,7 +1222,7 @@ impl PyDiGraph {
     ///
     /// :returns index: The index of the newly created parent node
     /// :rtype: int
-    #[text_signature = "(child, obj, edge, /)"]
+    #[text_signature = "(self, child, obj, edge, /)"]
     pub fn add_parent(
         &mut self,
         child: usize,
@@ -1249,7 +1249,7 @@ impl PyDiGraph {
     ///     is the edge data object for all nodes that share an edge with the
     ///     specified node.
     /// :rtype: dict
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn adj(&mut self, node: usize) -> HashMap<usize, &PyObject> {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.neighbors(index);
@@ -1282,7 +1282,7 @@ impl PyDiGraph {
     ///     the value is the edge data object for all nodes that share an
     ///     edge with the specified node.
     /// :rtype: dict
-    #[text_signature = "(node, direction, /)"]
+    #[text_signature = "(self, node, direction, /)"]
     pub fn adj_direction(
         &mut self,
         node: usize,
@@ -1331,7 +1331,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn neighbors(&self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
@@ -1351,7 +1351,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn successor_indices(&mut self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
@@ -1374,7 +1374,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn predecessor_indices(&mut self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
@@ -1398,7 +1398,7 @@ impl PyDiGraph {
     /// :returns: A list of tuples of the form:
     ///     ``(parent_index, node_index, edge_data)```
     /// :rtype: list
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn in_edges(&self, node: usize) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
@@ -1419,7 +1419,7 @@ impl PyDiGraph {
     /// :returns out_edges: A list of tuples of the form:
     ///     ```(node_index, child_index, edge_data)```
     /// :rtype: list
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn out_edges(&self, node: usize) -> Vec<(usize, usize, &PyObject)> {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
@@ -1437,7 +1437,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of int indices of the newly created nodes
     /// :rtype: NodeIndices
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
         let mut out_list: Vec<usize> = Vec::new();
         for obj in obj_list {
@@ -1454,7 +1454,7 @@ impl PyDiGraph {
     ///
     /// :param list index_list: A list of node indicies to remove from the
     ///     the graph.
-    #[text_signature = "(index_list, /)"]
+    #[text_signature = "(self, index_list, /)"]
     pub fn remove_nodes_from(
         &mut self,
         index_list: Vec<usize>,
@@ -1471,7 +1471,7 @@ impl PyDiGraph {
     ///
     /// :returns: The inbound degree for the specified node
     /// :rtype: int
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn in_degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Incoming;
@@ -1484,7 +1484,7 @@ impl PyDiGraph {
     /// :param int node: The index of the node to find the outbound degree of
     /// :returns: The outbound degree for the specified node
     /// :rtype: int
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn out_degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let dir = petgraph::Direction::Outgoing;
@@ -1504,7 +1504,7 @@ impl PyDiGraph {
     ///
     /// :returns: The node object that has an edge to it from the provided
     ///     node index which matches the provided condition
-    #[text_signature = "(node, predicate, /)"]
+    #[text_signature = "(self, node, predicate, /)"]
     pub fn find_adjacent_node_by_edge(
         &self,
         py: Python,
@@ -1580,7 +1580,7 @@ impl PyDiGraph {
     ///       os.remove(tmp_path)
     ///   image
     ///
-    #[text_signature = "(/, node_attr=None, edge_attr=None, graph_attr=None, filename=None)"]
+    #[text_signature = "(self, /, node_attr=None, edge_attr=None, graph_attr=None, filename=None)"]
     pub fn to_dot(
         &self,
         py: Python,
@@ -1649,7 +1649,7 @@ impl PyDiGraph {
     ///   image
     ///
     #[staticmethod]
-    #[text_signature = "(path, /, comment=None, deliminator=None)"]
+    #[text_signature = "(self, path, /, comment=None, deliminator=None)"]
     pub fn read_edge_list(
         py: Python,
         path: &str,
@@ -1808,7 +1808,7 @@ impl PyDiGraph {
     ///       os.remove(tmp_path)
     ///   image
     ///
-    #[text_signature = "(other, node_map, /, node_map_func=None, edge_map_func=None)"]
+    #[text_signature = "(self, other, node_map, /, node_map_func=None, edge_map_func=None)"]
     pub fn compose(
         &mut self,
         py: Python,
@@ -1867,7 +1867,7 @@ impl PyDiGraph {
     ///     the other.
     /// :rtype: PyGraph
     ///
-    #[text_signature = "(nodes, /)"]
+    #[text_signature = "(self, nodes, /)"]
     pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyDiGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
         let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
@@ -1900,6 +1900,7 @@ impl PyDiGraph {
     ///
     /// :returns: True if the graph is symmetric
     /// :rtype: bool
+    #[text_signature = "(self)"]
     pub fn is_symmetric(&self) -> bool {
         let mut edges: HashSet<(NodeIndex, NodeIndex)> = HashSet::new();
         for (source, target) in self
@@ -1929,6 +1930,7 @@ impl PyDiGraph {
     /// :returns: A new PyGraph object with an undirected edge for every
     ///     directed edge in this graph
     /// :rtype: PyGraph
+    #[text_signature = "(self)"]
     pub fn to_undirected(&self, py: Python) -> crate::graph::PyGraph {
         let mut new_graph = StableUnGraph::<PyObject, PyObject>::default();
         let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -334,7 +334,7 @@ impl PyGraph {
     ///
     /// :returns: A list of all the edge data objects in the graph
     /// :rtype: list
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn edges(&self) -> Vec<&PyObject> {
         self.graph
             .edge_indices()
@@ -346,7 +346,7 @@ impl PyGraph {
     ///
     /// :returns: A list of all the node data objects in the graph
     /// :rtype: list
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn nodes(&self) -> Vec<&PyObject> {
         self.graph
             .node_indices()
@@ -358,7 +358,7 @@ impl PyGraph {
     ///
     /// :returns: A list of all the node indexes in the graph
     /// :rtype: NodeIndices
-    #[text_signature = "()"]
+    #[text_signature = "(self)"]
     pub fn node_indexes(&self) -> NodeIndices {
         NodeIndices {
             nodes: self.graph.node_indices().map(|node| node.index()).collect(),
@@ -372,7 +372,7 @@ impl PyGraph {
     ///
     /// :returns: True if there is an edge false if there is no edge
     /// :rtype: bool
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
@@ -391,7 +391,7 @@ impl PyGraph {
     /// :returns: The data object set for the edge
     /// :raises NoEdgeBetweenNodes: when there is no edge between the provided
     ///     nodes
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn get_edge_data(
         &self,
         node_a: usize,
@@ -418,7 +418,7 @@ impl PyGraph {
     ///
     /// :returns: The data object set for that node
     /// :raises IndexError: when an invalid node index is provided
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
         let index = NodeIndex::new(node);
         let node = match self.graph.node_weight(index) {
@@ -438,7 +438,7 @@ impl PyGraph {
     /// :returns: A list with all the data objects for the edges between nodes
     /// :rtype: list
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn get_all_edge_data(
         &self,
         node_a: usize,
@@ -466,6 +466,7 @@ impl PyGraph {
     ///
     /// :returns: An edge list with weights
     /// :rtype: list
+    #[text_signature = "(self)"]
     pub fn edge_list(&self) -> Vec<(usize, usize)> {
         self.edge_references()
             .map(|edge| (edge.source().index(), edge.target().index()))
@@ -480,6 +481,7 @@ impl PyGraph {
     ///
     /// :returns: An edge list with weights
     /// :rtype: list
+    #[text_signature = "(self)"]
     pub fn weighted_edge_list(
         &self,
         py: Python,
@@ -500,7 +502,7 @@ impl PyGraph {
     /// :param int node: The index of the node to remove. If the index is not
     ///     present in the graph it will be ignored and this function will
     ///     have no effect.
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn remove_node(&mut self, node: usize) -> PyResult<()> {
         let index = NodeIndex::new(node);
         self.graph.remove_node(index);
@@ -518,7 +520,7 @@ impl PyGraph {
     /// :param int child: Index of the child node
     /// :param edge: The object to set as the data for the edge. It can be any
     ///     python object.
-    #[text_signature = "(node_a, node_b, edge, /)"]
+    #[text_signature = "(self, node_a, node_b, edge, /)"]
     pub fn add_edge(
         &mut self,
         node_a: usize,
@@ -540,7 +542,7 @@ impl PyGraph {
     ///
     /// :returns: A list of int indices of the newly created edges
     /// :rtype: list
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_edges_from(
         &mut self,
         obj_list: Vec<(usize, usize, PyObject)>,
@@ -565,7 +567,7 @@ impl PyGraph {
     ///
     /// :returns: A list of int indices of the newly created edges
     /// :rtype: list
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_edges_from_no_data(
         &mut self,
         py: Python,
@@ -590,7 +592,7 @@ impl PyGraph {
     ///     where source and target are integer node indices. If the node index
     ///     is not present in the graph, nodes will be added (with a node
     ///     weight of ``None``) to that index.
-    #[text_signature = "(edge_list, /)"]
+    #[text_signature = "(self, edge_list, /)"]
     pub fn extend_from_edge_list(
         &mut self,
         py: Python,
@@ -618,7 +620,7 @@ impl PyGraph {
     ///     ``(source, target, weight)`` where source and target are integer
     ///     node indices. If the node index is not present in the graph,
     ///     nodes will be added (with a node weight of ``None``) to that index.
-    #[text_signature = "(edge_lsit, /)"]
+    #[text_signature = "(self, edge_lsit, /)"]
     pub fn extend_from_weighted_edge_list(
         &mut self,
         py: Python,
@@ -647,7 +649,7 @@ impl PyGraph {
     ///
     /// :raises NoEdgeBetweenNodes: If there are no edges between the nodes
     ///     specified
-    #[text_signature = "(node_a, node_b, /)"]
+    #[text_signature = "(self, node_a, node_b, /)"]
     pub fn remove_edge(
         &mut self,
         node_a: usize,
@@ -670,7 +672,7 @@ impl PyGraph {
     /// Remove an edge identified by the provided index
     ///
     /// :param int edge: The index of the edge to remove
-    #[text_signature = "(edge, /)"]
+    #[text_signature = "(self, edge, /)"]
     pub fn remove_edge_from_index(&mut self, edge: usize) -> PyResult<()> {
         let edge_index = EdgeIndex::new(edge);
         self.graph.remove_edge(edge_index);
@@ -684,7 +686,7 @@ impl PyGraph {
     ///
     /// :param list index_list: A list of node index pairs to remove from
     ///     the graph
-    #[text_signature = "(index_list, /)"]
+    #[text_signature = "(self, index_list, /)"]
     pub fn remove_edges_from(
         &mut self,
         index_list: Vec<(usize, usize)>,
@@ -712,7 +714,7 @@ impl PyGraph {
     ///
     /// :returns: The index of the newly created node
     /// :rtype: int
-    #[text_signature = "(obj, /)"]
+    #[text_signature = "(self, obj, /)"]
     pub fn add_node(&mut self, obj: PyObject) -> PyResult<usize> {
         let index = self.graph.add_node(obj);
         Ok(index.index())
@@ -724,7 +726,7 @@ impl PyGraph {
     ///
     /// :returns indices: A list of int indices of the newly created nodes
     /// :rtype: NodeIndices
-    #[text_signature = "(obj_list, /)"]
+    #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
         let mut out_list: Vec<usize> = Vec::new();
         for obj in obj_list {
@@ -741,7 +743,7 @@ impl PyGraph {
     ///
     /// :param list index_list: A list of node indicies to remove from the
     ///     the graph
-    #[text_signature = "(index_list, /)"]
+    #[text_signature = "(self, index_list, /)"]
     pub fn remove_nodes_from(
         &mut self,
         index_list: Vec<usize>,
@@ -766,7 +768,7 @@ impl PyGraph {
     ///     the value is the edge data object for all nodes that share an
     ///     edge with the specified node.
     /// :rtype: dict
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn adj(&mut self, node: usize) -> PyResult<HashMap<usize, &PyObject>> {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.neighbors(index);
@@ -788,7 +790,7 @@ impl PyGraph {
     ///
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn neighbors(&self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
@@ -805,7 +807,7 @@ impl PyGraph {
     ///
     /// :returns degree: The inbound degree for the specified node
     /// :rtype: int
-    #[text_signature = "(node, /)"]
+    #[text_signature = "(self, node, /)"]
     pub fn degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.edges(index);
@@ -864,7 +866,7 @@ impl PyGraph {
     ///       os.remove(tmp_path)
     ///   image
     ///
-    #[text_signature = "(/, node_attr=None, edge_attr=None, graph_attr=None, filename=None)"]
+    #[text_signature = "(self, /, node_attr=None, edge_attr=None, graph_attr=None, filename=None)"]
     pub fn to_dot(
         &self,
         py: Python,
@@ -933,7 +935,7 @@ impl PyGraph {
     ///   image
     ///
     #[staticmethod]
-    #[text_signature = "(path, /, comment=None, deliminator=None)"]
+    #[text_signature = "(self, path, /, comment=None, deliminator=None)"]
     pub fn read_edge_list(
         py: Python,
         path: &str,
@@ -1089,7 +1091,7 @@ impl PyGraph {
     ///       os.remove(tmp_path)
     ///   image
     ///
-    #[text_signature = "(other, node_map, /, node_map_func=None, edge_map_func=None)"]
+    #[text_signature = "(self, other, node_map, /, node_map_func=None, edge_map_func=None)"]
     pub fn compose(
         &mut self,
         py: Python,
@@ -1148,7 +1150,7 @@ impl PyGraph {
     ///     the other.
     /// :rtype: PyGraph
     ///
-    #[text_signature = "(nodes, /)"]
+    #[text_signature = "(self, nodes, /)"]
     pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
         let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,24 +256,37 @@ fn is_isomorphic(
     Ok(res)
 }
 
-/// [Graph] Return a new PyDiGraph by forming a union from`a` and `b` graphs.
+/// Return a new PyDiGraph by forming a union from two input PyDiGraph objects
 ///
-/// The algorithm has three phases:
-///  - adds all nodes from `b` to `a`. operates in O(n), n being number of nodes in `b`.
-///  - merges nodes from `b` over `a` given that:
-///     - `merge_nodes` is `true`. operates in O(n^2), n being number of nodes in `b`.
-///     - respective node in`b` and `a` share the same weight
-///  - adds all edges from `b` to `a`.
-///     - `merge_edges` is `true`
-///     - respective edge in`b` and `a` share the same weight
+/// The algorithm in this function operates in three phases:
 ///
-/// with the same weight in graphs `a` and `b` and merged those nodes.
+///  1. Add all the nodes from  ``second`` into ``first``. operates in O(n),
+///     with n being number of nodes in `b`.
+///  2. Merge nodes from ``second`` over ``first`` given that:
 ///
-/// The nodes from graph `b` will replace nodes from `a`.
+///     - The ``merge_nodes`` is ``True``. operates in O(n^2), with n being the
+///       number of nodes in ``second``.
+///     - The respective node in ``second`` and ``first`` share the same
+///       weight/data payload.
 ///
-///  At this point, only `PyDiGraph` is supported.
+///  3. Adds all the edges from ``second`` to ``first``. If the ``merge_edges``
+///     parameter is ``True`` and the respective edge in ``second`` and
+///     first`` share the same weight/data payload they will be merged
+///     together.
+///
+///  :param PyDiGraph first: The first directed graph object
+///  :param PyDiGraph second: The second directed graph object
+///  :param bool merge_nodes: If set to ``True`` nodes will be merged between
+///     ``second`` and ``first`` if the weights are equal.
+///  :param bool merge_edges: If set to ``True`` edges will be merged between
+///     ``second`` and ``first`` if the weights are equal.
+///
+///  :returns: A new PyDiGraph object that is the union of ``second`` and
+///     ``first``. It's worth noting the weight/data payload objects are
+///     passed by reference from ``first`` and ``second`` to this new object.
+///  :rtype: PyDiGraph
 #[pyfunction]
-#[text_signature = "(first, second, /)"]
+#[text_signature = "(first, second, merge_nodes, merge_edges, /)"]
 fn digraph_union(
     py: Python,
     first: &digraph::PyDiGraph,


### PR DESCRIPTION
This commit fixes some issues with the documentation and text_signature
attribute for methods. The documentation of digraph_union needed a bit
of cleanup and more details to explain how it works. The other issue
fixed here is the text_signature attribute for methods were missing the
'self' parameter. While the self is implicit in the typical call,
without it in the text_signature attribute the sphinx builds assume the
first parameter in the signature is self, and removes it from the
documentation. This commit fixes this by adding self to all the method
signature attributes.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
