### PR TITLE
Switch is_directed_acyclic_graph to use toposort internally

### DIFF
--- a/releasenotes/notes/fix-segfault-is_dag_fn-8335e900ffca6af9.yaml
+++ b/releasenotes/notes/fix-segfault-is_dag_fn-8335e900ffca6af9.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a potential segfault that could occur when calling
+    :func:`~retworkx.is_directed_acyclic_graph` with a a very deep
+    :class:`~retworkx.PyDiGraph` object as reported in
+    `Qiskit/qiskit-terra#5502 <https://github.com/Qiskit/qiskit-terra/issues/5502>`__.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,8 +231,10 @@ pub fn is_weakly_connected(graph: &digraph::PyDiGraph) -> PyResult<bool> {
 #[pyfunction]
 #[text_signature = "(graph, /)"]
 fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
-    let cycle_detected = algo::is_cyclic_directed(graph);
-    !cycle_detected
+    match algo::toposort(graph, None) {
+        Ok(_nodes) => true,
+        Err(_err) => false,
+    }
 }
 
 /// Determine if 2 graphs are structurally isomorphic

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -209,6 +209,15 @@ class TestEdges(unittest.TestCase):
         with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edges_from([(node_a, node_c, {}), (node_c, node_b, {})])
 
+    def test_is_directed_acyclic_graph(self):
+        dag = retworkx.generators.directed_path_graph(1000)
+        res = retworkx.is_directed_acyclic_graph(dag)
+        self.assertTrue(res)
+
+    def test_is_directed_acyclic_graph_false(self):
+        digraph = retworkx.generators.directed_cycle_graph(1000)
+        self.assertFalse(retworkx.is_directed_acyclic_graph(digraph))
+
     def test_add_edge_from_no_data(self):
         dag = retworkx.PyDAG()
         nodes = list(range(4))


### PR DESCRIPTION
Previously the retworkx.is_directed_acyclic_graph() function was
internally using the petgraph::algo::is_cyclic_directed function to look
for a potential cycle in the graph. However, as noted in the docs[1]
this function is recursive and as reported in Qiskit/qiskit-terra#5502
with very large graphs this is causing segfaults. To avoid this
potential issue this commit changes the internal implementation to use
petgraph::algo::toposort which isn't recursive and should be more
reliable.

Fixes: Qiskit/qiskit-terra#5502

[1] https://docs.rs/petgraph/0.5.1/petgraph/algo/fn.is_cyclic_directed.html

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
