### PR TITLE
Fix the read the docs builds

### DIFF
--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -11,3 +11,5 @@ dependencies:
     - jupyter-sphinx==0.2.3
     - pydot
     - pillow
+    - qiskit-sphinx-theme>=1.7
+    - reno>=3.2.0


### PR DESCRIPTION
In #214 we updated the documentation configuration to use the new
qiskit sphinx theme to be consistent with qiskit's documentation and
also add the use of reno for release notes. However, that PR did not
update the conda environment file used by read the docs for buidling the
documetation to include the new requiremetns. This commit corrects that
oversight and adds the missing dependencies to the docs builds.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
