### PR TITLE
Make clippy changes from rust 1.49.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2076,7 +2076,7 @@ pub fn directed_gnp_random_graph(
     for x in 0..num_nodes {
         inner_graph.add_node(x.to_object(py));
     }
-    if probability < 0.0 || probability > 1.0 {
+    if !(0.0..=1.0).contains(&probability) {
         return Err(PyValueError::new_err(
             "Probability out of range, must be 0 <= p <= 1",
         ));
@@ -2183,7 +2183,7 @@ pub fn undirected_gnp_random_graph(
     for x in 0..num_nodes {
         inner_graph.add_node(x.to_object(py));
     }
-    if probability < 0.0 || probability > 1.0 {
+    if !(0.0..=1.0).contains(&probability) {
         return Err(PyValueError::new_err(
             "Probability out of range, must be 0 <= p <= 1",
         ));


### PR DESCRIPTION
Rust 1.49.0 was recently released which included a new version of
clippy with new checks. When running cargo clippy with 1.49.0 a new
warning was introduced. This commit makes the style change so that
clippy doesn't highlight any issues.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
