### PR TITLE
Add max weight matching function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Download grcov
         run: curl -L https://github.com/mozilla/grcov/releases/download/v0.5.9/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - name: Install deps
-        run: pip install -U setuptools-rust
+        run: pip install -U setuptools-rust networkx
       - name: Build retworkx
         run: python setup.py develop
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,9 @@ before_install:
   - sh tools/install_rust.sh
   - export PATH=~/.cargo/bin:$PATH
   - which python
-  - pip install -U pip virtualenv
-install:
-  - virtualenv test-venv
-  - test-venv/bin/pip install -U .
+  - pip install -U pip virtualenv tox
 script:
-  - cd tests && ../test-venv/bin/python -m unittest discover .
+  - tox -epy
 stages:
   - name: Linux non-x86_64
     if: tag IS blank

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - sh tools/install_rust.sh
         - export PATH=~/.cargo/bin:$PATH
         - which python
-        - pip install -U pip virtualenv
+        - pip install -U pip virtualenv tox
         - rustup default 1.49.0
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c88d9506e2e9230f6107701b7d8425f4cb3f6df108ec3042a26e936666da5"
+checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
 dependencies = [
  "quote",
  "syn",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,12 +35,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "crossbeam-channel"
@@ -53,34 +59,35 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
+ "loom",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
 dependencies = [
  "quote",
  "syn",
@@ -97,6 +104,19 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "generator"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
 
 [[package]]
 name = "getrandom"
@@ -211,9 +231,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "lock_api"
@@ -222,6 +242,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loom"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -322,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -425,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -456,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -514,9 +554,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "retworkx"
@@ -532,6 +575,18 @@ dependencies = [
  "rand_pcg",
  "rayon",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 
 [[package]]
 name = "lock_api"
@@ -547,9 +547,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "syn"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cb8b1b4ebf86a89ee88cbd201b022b94138c623644d035185c84d3f41b7e66"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -570,9 +570,9 @@ checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -87,6 +87,7 @@ Algorithm Functions
    retworkx.digraph_dfs_edges
    retworkx.digraph_find_cycle
    retworkx.digraph_union
+   retworkx.max_weight_matching
 
 Exceptions
 ----------

--- a/releasenotes/notes/add-max-weight-matching-089ba67668b3b071.yaml
+++ b/releasenotes/notes/add-max-weight-matching-089ba67668b3b071.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add a new function, :func:`~retworkx.max_weight_matching` for computing the
+    maximum-weighted matching for a :class:`~retworkx.PyGraph` object.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2518,10 +2518,10 @@ pub fn cycle_basis(
 /// :param int default_weight: The ``int`` value to use for all edge weights
 ///     in the graph if ``weight_fn`` is not specified. Defaults to ``1``.
 ///
-/// :returns: A dictionary of matching, the key is the node index and the
-///     value is it's matched node index. Note that both directions will be
-///     listed in the output, for example: ``{0: 1, 1: 0}``.
-/// :rtype: dict
+/// :returns: A set of tuples ofthe matching, Note that only a single
+///     direction will be listed in the output, for example:
+///     ``{(0, 1),}``.
+/// :rtype: set
 ///
 /// .. [1] "Efficient Algorithms for Finding Maximum Matching in Graphs",
 ///     Zvi Galil, ACM Computing Surveys, 1986.
@@ -2534,7 +2534,7 @@ pub fn max_weight_matching(
     max_cardinality: bool,
     weight_fn: Option<PyObject>,
     default_weight: i128,
-) -> PyResult<HashMap<usize, usize>> {
+) -> PyResult<HashSet<(usize, usize)>> {
     max_weight_matching::max_weight_matching(
         py,
         graph,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2483,7 +2483,7 @@ pub fn cycle_basis(
 /// A maximal matching cannot add more edges and still be a matching.
 /// The cardinality of a matching is the number of matched edges.
 ///
-/// This function takes time :math:`O(n^3)` where ``n` is the number of nodes
+/// This function takes time :math:`O(n^3)` where ``n`` is the number of nodes
 /// in the graph.
 ///
 /// This method is based on the "blossom" method for finding augmenting
@@ -2493,7 +2493,7 @@ pub fn cycle_basis(
 /// :param PyGraph graph: The undirected graph to compute the max weight
 ///     matching for. Expects to have no parallel edges (multigraphs are
 ///     untested currently).
-/// :param max_cardinality bool: If True, compute the maximum-cardinality
+/// :param bool max_cardinality: If True, compute the maximum-cardinality
 ///     matching with maximum weight among all maximum-cardinality matchings.
 ///     Defaults False.
 /// :param callable weight_fn: An optional callable that will be passed a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2517,6 +2517,9 @@ pub fn cycle_basis(
 ///     edge weights.
 /// :param int default_weight: The ``int`` value to use for all edge weights
 ///     in the graph if ``weight_fn`` is not specified. Defaults to ``1``.
+/// :param bool verify_optimum: A boolean flag to run a check that the found
+///     solution is optimum. If set to true an exception will be raised if
+///     the found solution is not optimum. This is mostly useful for testing.
 ///
 /// :returns: A set of tuples ofthe matching, Note that only a single
 ///     direction will be listed in the output, for example:
@@ -2526,14 +2529,19 @@ pub fn cycle_basis(
 /// .. [1] "Efficient Algorithms for Finding Maximum Matching in Graphs",
 ///     Zvi Galil, ACM Computing Surveys, 1986.
 ///
-#[pyfunction(max_cardinality = "false", default_weight = 1)]
-#[text_signature = "(graph, /, max_cardinality=False, weight_fn=None, default_weight=1)"]
+#[pyfunction(
+    max_cardinality = "false",
+    default_weight = 1,
+    verify_optimum = "false"
+)]
+#[text_signature = "(graph, /, max_cardinality=False, weight_fn=None, default_weight=1, verify_optimum=False)"]
 pub fn max_weight_matching(
     py: Python,
     graph: &graph::PyGraph,
     max_cardinality: bool,
     weight_fn: Option<PyObject>,
     default_weight: i128,
+    verify_optimum: bool,
 ) -> PyResult<HashSet<(usize, usize)>> {
     max_weight_matching::max_weight_matching(
         py,
@@ -2541,6 +2549,7 @@ pub fn max_weight_matching(
         max_cardinality,
         weight_fn,
         default_weight,
+        verify_optimum,
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod generators;
 mod graph;
 mod iterators;
 mod k_shortest_path;
+mod max_weight_matching;
 mod union;
 
 use std::cmp::{Ordering, Reverse};
@@ -2475,6 +2476,61 @@ pub fn cycle_basis(
     cycles
 }
 
+/// Compute a maximum-weighted matching for a :class:`~retworkx.PyGraph`
+///
+/// A matching is a subset of edges in which no node occurs more than once.
+/// The weight of a matching is the sum of the weights of its edges.
+/// A maximal matching cannot add more edges and still be a matching.
+/// The cardinality of a matching is the number of matched edges.
+///
+/// This function takes time :math:`O(n^3)` where ``n` is the number of nodes
+/// in the graph.
+///
+/// This method is based on the "blossom" method for finding augmenting
+/// paths and the "primal-dual" method for finding a matching of maximum
+/// weight, both methods invented by Jack Edmonds [1]_.
+///
+/// :param PyGraph graph: The undirected graph to compute the max weight
+///     matching for. Expects to have no parallel edges (multigraphs are
+///     untested currently).
+/// :param max_cardinality bool: If True, compute the maximum-cardinality
+///     matching with maximum weight among all maximum-cardinality matchings.
+///     Defaults False.
+/// :param callable weight_fn: An optional callable that will be passed a
+///     single argument the edge object for each edge in the graph. It is
+///     expected to return an ``int`` weight for that edge. For example,
+///     if the weights are all integers you can use: ``lambda x: x``. If not
+///     specified the value for ``default_weight`` will be used for all
+///     edge weights.
+/// :param int default_weight: The ``int`` value to use for all edge weights
+///     in the graph if ``weight_fn`` is not specified. Defaults to ``1``.
+///
+/// :returns: A dictionary of matching, the key is the node index and the
+///     value is it's matched node index. Note that both directions will be
+///     listed in the output, for example: ``{0: 1, 1: 0}``.
+/// :rtype: dict
+///
+/// .. [1] "Efficient Algorithms for Finding Maximum Matching in Graphs",
+///     Zvi Galil, ACM Computing Surveys, 1986.
+///
+#[pyfunction(max_cardinality = "false", default_weight = 1)]
+#[text_signature = "(graph, /, max_cardinality=False, weight_fn=None, default_weight=1)"]
+pub fn max_weight_matching(
+    py: Python,
+    graph: &graph::PyGraph,
+    max_cardinality: bool,
+    weight_fn: Option<PyObject>,
+    default_weight: i128,
+) -> PyResult<HashMap<usize, usize>> {
+    max_weight_matching::max_weight_matching(
+        py,
+        graph,
+        max_cardinality,
+        weight_fn,
+        default_weight,
+    )
+}
+
 /// Compute the strongly connected components for a directed graph
 ///
 /// This function is implemented using Kosaraju's algorithm
@@ -2644,6 +2700,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_find_cycle))?;
     m.add_wrapped(wrap_pyfunction!(digraph_k_shortest_path_lengths))?;
     m.add_wrapped(wrap_pyfunction!(graph_k_shortest_path_lengths))?;
+    m.add_wrapped(wrap_pyfunction!(max_weight_matching))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
     m.add_class::<iterators::BFSSuccessors>()?;

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -102,7 +102,6 @@ fn assign_label(
     labels[b] = Some(t);
     label_ends[b] = p;
     label_ends[w] = p;
-    label_ends[b] = p;
     best_edge[w] = None;
     best_edge[b] = None;
     if t == 1 {
@@ -356,7 +355,7 @@ fn expand_blossom(
     label_ends: &mut Vec<Option<usize>>,
     best_edge: &mut Vec<Option<usize>>,
     queue: &mut Vec<usize>,
-    blossom_base: &[Option<usize>],
+    blossom_base: &mut Vec<Option<usize>>,
     endpoints: &[usize],
     mate: &[Option<usize>],
     blossom_endpoints: &mut Vec<Vec<usize>>,
@@ -563,6 +562,7 @@ fn expand_blossom(
     label_ends[blossom] = None;
     blossom_children[blossom].clear();
     blossom_endpoints[blossom].clear();
+    blossom_base[blossom] = None;
     best_edge[blossom] = None;
     unused_blossoms.push(blossom);
     Ok(())
@@ -1249,7 +1249,7 @@ pub fn max_weight_matching(
                     &mut label_ends,
                     &mut best_edge,
                     &mut queue,
-                    &blossom_base,
+                    &mut blossom_base,
                     &endpoints,
                     &mate,
                     &mut blossom_endpoints,
@@ -1283,7 +1283,7 @@ pub fn max_weight_matching(
                     &mut label_ends,
                     &mut best_edge,
                     &mut queue,
-                    &blossom_base,
+                    &mut blossom_base,
                     &endpoints,
                     &mate,
                     &mut blossom_endpoints,

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -291,7 +291,8 @@ fn add_blossom(
         in_blossoms[node] = blossom;
     }
     // Compute blossom_best_edges[blossom]
-    let mut best_edge_to: Vec<Option<usize>> = vec![None; 2 * num_nodes];
+    let mut best_edge_to: HashMap<usize, usize> =
+        HashMap::with_capacity(2 * num_nodes);
     for bv_ref in &blossom_children[blossom] {
         let bv = *bv_ref;
         // This sub-blossom does not have a list of least-slack edges;
@@ -317,15 +318,15 @@ fn add_blossom(
                 let blossom_j = in_blossoms[j];
                 if blossom_j != blossom
                     && labels[blossom_j] == Some(1)
-                    && (best_edge_to[blossom_j].is_none()
+                    && (best_edge_to.get(&blossom_j).is_none()
                         || slack(edge_index, &dual_var, &edges)
                             < slack(
-                                best_edge_to[blossom_j].unwrap(),
+                                best_edge_to[&blossom_j],
                                 &dual_var,
                                 &edges,
                             ))
                 {
-                    best_edge_to[blossom_j] = Some(edge_index);
+                    best_edge_to.insert(blossom_j, edge_index);
                 }
             }
         }
@@ -333,11 +334,7 @@ fn add_blossom(
         blossom_best_edges[bv].clear();
         best_edge[bv] = None;
     }
-    blossom_best_edges[blossom] = best_edge_to
-        .iter()
-        .filter(|x| x.is_some())
-        .map(|x| x.unwrap())
-        .collect();
+    blossom_best_edges[blossom] = best_edge_to.values().map(|x| *x).collect();
     //select best_edge[blossom]
     best_edge[blossom] = None;
     for edge_index in &blossom_best_edges[blossom] {

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -868,8 +868,8 @@ pub fn max_weight_matching(
     // the blossom.
     let mut labels: Vec<Option<usize>>;
     // If b is a labeled top-level blossom,
-    // label_ends[b] is the remote endpoint of the edge through which b is
-    // obtained. Its label, or None if b's base vertex is single.
+    // label_ends[b] is the remote endpoint of the edge through which b
+    // obtained its label, or None if b's base vertex is single.
     // If v is a vertex inside a T-blossom and label[v] == 2,
     // label_ends[v] is the remote endpoint of the edge through which v is
     // reachable from outside the blossom

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -414,7 +414,7 @@ fn expand_blossom(
             }
         }
     }
-    // if we expand a T-blossom during a stage, its a sub-blossoms must be
+    // if we expand a T-blossom during a stage, its sub-blossoms must be
     // relabeled
     if !end_stage && labels[blossom] == Some(2) {
         // start at the sub-blossom through which the expanding blossom
@@ -797,99 +797,6 @@ fn augment_matching(
         }
     }
 }
-
-///// Swap matched/unmatched edges over an alternating path between two
-///// single vertices. The augmenting path runs through the edge, which
-///// connects a pair of S vertices.
-//fn verify_optimum(
-//    max_cardinality: bool,
-//    num_nodes: usize,
-//    num_edges: usize,
-//    edges: &[(usize, usize, i128)],
-//    endpoints: &[usize],
-//    dual_var: &[i128],
-//    blossom_parents: &[Option<usize>],
-//    blossom_endpoints: &[BlossomList],
-//    blossom_base: &[Option<usize>],
-//    mate: &[Option<usize>],
-//) -> bool {
-//    let dual_var_node_min: i128 = *dual_var[..num_nodes].iter().min().unwrap();
-//    let node_dual_offset: i128 = if max_cardinality {
-//        // Vertices may have negative dual;
-//        // find a constant non-negative number to add to all vertex duals.
-//        max(0, -dual_var_node_min)
-//    } else {
-//        0
-//    };
-//    if dual_var_node_min + node_dual_offset < 0 {
-//        return false;
-//    }
-//    if *dual_var[num_nodes..].iter().min().unwrap() < 0 {
-//        return false;
-//    }
-//    // 0. all edges have non-negative slack and
-//    // 1. all matched edges have zero slack;
-//    for (edge, (i, j, weight)) in edges.iter().enumerate().take(num_edges) {
-//        let mut s = dual_var[*i] + dual_var[*j] - 2 * weight;
-//        let mut i_blossoms: Vec<usize> = vec![*i];
-//        let mut j_blossoms: Vec<usize> = vec![*j];
-//        while blossom_parents[*i_blossoms.last().unwrap()].is_some() {
-//            i_blossoms
-//                .push(blossom_parents[*i_blossoms.last().unwrap()].unwrap());
-//        }
-//        while blossom_parents[*j_blossoms.last().unwrap()].is_some() {
-//            j_blossoms
-//                .push(blossom_parents[*j_blossoms.last().unwrap()].unwrap());
-//        }
-//        i_blossoms.reverse();
-//        j_blossoms.reverse();
-//        for (blossom_i, blossom_j) in i_blossoms.iter().zip(j_blossoms.iter()) {
-//            if blossom_i != blossom_j {
-//                break;
-//            }
-//            s += 2 * dual_var[*blossom_i];
-//        }
-//        if s < 0 {
-//            return false;
-//        }
-//        if mate[*i].unwrap() / 2 == edge || mate[*j].unwrap() / 2 == edge {
-//            if mate[*i].unwrap() / 2 != edge || mate[*j].unwrap() / 2 != edge {
-//                return false;
-//            }
-//            if s == 0 {
-//                return false;
-//            }
-//        }
-//    }
-//    // 2. all single vertices have zero dual value;
-//    for node in 0..num_nodes {
-//        if mate[node].is_none() && dual_var[node] + node_dual_offset != 0 {
-//            return false;
-//        }
-//    }
-//    // 3. all blossoms with positive dual value are full.
-//    for blossom in num_nodes..2 * num_nodes {
-//        if blossom_base[blossom].is_some() && dual_var[blossom] > 0 {
-//            if blossom_endpoints[blossom].nodes.len() % 2 != 1 {
-//                return false;
-//            }
-//            for p in [
-//                blossom_endpoints[blossom].nodes[1],
-//                blossom_endpoints[blossom].nodes[2],
-//            ]
-//            .iter()
-//            {
-//                if mate[endpoints[*p]].unwrap() != *p ^ 1 {
-//                    return false;
-//                }
-//                if mate[endpoints[*p ^ 1]].unwrap() != *p {
-//                    return false;
-//                }
-//            }
-//        }
-//    }
-//    true
-//}
 
 /// Compute a maximum-weighted matching in the general undirected weighted
 /// graph given by "edges". If `max_cardinality` is true, only
@@ -1428,20 +1335,6 @@ pub fn max_weight_matching(
             }
         }
     }
-    //    if !verify_optimum(
-    //        max_cardinality,
-    //        num_nodes,
-    //        num_edges,
-    //        &edges,
-    //        &endpoints,
-    //        &dual_var,
-    //        &blossom_parents,
-    //        &blossom_endpoints,
-    //        &blossom_base,
-    //        &mate,
-    //    ) {
-    //        return Err(PyException::new_err("Solution found is not optimal"));
-    //    }
 
     // Transform mate[] such that mate[v] is the vertex to which v is paired
     // Also handle holes in node indices from graph removals by mapping

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -1090,7 +1090,7 @@ pub fn max_weight_matching(
                             label_ends[w] = Some(*p ^ 1);
                         }
                     } else if labels[in_blossoms[w]] == Some(1) {
-                        // Leep track of the least-slack non-allowable edge to
+                        // Keep track of the least-slack non-allowable edge to
                         // a different S-blossom
                         let blossom = in_blossoms[v];
                         if best_edge[blossom].is_none()

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -624,13 +624,13 @@ fn augment_blossom(
         // Step to the next sub-blossom and augment it recursively.
         j += j_step;
 
-        if j < 0 {
+        tmp = if j < 0 {
             let length = blossom_children[blossom].len();
             let index = length - j.abs() as usize;
-            tmp = blossom_children[blossom][index];
+            blossom_children[blossom][index]
         } else {
-            tmp = blossom_children[blossom][j as usize]
-        }
+            blossom_children[blossom][j as usize]
+        };
         let p = if j < 0 {
             let length = blossom_endpoints[blossom].len();
             let index = length - j.abs() as usize - endpoint_trick;
@@ -879,11 +879,7 @@ pub fn max_weight_matching(
     // If v is a top-level vertex, v is itself a blossom (a trivial blossom)
     // and in_blossoms[v] == v.
     // Initially all nodes are top-level trivial blossoms.
-    let mut in_blossoms: Vec<usize> = graph
-        .graph
-        .node_indices()
-        .map(|node| node.index())
-        .collect();
+    let mut in_blossoms: Vec<usize> = (0..num_nodes).collect();
     // if b is a sub-blossom
     // blossom_parents[b] is its immediate parent
     // If b is a top-level blossom, blossom_parents[b] is None

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -476,28 +476,25 @@ fn expand_blossom(
                 mate,
             )?;
             // Step to the next S-sub-blossom and note it's forwward endpoint.
-            if j < 0 {
+            let endpoint_index = if j < 0 {
+                let tmp = j - endpoint_trick as i128;
                 let length = blossom_endpoints[blossom].nodes.len();
-                let index = length - j.abs() as usize;
-                allowed_edge[blossom_endpoints[blossom].nodes
-                    [index - endpoint_trick]
-                    / 2] = true;
+                let index = length - tmp.abs() as usize;
+                blossom_endpoints[blossom].nodes[index]
             } else {
-                allowed_edge[blossom_endpoints[blossom].nodes
-                    [j as usize - endpoint_trick]
-                    / 2] = true;
-            }
+                blossom_endpoints[blossom].nodes[j as usize - endpoint_trick]
+            };
+            allowed_edge[endpoint_index / 2] = true;
             j += j_step;
-            if j < 0 {
+            p = if j < 0 {
+                let tmp = j - endpoint_trick as i128;
                 let length = blossom_endpoints[blossom].nodes.len();
-                let index = length - j.abs() as usize;
-                p = blossom_endpoints[blossom].nodes[index - endpoint_trick]
-                    ^ endpoint_trick;
+                let index = length - tmp.abs() as usize;
+                blossom_endpoints[blossom].nodes[index] ^ endpoint_trick
             } else {
-                p = blossom_endpoints[blossom].nodes
-                    [j as usize - endpoint_trick]
-                    ^ endpoint_trick;
-            }
+                blossom_endpoints[blossom].nodes[j as usize - endpoint_trick]
+                    ^ endpoint_trick
+            };
             // Step to the next T-sub-blossom.
             allowed_edge[p / 2] = true;
             j += j_step;
@@ -518,6 +515,7 @@ fn expand_blossom(
         label_ends[blossom_v] = Some(p);
         best_edge[blossom_v] = None;
         // Continue along the blossom until we get back to entry_child
+        j += j_step;
         let mut j_index = if j < 0 {
             let length = blossom_children[blossom].nodes.len();
             length - j.abs() as usize

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -1,0 +1,1410 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Needed to pass shared state between functions
+// closures don't work because of recurssion
+#![allow(clippy::too_many_arguments)]
+// Allow single character names to match naming convention from
+// paper
+#![allow(clippy::many_single_char_names)]
+
+use std::cmp::max;
+use std::mem;
+
+use hashbrown::HashMap;
+
+use petgraph::graph::NodeIndex;
+use petgraph::visit::{EdgeRef, IntoEdgeReferences};
+
+use crate::graph::PyGraph;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+fn weight_callable(
+    py: Python,
+    weight: PyObject,
+    weight_fn: &Option<PyObject>,
+    default: i128,
+) -> PyResult<i128> {
+    match weight_fn {
+        Some(weight_fn) => {
+            let res = weight_fn.call1(py, (weight,))?;
+            res.extract(py)
+        }
+        None => Ok(default),
+    }
+}
+
+// An inner container for a bloossom Vec
+// if exists is false it hasn't been initialized yet
+struct BlossomList {
+    exists: bool,
+    nodes: Vec<usize>,
+}
+
+/// Return 2 * slack of edge k (does not work inside blossoms).
+fn slack(
+    edge_index: usize,
+    dual_var: &[i128],
+    edges: &[(usize, usize, i128)],
+) -> i128 {
+    let (source_index, target_index, weight) = edges[edge_index];
+    dual_var[source_index] + dual_var[target_index] - 2 * weight
+}
+
+/// Generate the leaf vertices of a blossom.
+fn blossom_leaves(
+    blossom: usize,
+    num_nodes: usize,
+    blossom_children: &[BlossomList],
+) -> PyResult<Vec<usize>> {
+    let mut out_vec: Vec<usize> = Vec::new();
+    if blossom < num_nodes {
+        out_vec.push(blossom);
+    } else {
+        let child_blossom = &blossom_children[blossom];
+        if !child_blossom.exists {
+            return Err(PyException::new_err("child blossom not initialized"));
+        }
+        for c in &child_blossom.nodes {
+            let child = *c;
+            if child < num_nodes {
+                out_vec.push(child);
+            } else {
+                for v in blossom_leaves(child, num_nodes, blossom_children)? {
+                    out_vec.push(v);
+                }
+            }
+        }
+    }
+    Ok(out_vec)
+}
+
+/// Assign label t to the top-level blossom containing vertex w
+/// and record the fact that w was reached through the edge with
+/// remote endpoint p.
+fn assign_label(
+    w: usize,
+    t: usize,
+    p: Option<usize>,
+    num_nodes: usize,
+    in_blossoms: &[usize],
+    labels: &mut Vec<Option<usize>>,
+    label_ends: &mut Vec<Option<usize>>,
+    best_edge: &mut Vec<Option<usize>>,
+    queue: &mut Vec<usize>,
+    blossom_children: &[BlossomList],
+    blossom_base: &[Option<usize>],
+    endpoints: &[usize],
+    mate: &[Option<usize>],
+) -> PyResult<()> {
+    let b = in_blossoms[w];
+    assert!(labels[w] == Some(0) && labels[b] == Some(0));
+    labels[w] = Some(t);
+    labels[b] = Some(t);
+    label_ends[b] = p;
+    label_ends[w] = p;
+    label_ends[b] = p;
+    best_edge[w] = None;
+    best_edge[b] = None;
+    if t == 1 {
+        // b became an S-vertex/blossom; add it(s verticies) to the queue
+        queue.append(&mut blossom_leaves(b, num_nodes, &blossom_children)?);
+    } else if t == 2 {
+        // b became a T-vertex/blossom; assign label S to its mate.
+        // (If b is a non-trivial blossom, its base is the only vertex
+        // with an external mate.)
+        let blossom_index: usize = b;
+        let base: usize = blossom_base[blossom_index].unwrap();
+        assert!(mate[base].is_some());
+        assign_label(
+            endpoints[mate[base].unwrap()],
+            1,
+            match mate[base] {
+                Some(p) => Some(p ^ 1),
+                None => None,
+            },
+            num_nodes,
+            in_blossoms,
+            labels,
+            label_ends,
+            best_edge,
+            queue,
+            blossom_children,
+            blossom_base,
+            endpoints,
+            mate,
+        )?;
+    }
+    Ok(())
+}
+
+/// Trace back from vertices v and w to discover either a new blossom
+/// or an augmenting path. Return the base vertex of the new blossom or None.
+fn scan_blossom(
+    node_a: usize,
+    node_b: usize,
+    in_blossoms: &[usize],
+    blossom_base: &[Option<usize>],
+    endpoints: &[usize],
+    labels: &mut Vec<Option<usize>>,
+    label_ends: &[Option<usize>],
+    mate: &[Option<usize>],
+) -> Option<usize> {
+    let mut v: Option<usize> = Some(node_a);
+    let mut w: Option<usize> = Some(node_b);
+    // Trace back from v and w, placing breadcrumbs as we go
+    let mut path: Vec<usize> = Vec::new();
+    let mut base: Option<usize> = None;
+    while v.is_some() || w.is_some() {
+        // Look for a breadcrumb in v's blossom or put a new breadcrump
+        let mut blossom = in_blossoms[v.unwrap()];
+        if labels[blossom].is_none() || labels[blossom].unwrap() & 4 > 0 {
+            base = blossom_base[blossom];
+            break;
+        }
+        assert!(labels[blossom] == Some(1));
+        path.push(blossom);
+        labels[blossom] = Some(5);
+        // Trace one step bacl.
+        assert!(label_ends[blossom] == mate[blossom_base[blossom].unwrap()]);
+        if label_ends[blossom].is_none() {
+            // The base of blossom is single; stop tracing this path
+            v = None;
+        } else {
+            let tmp = endpoints[label_ends[blossom].unwrap()];
+            blossom = in_blossoms[tmp];
+            assert!(labels[blossom] == Some(2));
+            // blossom is a T-blossom; trace one more step back.
+            assert!(label_ends[blossom].is_some());
+            v = Some(endpoints[label_ends[blossom].unwrap()]);
+        }
+        // Swap v and w so that we alternate between both paths.
+        if w.is_some() {
+            mem::swap(&mut v, &mut w);
+        }
+    }
+    // Remvoe breadcrumbs.
+    for blossom in path {
+        labels[blossom] = Some(1);
+    }
+    // Return base vertex, if we found one.
+    base
+}
+
+/// Construct a new blossom with given base, containing edge k which
+/// connects a pair of S vertices. Label the new blossom as S; set its dual
+/// variable to zero; relabel its T-vertices to S and add them to the queue.
+fn add_blossom(
+    base: usize,
+    edge: usize,
+    blossom_children: &mut Vec<BlossomList>,
+    num_nodes: usize,
+    edges: &[(usize, usize, i128)],
+    in_blossoms: &mut Vec<usize>,
+    dual_var: &mut Vec<i128>,
+    labels: &mut Vec<Option<usize>>,
+    label_ends: &mut Vec<Option<usize>>,
+    best_edge: &mut Vec<Option<usize>>,
+    queue: &mut Vec<usize>,
+    blossom_base: &mut Vec<Option<usize>>,
+    endpoints: &[usize],
+    blossom_endpoints: &mut Vec<BlossomList>,
+    unused_blossoms: &mut Vec<usize>,
+    blossom_best_edges: &mut Vec<BlossomList>,
+    blossom_parents: &mut Vec<Option<usize>>,
+    neighbor_endpoints: &[Vec<usize>],
+    mate: &[Option<usize>],
+) -> PyResult<()> {
+    let (mut v, mut w, _weight) = edges[edge];
+    let blossom_b = in_blossoms[base];
+    let mut blossom_v = in_blossoms[v];
+    let mut blossom_w = in_blossoms[w];
+    // Create blossom
+    let blossom = unused_blossoms.pop().unwrap();
+    blossom_base[blossom] = Some(base);
+    blossom_parents[blossom] = None;
+    blossom_parents[blossom_b] = Some(blossom);
+    // Make list of sub-blossoms and their interconnecting edge endpoints.
+    blossom_children[blossom].exists = true;
+    let mut path: Vec<usize> = Vec::new();
+    blossom_endpoints[blossom].exists = true;
+    let mut local_endpoints: Vec<usize> = Vec::new();
+    // Trace back from blossom_v to base.
+    while blossom_v != blossom_b {
+        // Add blossom_v to the new blossom
+        blossom_parents[blossom_v] = Some(blossom);
+        path.push(blossom_v);
+        let blossom_v_endpoint_label = label_ends[blossom_v].unwrap();
+        local_endpoints.push(blossom_v_endpoint_label);
+        assert!(
+            labels[blossom_v] == Some(2)
+                || (labels[blossom_v] == Some(1)
+                    && label_ends[blossom_v]
+                        == mate[blossom_base[blossom_v].unwrap()])
+        );
+        // Traceone step back.
+        assert!(label_ends[blossom_v].is_some());
+        v = endpoints[blossom_v_endpoint_label];
+        blossom_v = in_blossoms[v];
+    }
+    // Reverse lists, add endpoint that connects the pair of S vertices.
+    path.push(blossom_b);
+    path.reverse();
+    local_endpoints.reverse();
+    local_endpoints.push(2 * edge);
+    // Trace back from w to base.
+    while blossom_w != blossom_b {
+        // Add blossom_w to the new blossom
+        blossom_parents[blossom_w] = Some(blossom);
+        path.push(blossom_w);
+        let blossom_w_endpoint_label = label_ends[blossom_w].unwrap();
+        local_endpoints.push(blossom_w_endpoint_label ^ 1);
+        assert!(
+            labels[blossom_w] == Some(2)
+                || (labels[blossom_w] == Some(1)
+                    && label_ends[blossom_w]
+                        == mate[blossom_base[blossom_w].unwrap()])
+        );
+        // Trace one step back
+        assert!(label_ends[blossom_w].is_some());
+        w = endpoints[blossom_w_endpoint_label];
+        blossom_w = in_blossoms[w];
+    }
+    // Set label to S.
+    assert!(labels[blossom_b] == Some(1));
+    labels[blossom] = Some(1);
+    label_ends[blossom] = label_ends[blossom_b];
+    // Set dual variable to 0
+    dual_var[blossom] = 0;
+    // Relabel vertices
+    for node in blossom_leaves(blossom, num_nodes, &blossom_children)? {
+        if labels[in_blossoms[node]] == Some(2) {
+            // This T-vertex now turns into an S-vertex because it becomes
+            // part of an S-blossom; add it to the queue
+            queue.push(node);
+        }
+        in_blossoms[node] = blossom;
+    }
+    // Compute blossom_best_edges[blossom]
+    let mut best_edge_to: Vec<Option<usize>> = vec![None; 2 * num_nodes];
+    for bv in path {
+        // This sub-blossom does not have a list of least-slack edges;
+        // get the information from the vertices.
+        let nblists: Vec<Vec<usize>> = if !blossom_best_edges[bv].exists {
+            let mut tmp: Vec<Vec<usize>> = Vec::new();
+            for node in blossom_leaves(bv, num_nodes, &blossom_children)? {
+                tmp.push(
+                    neighbor_endpoints[node].iter().map(|p| p / 2).collect(),
+                );
+            }
+            tmp
+        } else {
+            // Walk this sub-blossom's least-slack edges.
+            vec![blossom_best_edges[bv].nodes.clone()]
+        };
+        for nblist in nblists {
+            for edge_index in nblist {
+                let (mut i, mut j, _edge_weight) = edges[edge_index];
+                if in_blossoms[j] == blossom {
+                    mem::swap(&mut i, &mut j);
+                }
+                let blossom_j = in_blossoms[j];
+                if blossom_j != blossom
+                    && labels[blossom_j] == Some(1)
+                    && (best_edge_to[blossom_j].is_none()
+                        || slack(edge_index, &dual_var, &edges)
+                            < slack(
+                                best_edge_to[blossom_j].unwrap(),
+                                &dual_var,
+                                &edges,
+                            ))
+                {
+                    best_edge_to[blossom_j] = Some(edge_index);
+                }
+            }
+        }
+        // Forget about least-slack edges of the sub-blossom.
+        blossom_best_edges[bv].exists = false;
+        blossom_best_edges[bv].nodes = Vec::new();
+        best_edge[bv] = None;
+    }
+    blossom_best_edges[blossom].nodes = best_edge_to
+        .iter()
+        .filter(|x| x.is_some())
+        .map(|x| x.unwrap())
+        .collect();
+    blossom_best_edges[blossom].exists = true;
+    //select best_edge[blossom]
+    best_edge[blossom] = None;
+    for edge_index in &blossom_best_edges[blossom].nodes {
+        if best_edge[blossom].is_none()
+            || slack(*edge_index, &dual_var, &edges)
+                < slack(best_edge[blossom].unwrap(), &dual_var, &edges)
+        {
+            best_edge[blossom] = Some(*edge_index);
+        }
+    }
+    Ok(())
+}
+
+/// Expand the given top level blossom
+fn expand_blossom(
+    blossom: usize,
+    end_stage: bool,
+    num_nodes: usize,
+    blossom_children: &mut Vec<BlossomList>,
+    in_blossoms: &mut Vec<usize>,
+    dual_var: &[i128],
+    labels: &mut Vec<Option<usize>>,
+    label_ends: &mut Vec<Option<usize>>,
+    best_edge: &mut Vec<Option<usize>>,
+    queue: &mut Vec<usize>,
+    blossom_base: &[Option<usize>],
+    endpoints: &[usize],
+    mate: &[Option<usize>],
+    blossom_endpoints: &mut Vec<BlossomList>,
+    allowed_edge: &mut Vec<bool>,
+    unused_blossoms: &mut Vec<usize>,
+) -> PyResult<()> {
+    if !blossom_children[blossom].exists {
+        panic!("blossom children not defined");
+    }
+    // convert sub-blossoms into top-level blossoms.
+    for s in blossom_children[blossom].nodes.clone() {
+        if s < num_nodes {
+            in_blossoms[s] = s
+        } else if end_stage && dual_var[s] == 0 {
+            // Recursively expand this sub-blossom
+            expand_blossom(
+                s,
+                end_stage,
+                num_nodes,
+                blossom_children,
+                in_blossoms,
+                dual_var,
+                labels,
+                label_ends,
+                best_edge,
+                queue,
+                blossom_base,
+                endpoints,
+                mate,
+                blossom_endpoints,
+                allowed_edge,
+                unused_blossoms,
+            )?;
+        } else {
+            for v in blossom_leaves(s, num_nodes, blossom_children)? {
+                in_blossoms[v] = s;
+            }
+        }
+    }
+    // if we expand a T-blossom during a stage, its a sub-blossoms must be
+    // relabeled
+    if !end_stage && labels[blossom] == Some(2) {
+        // start at the sub-blossom through which the expanding blossom
+        // obtained its label, and relabel sub-blossoms until we reach the
+        // base.
+        assert!(label_ends[blossom].is_some());
+        let entry_child =
+            in_blossoms[endpoints[label_ends[blossom].unwrap() ^ 1]];
+        // Decied in which direction we will go around the blossom.
+        let mut j = blossom_children[blossom]
+            .nodes
+            .iter()
+            .position(|x| *x == entry_child)
+            .unwrap();
+        let j_step: i64;
+        let endpoint_trick: usize;
+        if j & 1 > 0 {
+            // Start index is odd; go forward and wrap
+            j -= blossom_children[blossom].nodes.len();
+            j_step = 1;
+            endpoint_trick = 0;
+        } else {
+            // start index is even; go backward
+            j_step = -1;
+            endpoint_trick = 1;
+        }
+        // Move along the blossom until we get to the base
+        let mut p = label_ends[blossom].unwrap();
+        while j != 0 {
+            // Relabel the T-sub-blossom.
+            labels[endpoints[p ^ 1]] = Some(0);
+            labels[endpoints[blossom_endpoints[blossom].nodes
+                [j - endpoint_trick]
+                ^ endpoint_trick
+                ^ 1]] = Some(0);
+            assign_label(
+                endpoints[p ^ 1],
+                2,
+                Some(p),
+                num_nodes,
+                in_blossoms,
+                labels,
+                label_ends,
+                best_edge,
+                queue,
+                blossom_children,
+                blossom_base,
+                endpoints,
+                mate,
+            )?;
+            // Step to the next S-sub-blossom and note it's forwward endpoint.
+            allowed_edge
+                [blossom_endpoints[blossom].nodes[j - endpoint_trick] / 2] =
+                true;
+            if j_step > 0 {
+                j += j_step as usize;
+            } else {
+                j -= j_step.abs() as usize;
+            }
+            p = blossom_endpoints[blossom].nodes[j - endpoint_trick]
+                ^ endpoint_trick;
+            // Step to the next T-sub-blossom.
+            allowed_edge[p / 2] = true;
+            if j_step > 0 {
+                j += j_step as usize;
+            } else {
+                j -= j_step.abs() as usize;
+            }
+        }
+        // Relabel the base T-sub-blossom WITHOUT stepping through to
+        // its mate (so don't call assign_label())
+        let blossom_v = blossom_children[blossom].nodes[j];
+        labels[endpoints[p ^ 1]] = Some(2);
+        labels[blossom_v] = Some(2);
+        label_ends[endpoints[p ^ 1]] = Some(p);
+        label_ends[blossom_v] = Some(p);
+        best_edge[blossom_v] = None;
+        // Continue along the blossom until we get back to entry_child
+        while blossom_children[blossom].nodes[j] != entry_child {
+            // Examine the vertices of the sub-blossom to see whether
+            // it is reachable from a neighboring S-vertex outside the
+            // expanding blososm.
+            let bv = blossom_children[blossom].nodes[j];
+            if labels[bv] == Some(1) {
+                // This sub-blossom just got label S through one of its
+                // neighbors; leave it
+                if j_step > 0 {
+                    j += j_step as usize;
+                } else {
+                    j -= j_step.abs() as usize;
+                }
+                continue;
+            }
+            let mut v: usize = 0;
+            for tmp in blossom_leaves(bv, num_nodes, blossom_children)? {
+                v = tmp;
+                if labels[v].unwrap() != 0 {
+                    break;
+                }
+            }
+            // If the sub-blossom contains a reachable vertex, assign label T
+            // to the sub-blossom
+            if labels[v] != Some(0) {
+                assert!(labels[v] == Some(2));
+                assert!(in_blossoms[v] == bv);
+                labels[v] = Some(0);
+                labels[endpoints[mate[blossom_base[bv].unwrap()].unwrap()]] =
+                    Some(0);
+                assign_label(
+                    v,
+                    2,
+                    label_ends[v],
+                    num_nodes,
+                    in_blossoms,
+                    labels,
+                    label_ends,
+                    best_edge,
+                    queue,
+                    blossom_children,
+                    blossom_base,
+                    endpoints,
+                    mate,
+                )?;
+            }
+            if j_step > 0 {
+                j += j_step as usize;
+            } else {
+                j -= j_step.abs() as usize;
+            }
+        }
+    }
+    // Recycle the blossom number.
+    labels[blossom] = None;
+    label_ends[blossom] = None;
+    blossom_children[blossom].exists = false;
+    blossom_children[blossom].nodes.clear();
+    blossom_endpoints[blossom].exists = false;
+    blossom_endpoints[blossom].nodes.clear();
+    best_edge[blossom] = None;
+    unused_blossoms.push(blossom);
+    Ok(())
+}
+
+/// Swap matched/unmatched edges over an alternating path through blossom b
+/// between vertex v and the base vertex. Keep blossom bookkeeping consistent.
+fn augment_blossom(
+    blossom: usize,
+    node: usize,
+    num_nodes: usize,
+    blossom_parents: &[Option<usize>],
+    endpoints: &[usize],
+    blossom_children: &mut Vec<BlossomList>,
+    blossom_endpoints: &mut Vec<BlossomList>,
+    blossom_base: &mut Vec<Option<usize>>,
+    mate: &mut Vec<Option<usize>>,
+) {
+    // Bubble up through the blossom tree from vertex v to an immediate
+    // sub-blossom of b.
+    let mut tmp = node;
+    while blossom_parents[tmp].unwrap() != blossom {
+        tmp = blossom_parents[tmp].unwrap();
+    }
+    // Recursively deal with the first sub-blossom.
+    if tmp >= num_nodes {
+        augment_blossom(
+            tmp,
+            node,
+            num_nodes,
+            blossom_parents,
+            endpoints,
+            blossom_children,
+            blossom_endpoints,
+            blossom_base,
+            mate,
+        );
+    }
+    // Decide in which direction we will go round the blossom.
+    let i = blossom_children[blossom]
+        .nodes
+        .iter()
+        .position(|x| *x == tmp)
+        .unwrap();
+    let mut j = i;
+    let j_step: i64;
+    let endpoint_trick: usize;
+    if i & 1 > 0 {
+        // start index is odd; go forward and wrap.
+        j -= blossom_children[blossom].nodes.len();
+        j_step = 1;
+        endpoint_trick = 0;
+    } else {
+        // Start index is even; go backward.
+        j_step = -1;
+        endpoint_trick = 1;
+    }
+    // Move along the blossom until we get to the base.
+    while j != 0 {
+        // Step to the next sub-blossom and augment it recursively.
+        if j_step > 0 {
+            j += j_step as usize;
+        } else {
+            j -= j_step.abs() as usize;
+        }
+        tmp = blossom_children[blossom].nodes[j];
+        let p = blossom_endpoints[blossom].nodes[j - endpoint_trick]
+            ^ endpoint_trick;
+        if tmp > num_nodes {
+            augment_blossom(
+                tmp,
+                endpoints[p],
+                num_nodes,
+                blossom_parents,
+                endpoints,
+                blossom_children,
+                blossom_endpoints,
+                blossom_base,
+                mate,
+            );
+        }
+        if j_step > 0 {
+            j += j_step as usize;
+        } else {
+            j -= j_step.abs() as usize;
+        }
+        tmp = blossom_children[blossom].nodes[j];
+        if tmp > num_nodes {
+            augment_blossom(
+                tmp,
+                endpoints[p ^ 1],
+                num_nodes,
+                blossom_parents,
+                endpoints,
+                blossom_children,
+                blossom_endpoints,
+                blossom_base,
+                mate,
+            );
+        }
+        // Match the edge connecting those sub-blossoms.
+        mate[endpoints[p]] = Some(p ^ 1);
+        mate[endpoints[p ^ 1]] = Some(p);
+    }
+    // Rotate the list of sub-blossoms to put the new base at the front.
+    let mut children: Vec<usize> =
+        blossom_children[blossom].nodes[i..].to_vec();
+    children.extend_from_slice(&blossom_children[blossom].nodes[..i]);
+    blossom_children[blossom].exists = true;
+    blossom_children[blossom].nodes = children;
+    let mut endpoint: Vec<usize> =
+        blossom_endpoints[blossom].nodes[i..].to_vec();
+    endpoint.extend_from_slice(&blossom_endpoints[blossom].nodes[..i]);
+    blossom_endpoints[blossom].exists = true;
+    blossom_endpoints[blossom].nodes = endpoint;
+    blossom_base[blossom] = blossom_base[blossom_children[blossom].nodes[0]];
+    assert!(blossom_base[blossom] == Some(node));
+}
+
+/// Swap matched/unmatched edges over an alternating path between two
+/// single vertices. The augmenting path runs through edge k, which
+/// connects a pair of S vertices.
+fn augment_matching(
+    edge: usize,
+    num_nodes: usize,
+    edges: &[(usize, usize, i128)],
+    in_blossoms: &[usize],
+    labels: &[Option<usize>],
+    label_ends: &[Option<usize>],
+    blossom_parents: &[Option<usize>],
+    endpoints: &[usize],
+    blossom_children: &mut Vec<BlossomList>,
+    blossom_endpoints: &mut Vec<BlossomList>,
+    blossom_base: &mut Vec<Option<usize>>,
+    mate: &mut Vec<Option<usize>>,
+) {
+    let (v, w, _weight) = edges[edge];
+    for (s_ref, p_ref) in [(v, 2 * edge + 1), (w, 2 * edge)].iter() {
+        // Match vertex s to remote endpoint p. Then trace back from s
+        // until we find a single vertex, swapping matched and unmatched
+        // edges as we go.
+        let mut s: usize = *s_ref;
+        let mut p: usize = *p_ref;
+        loop {
+            let blossom_s = in_blossoms[s];
+            assert!(labels[blossom_s] == Some(1));
+            assert!(
+                label_ends[blossom_s] == mate[blossom_base[blossom_s].unwrap()]
+            );
+            // Augment through the S-blossom from s to base.
+            if blossom_s >= num_nodes {
+                augment_blossom(
+                    blossom_s,
+                    s,
+                    num_nodes,
+                    blossom_parents,
+                    endpoints,
+                    blossom_children,
+                    blossom_endpoints,
+                    blossom_base,
+                    mate,
+                );
+            }
+            // Update mate[s]
+            mate[s] = Some(p);
+            // Trace one step back.
+            if label_ends[blossom_s].is_none() {
+                // Reached a single vertex; stop
+                break;
+            }
+            let t = endpoints[label_ends[blossom_s].unwrap()];
+            let blossom_t = in_blossoms[t];
+            assert!(labels[blossom_t] == Some(2));
+            // Trace one step back
+            assert!(label_ends[blossom_t].is_some());
+            s = endpoints[label_ends[blossom_t].unwrap()];
+            let j = endpoints[label_ends[blossom_t].unwrap() ^ 1];
+            // Augment through the T-blossom from j to base.
+            assert!(blossom_base[blossom_t] == Some(t));
+            if blossom_t >= num_nodes {
+                augment_blossom(
+                    blossom_t,
+                    j,
+                    num_nodes,
+                    blossom_parents,
+                    endpoints,
+                    blossom_children,
+                    blossom_endpoints,
+                    blossom_base,
+                    mate,
+                );
+            }
+            // Update mate[j]
+            mate[j] = label_ends[blossom_t];
+            // Keep the opposite endpoint;
+            // it will be assigned to mate[s] in the next step.
+            p = label_ends[blossom_t].unwrap() ^ 1;
+        }
+    }
+}
+
+///// Swap matched/unmatched edges over an alternating path between two
+///// single vertices. The augmenting path runs through the edge, which
+///// connects a pair of S vertices.
+//fn verify_optimum(
+//    max_cardinality: bool,
+//    num_nodes: usize,
+//    num_edges: usize,
+//    edges: &[(usize, usize, i128)],
+//    endpoints: &[usize],
+//    dual_var: &[i128],
+//    blossom_parents: &[Option<usize>],
+//    blossom_endpoints: &[BlossomList],
+//    blossom_base: &[Option<usize>],
+//    mate: &[Option<usize>],
+//) -> bool {
+//    let dual_var_node_min: i128 = *dual_var[..num_nodes].iter().min().unwrap();
+//    let node_dual_offset: i128 = if max_cardinality {
+//        // Vertices may have negative dual;
+//        // find a constant non-negative number to add to all vertex duals.
+//        max(0, -dual_var_node_min)
+//    } else {
+//        0
+//    };
+//    if dual_var_node_min + node_dual_offset < 0 {
+//        return false;
+//    }
+//    if *dual_var[num_nodes..].iter().min().unwrap() < 0 {
+//        return false;
+//    }
+//    // 0. all edges have non-negative slack and
+//    // 1. all matched edges have zero slack;
+//    for (edge, (i, j, weight)) in edges.iter().enumerate().take(num_edges) {
+//        let mut s = dual_var[*i] + dual_var[*j] - 2 * weight;
+//        let mut i_blossoms: Vec<usize> = vec![*i];
+//        let mut j_blossoms: Vec<usize> = vec![*j];
+//        while blossom_parents[*i_blossoms.last().unwrap()].is_some() {
+//            i_blossoms
+//                .push(blossom_parents[*i_blossoms.last().unwrap()].unwrap());
+//        }
+//        while blossom_parents[*j_blossoms.last().unwrap()].is_some() {
+//            j_blossoms
+//                .push(blossom_parents[*j_blossoms.last().unwrap()].unwrap());
+//        }
+//        i_blossoms.reverse();
+//        j_blossoms.reverse();
+//        for (blossom_i, blossom_j) in i_blossoms.iter().zip(j_blossoms.iter()) {
+//            if blossom_i != blossom_j {
+//                break;
+//            }
+//            s += 2 * dual_var[*blossom_i];
+//        }
+//        if s < 0 {
+//            return false;
+//        }
+//        if mate[*i].unwrap() / 2 == edge || mate[*j].unwrap() / 2 == edge {
+//            if mate[*i].unwrap() / 2 != edge || mate[*j].unwrap() / 2 != edge {
+//                return false;
+//            }
+//            if s == 0 {
+//                return false;
+//            }
+//        }
+//    }
+//    // 2. all single vertices have zero dual value;
+//    for node in 0..num_nodes {
+//        if mate[node].is_none() && dual_var[node] + node_dual_offset != 0 {
+//            return false;
+//        }
+//    }
+//    // 3. all blossoms with positive dual value are full.
+//    for blossom in num_nodes..2 * num_nodes {
+//        if blossom_base[blossom].is_some() && dual_var[blossom] > 0 {
+//            if blossom_endpoints[blossom].nodes.len() % 2 != 1 {
+//                return false;
+//            }
+//            for p in [
+//                blossom_endpoints[blossom].nodes[1],
+//                blossom_endpoints[blossom].nodes[2],
+//            ]
+//            .iter()
+//            {
+//                if mate[endpoints[*p]].unwrap() != *p ^ 1 {
+//                    return false;
+//                }
+//                if mate[endpoints[*p ^ 1]].unwrap() != *p {
+//                    return false;
+//                }
+//            }
+//        }
+//    }
+//    true
+//}
+
+/// Compute a maximum-weighted matching in the general undirected weighted
+/// graph given by "edges". If `max_cardinality` is true, only
+/// maximum-cardinality matchings are considered as solutions.
+///
+/// The algorithm is based on "Efficient Algorithms for Finding Maximum
+/// Matching in Graphs" by Zvi Galil, ACM Computing Surveys, 1986.
+///
+/// Based on networkx implementation
+/// https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/matching.py
+///
+/// With reference to the standalone protoype implementation from:
+/// http://jorisvr.nl/article/maximum-matching
+///
+/// http://jorisvr.nl/files/graphmatching/20130407/mwmatching.py
+///
+/// The function takes time O(n**3)
+pub fn max_weight_matching(
+    py: Python,
+    graph: &PyGraph,
+    max_cardinality: bool,
+    weight_fn: Option<PyObject>,
+    default_weight: i128,
+) -> PyResult<HashMap<usize, usize>> {
+    let mut out_map: HashMap<usize, usize> = HashMap::new();
+    let num_edges = graph.graph.edge_count();
+    let num_nodes = graph.graph.node_count();
+    // Exit fast for graph without edges
+    if num_edges == 0 {
+        return Ok(out_map);
+    }
+    // Node indicies in the PyGraph may not be contiguous however the
+    // algorithm operates on contiguous indices 0..num_nodes node_map maps the
+    // algorithm index to the PyGraph's index
+    let node_map: HashMap<NodeIndex, usize> = graph
+        .graph
+        .node_indices()
+        .enumerate()
+        .map(|(index, node_index)| (node_index, index))
+        .collect();
+    let mut edges: Vec<(usize, usize, i128)> = Vec::with_capacity(num_edges);
+    let mut max_weight: i128 = 0;
+    for edge in graph.graph.edge_references() {
+        let edge_weight: i128 = weight_callable(
+            py,
+            edge.weight().clone_ref(py),
+            &weight_fn,
+            default_weight,
+        )?;
+        if edge_weight > max_weight {
+            max_weight = edge_weight;
+        };
+        edges.push((
+            node_map[&edge.source()],
+            node_map[&edge.target()],
+            edge_weight,
+        ));
+    }
+    // If p is an edge endpoint
+    // endpoint[p] is the node index to which endpoint p is attached
+    let endpoints: Vec<usize> = (0..2 * num_edges)
+        .map(|endpoint| {
+            let edge_tuple = edges[endpoint / 2];
+            let out_value: usize;
+            if endpoint % 2 == 0 {
+                out_value = edge_tuple.0;
+            } else {
+                out_value = edge_tuple.1;
+            }
+            out_value
+        })
+        .collect();
+    // If v is a node/vertex
+    // neighbor_endpoints[v] is the list of remote endpoints of the edges
+    // attached to v.
+    // Not modified by algorithm (only mut to initially construct contents).
+    let mut neighbor_endpoints: Vec<Vec<usize>> =
+        (0..num_nodes).map(|_| Vec::new()).collect();
+    for edge in 0..num_edges {
+        neighbor_endpoints[edges[edge].0].push(2 * edge + 1);
+        neighbor_endpoints[edges[edge].1].push(2 * edge);
+    }
+    // If v is a vertex,
+    // mate[v] is the remote endpoint of its matched edge, or None if it is
+    // single (i.e. endpoint[mate[v]] is v's partner vertex).
+    // Initially all vertices are single; updated during augmentation.
+    let mut mate: Vec<Option<usize>> = vec![None; num_nodes];
+
+    // If b is a top-level blossom
+    // label[b] is 0 if b is unlabeled (free);
+    //             1 if b is a S-vertex/blossom;
+    //             2 if b is a T-vertex/blossom;
+    // The label of a vertex/node is found by looking at the label of its
+    // top-level containing blossom
+    // If v is a node/vertex inside a T-Blossom,
+    // label[v] is LabelType::T_Vertex if and only if v is reachable from
+    // an S_Vertex outside the blossom.
+    let mut labels: Vec<Option<usize>>;
+    // If b is a labeled top-level blossom,
+    // label_ends[b] is the remote endpoint of the edge through which b is
+    // obtained. Its label, or None if b's base vertex is single.
+    // If v is a vertex inside a T-blossom and label[v] == 2,
+    // label_ends[v] is the remote endpoint of the edge through which v is
+    // reachable from outside the blossom
+    let mut label_ends: Vec<Option<usize>> = vec![None; 2 * num_nodes];
+    // If v is a vertex/node
+    // in_blossoms[v] is the top-level blossom to which v belongs.
+    // If v is a top-level vertex, v is itself a blossom (a trivial blossom)
+    // and in_blossoms[v] == v.
+    // Initially all nodes are top-level trivial blossoms.
+    let mut in_blossoms: Vec<usize> = graph
+        .graph
+        .node_indices()
+        .map(|node| node.index())
+        .collect();
+    // if b is a sub-blossom
+    // blossom_parents[b] is its immediate parent
+    // If b is a top-level blossom, blossom_parents[b] is None
+    let mut blossom_parents: Vec<Option<usize>> = vec![None; 2 * num_nodes];
+    //  If b is a non-trivial (sub-)blossom,
+    // blossom_children[b] is an ordered list of its sub-blossoms, starting with
+    // the base and going round the blossom.
+    let mut blossom_children: Vec<BlossomList> = (0..2 * num_nodes)
+        .map(|_| BlossomList {
+            exists: false,
+            nodes: Vec::new(),
+        })
+        .collect();
+    // If b is a (sub-)blossom,
+    // blossombase[b] is its base VERTEX (i.e. recursive sub-blossom).
+    let mut blossom_base: Vec<Option<usize>> =
+        (0..num_nodes).map(Some).collect();
+    blossom_base.append(&mut vec![None; num_nodes]);
+    // If b is a non-trivial (sub-)blossom,
+    // blossomendps[b] is a list of endpoints on its connecting edges,
+    // such that blossomendps[b][i] is the local endpoint of blossomchilds[b][i]
+    // on the edge that connects it to blossomchilds[b][wrap(i+1)].
+    let mut blossom_endpoints: Vec<BlossomList> = (0..2 * num_nodes)
+        .map(|_| BlossomList {
+            exists: false,
+            nodes: Vec::new(),
+        })
+        .collect();
+    // If v is a free vertex (or an unreached vertex inside a T-blossom),
+    // best_edge[v] is the edge to an S-vertex with least slack,
+    // or -1 if there is no such edge.
+    // If b is a (possibly trivial) top-level S-blossom,
+    // best_edge[b] is the least-slack edge to a different S-blossom,
+    // or -1 if there is no such edge.
+    let mut best_edge: Vec<Option<usize>>;
+    // If b is a non-trivial top-level S-blossom,
+    // blossom_best_edges[b] is a list of least-slack edges to neighboring
+    // S-blossoms, or None if no such list has been computed yet.
+    // This is used for efficient computation of delta3.
+    let mut blossom_best_edges: Vec<BlossomList> = (0..2 * num_nodes)
+        .map(|_| BlossomList {
+            exists: false,
+            nodes: Vec::new(),
+        })
+        .collect();
+    let mut unused_blossoms: Vec<usize> = (num_nodes..2 * num_nodes).collect();
+    // If v is a vertex,
+    // dual_var[v] = 2 * u(v) where u(v) is the v's variable in the dual
+    // optimization problem (multiplication by two ensures integer values
+    // throughout the algorithm if all edge weights are integers).
+    // If b is a non-trivial blossom,
+    // dual_var[b] = z(b) where z(b) is b's variable in the dual optimization
+    // problem.
+    let mut dual_var: Vec<i128> = vec![max_weight; num_nodes];
+    dual_var.append(&mut vec![0; num_nodes]);
+    // If allowed_edge[k] is true, edge k has zero slack in the optimization
+    // problem; if allowed_edge[k] is false, the edge's slack may or may not
+    // be zero.
+    let mut allowed_edge: Vec<bool>;
+    // Queue of newly discovered S-vertices
+    let mut queue: Vec<usize> = Vec::with_capacity(num_nodes);
+
+    // Main loop: continue until no further improvement is possible
+    for _ in 0..num_nodes {
+        // Each iteration of this loop is a "stage".
+        // A stage finds an augmenting path and uses that to improve
+        // the matching.
+
+        // Removal labels from top-level blossoms/vertices
+        labels = vec![Some(0); 2 * num_nodes];
+        // Forget all about least-slack edges.
+        best_edge = vec![None; 2 * num_nodes];
+        blossom_best_edges.splice(
+            num_nodes..,
+            (0..num_nodes).map(|_| BlossomList {
+                exists: false,
+                nodes: Vec::new(),
+            }),
+        );
+        // Loss of labeling means that we can not be sure that currently
+        // allowable edges remain allowable througout this stage.
+        allowed_edge = vec![false; num_edges];
+        // Make queue empty
+        queue.clear();
+        // Label single blossom/vertices with S and put them in queue.
+        for v in 0..num_nodes {
+            if mate[v].is_none() && labels[in_blossoms[v]] == Some(0) {
+                assign_label(
+                    v,
+                    1,
+                    None,
+                    num_nodes,
+                    &in_blossoms,
+                    &mut labels,
+                    &mut label_ends,
+                    &mut best_edge,
+                    &mut queue,
+                    &blossom_children,
+                    &blossom_base,
+                    &endpoints,
+                    &mate,
+                )?;
+            }
+        }
+        // Loop until we succeed in augmenting the matching.
+        let mut augmented = false;
+        loop {
+            // Each iteration of this loop is a "substage".
+            // A substage tries to find an augmenting path;
+            // if found, the path is used to improve the matching and
+            // the stage ends. If there is no augmenting path, the
+            // primal-dual method is used to pump some slack out of
+            // the dual variables.
+
+            // Continue labeling until all vertices which are reachable
+            // through an alternating path have got a label.
+            while !queue.is_empty() && !augmented {
+                // Take an S vertex from the queue
+                let v = queue.pop().unwrap();
+                assert!(labels[in_blossoms[v]] == Some(1));
+
+                // Scan it's neighbors
+                for p in &neighbor_endpoints[in_blossoms[v]] {
+                    let k = *p / 2;
+                    let mut kslack = 0;
+                    let w = endpoints[*p];
+                    // w is a neighbor of v
+                    if in_blossoms[v] == in_blossoms[w] {
+                        // this edge is internal to a blossom; ignore it
+                        continue;
+                    }
+                    if !allowed_edge[k] {
+                        kslack = slack(k, &dual_var, &edges);
+                        if kslack <= 0 {
+                            // edge k has zero slack -> it is allowable
+                            allowed_edge[k] = true;
+                        }
+                    }
+                    if allowed_edge[k] {
+                        if labels[in_blossoms[w]] == Some(0) {
+                            // (C1) w is a free vertex;
+                            // label w with T and label its mate with S (R12).
+                            assign_label(
+                                w,
+                                2,
+                                Some(*p ^ 1),
+                                num_nodes,
+                                &in_blossoms,
+                                &mut labels,
+                                &mut label_ends,
+                                &mut best_edge,
+                                &mut queue,
+                                &blossom_children,
+                                &blossom_base,
+                                &endpoints,
+                                &mate,
+                            )?;
+                        } else if labels[in_blossoms[w]] == Some(1) {
+                            // (C2) w is an S-vertex (not in the same blossom);
+                            // follow back-links to discover either an
+                            // augmenting path or a new blossom.
+                            let base = scan_blossom(
+                                v,
+                                w,
+                                &in_blossoms,
+                                &blossom_base,
+                                &endpoints,
+                                &mut labels,
+                                &label_ends,
+                                &mate,
+                            );
+                            if base.is_some() {
+                                // Found a new blossom; add it to the blossom
+                                // bookkeeping and turn it into an S-blossom.
+                                add_blossom(
+                                    base.unwrap(),
+                                    k,
+                                    &mut blossom_children,
+                                    num_nodes,
+                                    &edges,
+                                    &mut in_blossoms,
+                                    &mut dual_var,
+                                    &mut labels,
+                                    &mut label_ends,
+                                    &mut best_edge,
+                                    &mut queue,
+                                    &mut blossom_base,
+                                    &endpoints,
+                                    &mut blossom_endpoints,
+                                    &mut unused_blossoms,
+                                    &mut blossom_best_edges,
+                                    &mut blossom_parents,
+                                    &neighbor_endpoints,
+                                    &mate,
+                                )?;
+                            } else {
+                                // Found an augmenting path; augment the
+                                // matching and end this stage.
+                                augment_matching(
+                                    k,
+                                    num_nodes,
+                                    &edges,
+                                    &in_blossoms,
+                                    &labels,
+                                    &label_ends,
+                                    &blossom_parents,
+                                    &endpoints,
+                                    &mut blossom_children,
+                                    &mut blossom_endpoints,
+                                    &mut blossom_base,
+                                    &mut mate,
+                                );
+                                augmented = true;
+                                break;
+                            }
+                        } else if labels[w] == Some(0) {
+                            // w is inside a T-blossom, but w itself has not
+                            // yet been reached from outside the blossom;
+                            // mark it as reached (we need this to relabel
+                            // during T-blossom expansion).
+                            assert!(labels[in_blossoms[w]] == Some(2));
+                            labels[w] = Some(2);
+                            label_ends[w] = Some(*p ^ 1);
+                        }
+                    } else if labels[in_blossoms[w]] == Some(1) {
+                        // keep track of the least-slack non-allowable edge to
+                        // a different S-blossom
+                        let blossom = in_blossoms[v];
+                        if best_edge[blossom].is_none()
+                            || kslack
+                                < slack(
+                                    best_edge[blossom].unwrap(),
+                                    &dual_var,
+                                    &edges,
+                                )
+                        {
+                            best_edge[blossom] = Some(k);
+                        }
+                    } else if labels[w] == Some(0) {
+                        // w is a free vertex (or an unreached vertex inside
+                        // a T-blossom) but we can not reach it yet;
+                        // keep track of the least-slack edge that reaches w.
+                        if best_edge[w].is_none()
+                            || kslack
+                                < slack(
+                                    best_edge[w].unwrap(),
+                                    &dual_var,
+                                    &edges,
+                                )
+                        {
+                            best_edge[w] = Some(k)
+                        }
+                    }
+                }
+            }
+            if augmented {
+                break;
+            }
+            // There is no augmenting path under these constraints;
+            // compute delta and reduce slack in the optimization problem.
+            // (Note that our vertex dual variables, edge slacks and delta's
+            // are pre-multiplied by two.)
+            let mut delta_type = -1;
+            let mut delta: Option<i128> = None;
+            let mut delta_edge: Option<usize> = None;
+            let mut delta_blossom: Option<usize> = None;
+
+            // Compute delta1: the minumum value of any vertex dual.
+            if !max_cardinality {
+                delta_type = 1;
+                delta = Some(*dual_var[..num_nodes].iter().min().unwrap());
+            }
+
+            // Compute delta2: the minimum slack on any edge between
+            // an S-vertex and a free vertex.
+            for v in 0..num_nodes {
+                if labels[in_blossoms[v]] == Some(0) && best_edge[v].is_some() {
+                    let d = slack(best_edge[v].unwrap(), &dual_var, &edges);
+                    if delta_type == -1 || d < delta.unwrap() {
+                        delta = Some(d);
+                        delta_type = 2;
+                        delta_edge = best_edge[v];
+                    }
+                }
+            }
+
+            // Compute delta3: half the minimum slack on any edge between a
+            // pair of S-blossoms
+            for blossom in 0..2 * num_nodes {
+                if blossom_parents[blossom].is_none()
+                    && labels[blossom] == Some(1)
+                    && best_edge[blossom].is_some()
+                {
+                    let kslack =
+                        slack(best_edge[blossom].unwrap(), &dual_var, &edges);
+                    assert!(kslack % 2 == 0);
+                    let d = Some(kslack / 2);
+                    if delta_type == -1 || d < delta {
+                        delta = d;
+                        delta_type = 3;
+                        delta_edge = best_edge[blossom];
+                    }
+                }
+            }
+
+            // Compute delta4: minimum z variable of any T-blossom
+            for blossom in num_nodes..2 * num_nodes {
+                if blossom_base[blossom].is_some()
+                    && blossom_parents[blossom].is_none()
+                    && labels[blossom] == Some(2)
+                    && (delta_type == -1 || dual_var[blossom] < delta.unwrap())
+                {
+                    delta = Some(dual_var[blossom]);
+                    delta_type = 4;
+                    delta_blossom = Some(blossom);
+                }
+            }
+            if delta_type == -1 {
+                //No further improvement possible; max-cardinality optimum
+                // reached. Do a final delta update to make the optimum
+                // verifyable
+                assert!(max_cardinality);
+                delta_type = 1;
+                delta =
+                    Some(max(0, *dual_var[..num_nodes].iter().min().unwrap()));
+            }
+
+            // Update dual variables according to delta.
+            for v in 0..num_nodes {
+                if labels[in_blossoms[v]] == Some(1) {
+                    // S-vertex: 2*u = 2*u - 2*delta
+                    dual_var[v] -= delta.unwrap();
+                } else if labels[in_blossoms[v]] == Some(2) {
+                    // T-vertex: 2*u = 2*u + 2*delta
+                    dual_var[v] += delta.unwrap();
+                }
+            }
+            for b in num_nodes..2 * num_nodes {
+                if blossom_base[b].is_some() && blossom_parents[b].is_none() {
+                    if labels[b] == Some(1) {
+                        // top-level S-blossom: z = z + 2*delta
+                        dual_var[b] += delta.unwrap();
+                    } else if labels[b] == Some(2) {
+                        // top-level T-blossom: z = z - 2*delta
+                        dual_var[b] -= delta.unwrap();
+                    }
+                }
+            }
+            // Take action at the point where minimum delta occured.
+            if delta_type == 1 {
+                // No further improvement possible; optimum reached
+                break;
+            } else if delta_type == 2 {
+                // Use the least-slack edge to continue the search.
+                allowed_edge[delta_edge.unwrap()] = true;
+                let (mut i, mut j, _weight) = edges[delta_edge.unwrap()];
+                if labels[in_blossoms[i]] == Some(0) {
+                    mem::swap(&mut i, &mut j);
+                }
+                assert!(labels[in_blossoms[i]] == Some(1));
+                queue.push(i);
+            } else if delta_type == 3 {
+                // Use the least-slack edge to continue the search.
+                allowed_edge[delta_edge.unwrap()] = true;
+                let (i, _j, _weight) = edges[delta_edge.unwrap()];
+                assert!(labels[in_blossoms[i]] == Some(1));
+                queue.push(i);
+            } else if delta_type == 4 {
+                // Expand the least-z blossom
+                expand_blossom(
+                    delta_blossom.unwrap(),
+                    false,
+                    num_nodes,
+                    &mut blossom_children,
+                    &mut in_blossoms,
+                    &dual_var,
+                    &mut labels,
+                    &mut label_ends,
+                    &mut best_edge,
+                    &mut queue,
+                    &blossom_base,
+                    &endpoints,
+                    &mate,
+                    &mut blossom_endpoints,
+                    &mut allowed_edge,
+                    &mut unused_blossoms,
+                )?;
+            }
+            // end of this substage
+        }
+        // Stop when no more augment paths can be found
+        if !augmented {
+            break;
+        }
+
+        // End of a stage; expand all S-blossoms which have a dual_var == 0
+        for blossom in num_nodes..2 * num_nodes {
+            if blossom_parents[blossom].is_none()
+                && blossom_base[blossom].is_some()
+                && labels[blossom] == Some(1)
+                && dual_var[blossom] == 0
+            {
+                expand_blossom(
+                    blossom,
+                    true,
+                    num_nodes,
+                    &mut blossom_children,
+                    &mut in_blossoms,
+                    &dual_var,
+                    &mut labels,
+                    &mut label_ends,
+                    &mut best_edge,
+                    &mut queue,
+                    &blossom_base,
+                    &endpoints,
+                    &mate,
+                    &mut blossom_endpoints,
+                    &mut allowed_edge,
+                    &mut unused_blossoms,
+                )?;
+            }
+        }
+    }
+    //    if !verify_optimum(
+    //        max_cardinality,
+    //        num_nodes,
+    //        num_edges,
+    //        &edges,
+    //        &endpoints,
+    //        &dual_var,
+    //        &blossom_parents,
+    //        &blossom_endpoints,
+    //        &blossom_base,
+    //        &mate,
+    //    ) {
+    //        return Err(PyException::new_err("Solution found is not optimal"));
+    //    }
+
+    // Transform mate[] such that mate[v] is the vertex to which v is paired
+    // Also handle holes in node indices from graph removals by mapping
+    // linear index to node index.
+    let node_list: Vec<NodeIndex> = graph.graph.node_indices().collect();
+    for (index, node) in mate.iter().enumerate() {
+        if node.is_some() {
+            out_map.insert(
+                node_list[index].index(),
+                node_list[endpoints[node.unwrap()]].index(),
+            );
+        }
+    }
+    Ok(out_map)
+}

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -873,7 +873,7 @@ pub fn max_weight_matching(
     // If v is a vertex inside a T-blossom and label[v] == 2,
     // label_ends[v] is the remote endpoint of the edge through which v is
     // reachable from outside the blossom
-    let mut label_ends: Vec<Option<usize>> = vec![None; 2 * num_nodes];
+    let mut label_ends: Vec<Option<usize>>;
     // If v is a vertex/node
     // in_blossoms[v] is the top-level blossom to which v belongs.
     // If v is a top-level vertex, v is itself a blossom (a trivial blossom)
@@ -939,6 +939,7 @@ pub fn max_weight_matching(
 
         // Removal labels from top-level blossoms/vertices
         labels = vec![Some(0); 2 * num_nodes];
+        label_ends = vec![None; 2 * num_nodes];
         // Forget all about least-slack edges.
         best_edge = vec![None; 2 * num_nodes];
         blossom_best_edges

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -922,6 +922,8 @@ pub fn max_weight_matching(
     // If b is a non-trivial blossom,
     // dual_var[b] = z(b) where z(b) is b's variable in the dual optimization
     // problem.
+    // dual_var is for vertex v in 0..num_nodes and blossom b in
+    // num_nodes..2* num nodes
     let mut dual_var: Vec<i128> = vec![max_weight; num_nodes];
     dual_var.append(&mut vec![0; num_nodes]);
     // If allowed_edge[k] is true, edge k has zero slack in the optimization

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -53,6 +53,19 @@ class TestMaxWeightMatching(unittest.TestCase):
 
     def compare_rx_nx_sets(self, rx_graph, rx_matches, nx_matches, seed,
                            nx_graph):
+
+        def get_rx_weight(edge):
+            weight = rx_graph.get_edge_data(*edge)
+            if weight is None:
+                return 1
+            return weight
+
+        def get_nx_weight(edge):
+            weight = nx_graph.get_edge_data(*edge)
+            if not weight:
+                return 1
+            return weight['weight']
+
         not_match = False
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
@@ -70,14 +83,8 @@ class TestMaxWeightMatching(unittest.TestCase):
                             "%s is not a valid matching" % rx_matches)
             self.assertTrue(is_maximal_matching(rx_graph, rx_matches),
                             "%s is not a maximal matching" % rx_matches)
-            for (u, v) in rx_matches:
-                for nx_edge in nx_matches:
-                    if u in nx_edge or v in nx_edge:
-                        rx_weight = rx_graph.get_edge_data(u, v)
-                        nx_weight = nx_graph.get_edge_data(*nx_edge)
-                        if not nx_weight:
-                            nx_weight = None
-                        self.assertEqual(rx_weight, nx_weight)
+            self.assertEqual(sum(map(get_rx_weight, rx_matches)),
+                             sum(map(get_nx_weight, nx_matches)))
 
     def test_empty_graph(self):
         graph = retworkx.PyGraph()

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -110,6 +110,34 @@ class TestMaxWeightMatching(unittest.TestCase):
             retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
             {1: 2, 2: 1, 3: 6, 4: 5, 5: 4, 6: 3})
 
+    def test_s_t_blossom_with_removed_nodes(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 9),
+            (1, 3, 8),
+            (2, 3, 10),
+            (1, 4, 5),
+            (4, 5, 4),
+            (1, 6, 3),
+        ])
+        node_id = graph.add_node(None)
+        graph.remove_node(5)
+        graph.add_edge(4, node_id, 4)
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 7, 7: 4, 6: 1})
+        graph.remove_edge(1, 6)
+        graph.remove_edge(4, 7)
+        graph.extend_from_weighted_edge_list([(4, node_id, 3), (1, 6, 4)])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 7, 7: 4, 6: 1})
+        graph.remove_edge(1, 6)
+        graph.add_edge(3, 6, 4)
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 6, 4: 7, 7: 4, 6: 3})
+
     def test_nested_s_blossom(self):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -42,8 +42,17 @@ class TestMaxWeightMatching(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from([0, 1])
         graph.add_edges_from([(0, 1, 1)])
-        self.compare_match_sets(retworkx.max_weight_matching(graph),
-                                {(0, 1), })
+        self.compare_match_sets(
+            retworkx.max_weight_matching(graph, verify_optimum=True),
+            {(0, 1), })
+
+    def test_single_edge_no_verification(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        graph.add_edges_from([(0, 1, 1)])
+        self.compare_match_sets(
+            retworkx.max_weight_matching(graph, verify_optimum=False),
+            {(0, 1), })
 
     def test_single_self_edge(self):
         graph = retworkx.PyGraph()
@@ -54,7 +63,8 @@ class TestMaxWeightMatching(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 10), (2, 3, 11)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(2, 3), })
 
     def test_path_graph(self):
@@ -62,10 +72,12 @@ class TestMaxWeightMatching(unittest.TestCase):
         graph.extend_from_weighted_edge_list(
             [(1, 2, 5), (2, 3, 11), (3, 4, 5)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(2, 3), })
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), (3, 4)})
 
     def test_negative_weights(self):
@@ -78,10 +90,12 @@ class TestMaxWeightMatching(unittest.TestCase):
             (3, 4, -6),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), })
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 3), (2, 4)})
 
     def test_s_blossom(self):
@@ -93,11 +107,13 @@ class TestMaxWeightMatching(unittest.TestCase):
             (2, 3, 7),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(0, 1), (2, 3)})
         graph.extend_from_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(0, 5), (1, 2), (3, 4)})
 
     def test_s_t_blossom(self):
@@ -111,18 +127,21 @@ class TestMaxWeightMatching(unittest.TestCase):
             (1, 6, 3),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 6), (2, 3), (4, 5)})
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 5)
         graph.extend_from_weighted_edge_list([(4, 5, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 6), (2, 3), (4, 5)})
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), (3, 6), (4, 5)})
 
     def test_s_t_blossom_with_removed_nodes(self):
@@ -139,18 +158,21 @@ class TestMaxWeightMatching(unittest.TestCase):
         graph.remove_node(5)
         graph.add_edge(4, node_id, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 6), (2, 3), (4, 7)})
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 7)
         graph.extend_from_weighted_edge_list([(4, node_id, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 6), (2, 3), (4, 7)})
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), (3, 6), (4, 7)})
 
     def test_nested_s_blossom(self):
@@ -166,7 +188,8 @@ class TestMaxWeightMatching(unittest.TestCase):
         ])
         expected = {(1, 3), (2, 4), (5, 6)}
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             expected)
 
     def test_nested_s_blossom_relabel(self):
@@ -183,7 +206,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (7, 8, 8),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), (3, 4), (5, 6), (7, 8)})
 
     def test_nested_s_blossom_expand(self):
@@ -201,7 +225,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (7, 8, 12),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 2), (3, 5), (4, 6), (7, 8)})
 
     def test_s_blossom_relabel_expand(self):
@@ -217,7 +242,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (5, 7, 13),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             {(1, 6), (2, 3), (4, 8), (5, 7)})
 
     def test_nested_s_blossom_relabel_expand(self):
@@ -234,7 +260,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (5, 6, 7),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(
                 {1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1}))
 
@@ -253,7 +280,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (9, 10, 5),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(
                 {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
                  10: 9}))
@@ -273,7 +301,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (9, 10, 5),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(
                 {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
                  10: 9}))
@@ -293,7 +322,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (9, 10, 5),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(
                 {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
                  10: 9}))
@@ -314,7 +344,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             (4, 9, 30),
         ])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(
                 {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4,
                  10: 8}))
@@ -351,7 +382,8 @@ class TestMaxWeightMatching(unittest.TestCase):
             12: 11,
         }
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
+                                         verify_optimum=True),
             match_dict_to_set(expected))
 
     def test_gnp_random_against_networkx(self):
@@ -360,7 +392,8 @@ class TestMaxWeightMatching(unittest.TestCase):
                                                             seed=42 + i)
             nx_graph = networkx.Graph(list(rx_graph.edge_list()))
             nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph)
+            rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                      verify_optimum=True)
             # Convert retworkx dict output to networkx set of tuples
             for (u, v) in rx_matches:
                 if (u, v) not in nx_matches:
@@ -378,7 +411,7 @@ class TestMaxWeightMatching(unittest.TestCase):
         nx_matches = networkx.max_weight_matching(
             nx_graph, maxcardinality=True)
         rx_matches = retworkx.max_weight_matching(
-            rx_graph, max_cardinality=True)
+            rx_graph, max_cardinality=True, verify_optimum=True)
         # Convert retworkx dict output to networkx set of tuples
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
@@ -394,7 +427,7 @@ class TestMaxWeightMatching(unittest.TestCase):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
         nx_matches = networkx.max_weight_matching(nx_graph)
-        rx_matches = retworkx.max_weight_matching(rx_graph)
+        rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
                 if (v, u) not in nx_matches:
@@ -411,7 +444,7 @@ class TestMaxWeightMatching(unittest.TestCase):
         nx_matches = networkx.max_weight_matching(
             nx_graph, maxcardinality=True)
         rx_matches = retworkx.max_weight_matching(
-            rx_graph, max_cardinality=True)
+            rx_graph, max_cardinality=True, verify_optimum=True)
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
                 if (v, u) not in nx_matches:

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -59,8 +59,8 @@ class TestMaxWeightMatching(unittest.TestCase):
                           "reverse %s not found in networkx output.\nretworkx"
                           " output: %s\nnetworkx output: %s\nedge list: %s\n"
                           "falling back to checking for a valid solution" % (
-                            seed, (u, v), (v, u), rx_matches,
-                            nx_matches, list(rx_graph.edge_list())))
+                              seed, (u, v), (v, u), rx_matches,
+                              nx_matches, list(rx_graph.edge_list())))
                     not_match = True
                     break
         if not_match:
@@ -68,7 +68,6 @@ class TestMaxWeightMatching(unittest.TestCase):
                             "%s is not a valid matching" % rx_matches)
             self.assertTrue(is_maximal_matching(rx_graph, rx_matches),
                             "%s is not a maximal matching" % rx_matches)
-
 
     def test_empty_graph(self):
         graph = retworkx.PyGraph()
@@ -431,7 +430,6 @@ class TestMaxWeightMatching(unittest.TestCase):
             rx_matches = retworkx.max_weight_matching(rx_graph,
                                                       verify_optimum=True)
             self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i)
-
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -476,6 +476,25 @@ class TestMaxWeightMatching(unittest.TestCase):
         self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 428,
                                 nx_graph)
 
+    def test_gnp_random_against_networkx_with_weight_max_cardinality(self):
+        for i in range(1024):
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(0, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph,
+                                                      maxcardinality=True)
+            rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                      weight_fn=lambda x: x,
+                                                      max_cardinality=True,
+                                                      verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
+                                    nx_graph)
+
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -80,7 +80,7 @@ class TestMaxWeightMatching(unittest.TestCase):
         self.assertEqual(
             retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
             {0: 1, 1: 0, 2: 3, 3: 2})
-        graph.extend_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
+        graph.extend_from_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
         self.assertEqual(
             retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
             {0: 5, 1: 2, 2: 1, 3: 4, 4: 3, 5: 0})

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -16,6 +16,7 @@
 import unittest
 
 import retworkx
+import networkx
 
 
 class TestMaxWeightMatching(unittest.TestCase):
@@ -329,3 +330,25 @@ class TestMaxWeightMatching(unittest.TestCase):
         self.assertEqual(
             retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
             expected)
+
+    def test_gnp_random_against_networkx(self):
+        rx_graph = retworkx.undirected_gnp_random_graph(10, .75, seed=42)
+        nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+        nx_matches = networkx.max_weight_matching(nx_graph)
+        rx_match_dict = retworkx.max_weight_matching(rx_graph)
+        # Convert retworkx dict output to networkx set of tuples
+        rx_matches = {
+            (u, v) for (u, v) in set(map(frozenset, rx_match_dict.items()))}
+        self.assertEqual(nx_matches, rx_matches)
+
+    def test_gnp_random_against_networkx_max_cardinality(self):
+        rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
+        nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+        nx_matches = networkx.max_weight_matching(
+            nx_graph, maxcardinality=True)
+        rx_match_dict = retworkx.max_weight_matching(
+            rx_graph, max_cardinality=True)
+        # Convert retworkx dict output to networkx set of tuples
+        rx_matches = {
+            (u, v) for (u, v) in set(map(frozenset, rx_match_dict.items()))}
+        self.assertEqual(nx_matches, rx_matches)

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -427,7 +427,8 @@ class TestMaxWeightMatching(unittest.TestCase):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
         nx_matches = networkx.max_weight_matching(nx_graph)
-        rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
+        rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                  verify_optimum=True)
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
                 if (v, u) not in nx_matches:

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -466,6 +466,23 @@ class TestMaxWeightMatching(unittest.TestCase):
             self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
                                     nx_graph)
 
+    def test_gnp_random_against_networkx_with_negative_weight(self):
+        for i in range(1024):
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph)
+            rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                      weight_fn=lambda x: x,
+                                                      verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
+                                    nx_graph)
+
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
@@ -483,6 +500,25 @@ class TestMaxWeightMatching(unittest.TestCase):
                                                             seed=42 + i)
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(0, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph,
+                                                      maxcardinality=True)
+            rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                      weight_fn=lambda x: x,
+                                                      max_cardinality=True,
+                                                      verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
+                                    nx_graph)
+
+    def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
+        for i in range(1024):
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
             nx_graph = networkx.Graph(
                 [(x[0], x[1],
                   {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -440,48 +440,49 @@ class TestMaxWeightMatching(unittest.TestCase):
 
     def test_gnp_random_against_networkx(self):
         for i in range(1024):
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
-            nx_graph = networkx.Graph(list(rx_graph.edge_list()))
-            nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
-                                    nx_graph)
+            with self.subTest(i=i):
+                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                                seed=42 + i)
+                nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+                nx_matches = networkx.max_weight_matching(nx_graph)
+                rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                          verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                        42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_weight(self):
         for i in range(1024):
-            random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
-            for edge in rx_graph.edge_list():
-                rx_graph.update_edge(*edge, random.randint(0, 5000))
-            nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      weight_fn=lambda x: x,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
-                                    nx_graph)
+            with self.subTest(i=i):
+                random.seed(i)
+                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                                seed=42 + i)
+                for edge in rx_graph.edge_list():
+                    rx_graph.update_edge(*edge, random.randint(0, 5000))
+                nx_graph = networkx.Graph(
+                    [(x[0], x[1],
+                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                nx_matches = networkx.max_weight_matching(nx_graph)
+                rx_matches = retworkx.max_weight_matching(
+                    rx_graph, weight_fn=lambda x: x, verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                        42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_negative_weight(self):
         for i in range(1024):
-            random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
-            for edge in rx_graph.edge_list():
-                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
-            nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      weight_fn=lambda x: x,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
-                                    nx_graph)
+            with self.subTest(i=i):
+                random.seed(i)
+                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                                seed=42 + i)
+                for edge in rx_graph.edge_list():
+                    rx_graph.update_edge(*edge, random.randint(-5000, 5000))
+                nx_graph = networkx.Graph(
+                    [(x[0], x[1],
+                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                nx_matches = networkx.max_weight_matching(nx_graph)
+                rx_matches = retworkx.max_weight_matching(
+                    rx_graph, weight_fn=lambda x: x, verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                        42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
@@ -495,41 +496,41 @@ class TestMaxWeightMatching(unittest.TestCase):
 
     def test_gnp_random_against_networkx_with_weight_max_cardinality(self):
         for i in range(1024):
-            random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
-            for edge in rx_graph.edge_list():
-                rx_graph.update_edge(*edge, random.randint(0, 5000))
-            nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph,
-                                                      maxcardinality=True)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      weight_fn=lambda x: x,
-                                                      max_cardinality=True,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
-                                    nx_graph)
+            with self.subTest(i=i):
+                random.seed(i)
+                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                                seed=42 + i)
+                for edge in rx_graph.edge_list():
+                    rx_graph.update_edge(*edge, random.randint(0, 5000))
+                nx_graph = networkx.Graph(
+                    [(x[0], x[1],
+                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                nx_matches = networkx.max_weight_matching(nx_graph,
+                                                          maxcardinality=True)
+                rx_matches = retworkx.max_weight_matching(
+                    rx_graph, weight_fn=lambda x: x, max_cardinality=True,
+                    verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                        42 + i, nx_graph)
 
     def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
         for i in range(1024):
-            random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
-            for edge in rx_graph.edge_list():
-                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
-            nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                  {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph,
-                                                      maxcardinality=True)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      weight_fn=lambda x: x,
-                                                      max_cardinality=True,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i,
-                                    nx_graph)
+            with self.subTest(i=i):
+                random.seed(i)
+                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                                seed=42 + i)
+                for edge in rx_graph.edge_list():
+                    rx_graph.update_edge(*edge, random.randint(-5000, 5000))
+                nx_graph = networkx.Graph(
+                    [(x[0], x[1],
+                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                nx_matches = networkx.max_weight_matching(nx_graph,
+                                                          maxcardinality=True)
+                rx_matches = retworkx.max_weight_matching(
+                    rx_graph, weight_fn=lambda x: x, max_cardinality=True,
+                    verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                        42 + i, nx_graph)
 
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -332,14 +332,22 @@ class TestMaxWeightMatching(unittest.TestCase):
             expected)
 
     def test_gnp_random_against_networkx(self):
-        rx_graph = retworkx.undirected_gnp_random_graph(10, .75, seed=42)
-        nx_graph = networkx.Graph(list(rx_graph.edge_list()))
-        nx_matches = networkx.max_weight_matching(nx_graph)
-        rx_match_dict = retworkx.max_weight_matching(rx_graph)
-        # Convert retworkx dict output to networkx set of tuples
-        rx_matches = {
-            (u, v) for (u, v) in set(map(frozenset, rx_match_dict.items()))}
-        self.assertEqual(nx_matches, rx_matches)
+        for i in range(1024):
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+            nx_matches = networkx.max_weight_matching(nx_graph)
+            rx_match_dict = retworkx.max_weight_matching(rx_graph)
+            # Convert retworkx dict output to networkx set of tuples
+            for (u, v) in set(map(frozenset, rx_match_dict.items())):
+                if (u, v) not in nx_matches:
+                    if (v, u) not in nx_matches:
+                        self.fail("seed %s failed. Element %s and it's "
+                                  " reverse %s not found "
+                                  "in networkx output.\nretworkx output: %s"
+                                  "\nnetworkx output: %s\nedge list: %s" % (
+                                      42 + i, (u, v), (v, u), rx_match_dict,
+                                      nx_matches, list(rx_graph.edge_list())))
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
@@ -349,6 +357,44 @@ class TestMaxWeightMatching(unittest.TestCase):
         rx_match_dict = retworkx.max_weight_matching(
             rx_graph, max_cardinality=True)
         # Convert retworkx dict output to networkx set of tuples
-        rx_matches = {
-            (u, v) for (u, v) in set(map(frozenset, rx_match_dict.items()))}
-        self.assertEqual(nx_matches, rx_matches)
+        for (u, v) in set(map(frozenset, rx_match_dict.items())):
+            if (u, v) not in nx_matches:
+                if (v, u) not in nx_matches:
+                    self.fail("seed %s failed. Element %s and it's "
+                              " reverse %s not found "
+                              "in networkx output.\nretworkx output: %s"
+                              "\nnetworkx output: %s\nedge list: %s" % (
+                                  428, (u, v), (v, u), rx_match_dict,
+                                  nx_matches, list(rx_graph.edge_list())))
+
+    def test_gnm_random_against_networkx(self):
+        rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)
+        nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+        nx_matches = networkx.max_weight_matching(nx_graph)
+        rx_match_dict = retworkx.max_weight_matching(rx_graph)
+        for (u, v) in set(map(frozenset, rx_match_dict.items())):
+            if (u, v) not in nx_matches:
+                if (v, u) not in nx_matches:
+                    self.fail("seed %s failed. Element %s and it's "
+                              " reverse %s not found "
+                              "in networkx output.\nretworkx output: %s"
+                              "\nnetworkx output: %s\nedge list: %s" % (
+                                  42, (u, v), (v, u), rx_match_dict,
+                                  nx_matches, list(rx_graph.edge_list())))
+
+    def test_gnm_random_against_networkx_max_cardinality(self):
+        rx_graph = retworkx.undirected_gnm_random_graph(10, 12, seed=428)
+        nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+        nx_matches = networkx.max_weight_matching(
+            nx_graph, maxcardinality=True)
+        rx_match_dict = retworkx.max_weight_matching(
+            rx_graph, max_cardinality=True)
+        for (u, v) in set(map(frozenset, rx_match_dict.items())):
+            if (u, v) not in nx_matches:
+                if (v, u) not in nx_matches:
+                    self.fail("seed %s failed. Element %s and it's "
+                              " reverse %s not found "
+                              "in networkx output.\nretworkx output: %s"
+                              "\nnetworkx output: %s\nedge list: %s" % (
+                                  42, (u, v), (v, u), rx_match_dict,
+                                  nx_matches, list(rx_graph.edge_list())))

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -1,0 +1,303 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# These tests are adapated from the networkx test cases:
+# https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/tests/test_matching.py
+
+import unittest
+
+import retworkx
+
+
+class TestMaxWeightMatching(unittest.TestCase):
+
+    def test_empty_graph(self):
+        graph = retworkx.PyGraph()
+        self.assertEqual(retworkx.max_weight_matching(graph), {})
+
+    def test_single_edge(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1])
+        graph.add_edges_from([(0, 1, 1)])
+        self.assertEqual(retworkx.max_weight_matching(graph), {0: 1, 1: 0})
+
+    def test_single_self_edge(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([(0, 0, 100)])
+        self.assertEqual(retworkx.max_weight_matching(graph), {})
+
+    def test_small_graph(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([(1, 2, 10), (2, 3, 11)])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {3: 2, 2: 3})
+
+    def test_path_graph(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list(
+            [(1, 2, 5), (2, 3, 11), (3, 4, 5)])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {2: 3, 3: 2})
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 4, 4: 3})
+
+    def test_negative_weights(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 2),
+            (1, 3, -2),
+            (2, 3, 1),
+            (2, 4, -1),
+            (3, 4, -6),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1})
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x),
+            {1: 3, 2: 4, 3: 1, 4: 2})
+
+    def test_s_blossom(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (0, 1, 8),
+            (0, 2, 9),
+            (1, 2, 10),
+            (2, 3, 7),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {0: 1, 1: 0, 2: 3, 3: 2})
+        graph.extend_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {0: 5, 1: 2, 2: 1, 3: 4, 4: 3, 5: 0})
+
+    def test_s_t_blossom(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 9),
+            (1, 3, 8),
+            (2, 3, 10),
+            (1, 4, 5),
+            (4, 5, 4),
+            (1, 6, 3),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
+        graph.remove_edge(1, 6)
+        graph.remove_edge(4, 5)
+        graph.extend_from_weighted_edge_list([(4, 5, 3), (1, 6, 4)])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 5, 5: 4, 6: 1})
+        graph.remove_edge(1, 6)
+        graph.add_edge(3, 6, 4)
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 6, 4: 5, 5: 4, 6: 3})
+
+    def test_nested_s_blossom(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 9),
+            (1, 3, 9),
+            (2, 3, 10),
+            (2, 4, 8),
+            (3, 5, 8),
+            (4, 5, 10),
+            (5, 6, 6),
+        ])
+        expected = {1: 3, 2: 4, 3: 1, 4: 2, 5: 6, 6: 5}
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            expected)
+
+    def test_nested_s_blossom_relabel(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 10),
+            (1, 7, 10),
+            (2, 3, 12),
+            (3, 4, 20),
+            (3, 5, 20),
+            (4, 5, 25),
+            (5, 6, 10),
+            (6, 7, 10),
+            (7, 8, 8),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 4, 4: 3, 5: 6, 6: 5, 7: 8, 8: 7})
+
+    def test_nested_s_blossom_expand(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 8),
+            (1, 3, 8),
+            (2, 3, 10),
+            (2, 4, 12),
+            (3, 5, 12),
+            (4, 5, 14),
+            (4, 6, 12),
+            (5, 7, 12),
+            (6, 7, 14),
+            (7, 8, 12),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 5, 4: 6, 5: 3, 6: 4, 7: 8, 8: 7})
+
+    def test_s_blossom_relabel_expand(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 23),
+            (1, 5, 22),
+            (1, 6, 15),
+            (2, 3, 25),
+            (3, 4, 22),
+            (4, 5, 25),
+            (4, 8, 14),
+            (5, 7, 13),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4})
+
+    def test_nested_s_blossom_relabel_expand(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 19),
+            (1, 3, 20),
+            (1, 8, 8),
+            (2, 3, 25),
+            (2, 4, 18),
+            (3, 5, 18),
+            (4, 5, 13),
+            (4, 7, 7),
+            (5, 6, 7),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1})
+
+    def test_blossom_relabel_multiple_paths(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 45),
+            (1, 5, 45),
+            (2, 3, 50),
+            (3, 4, 45),
+            (4, 5, 50),
+            (1, 6, 30),
+            (3, 9, 35),
+            (4, 8, 35),
+            (5, 7, 26),
+            (9, 10, 5),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
+
+    def test_blossom_relabel_multiple_path_alternate(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 45),
+            (1, 5, 45),
+            (2, 3, 50),
+            (3, 4, 45),
+            (4, 5, 50),
+            (1, 6, 30),
+            (3, 9, 35),
+            (4, 8, 26),
+            (5, 7, 40),
+            (9, 10, 5),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
+
+    def test_blossom_relabel_multiple_paths_least_slack(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 45),
+            (1, 5, 45),
+            (2, 3, 50),
+            (3, 4, 45),
+            (4, 5, 50),
+            (1, 6, 30),
+            (3, 9, 35),
+            (4, 8, 28),
+            (5, 7, 26),
+            (9, 10, 5),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9})
+
+    def test_nested_blossom_expand_recursively(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 40),
+            (1, 3, 40),
+            (2, 3, 60),
+            (2, 4, 55),
+            (3, 5, 55),
+            (4, 5, 50),
+            (1, 8, 15),
+            (5, 7, 30),
+            (7, 6, 10),
+            (8, 10, 10),
+            (4, 9, 30),
+        ])
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8})
+
+    def test_nested_blossom_augmented(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([
+            (1, 2, 45),
+            (1, 7, 45),
+            (2, 3, 50),
+            (3, 4, 45),
+            (4, 5, 95),
+            (4, 6, 94),
+            (5, 6, 94),
+            (6, 7, 50),
+            (1, 8, 30),
+            (3, 11, 35),
+            (5, 9, 36),
+            (7, 10, 26),
+            (11, 12, 5),
+        ])
+        expected = {
+            1: 8,
+            2: 3,
+            3: 2,
+            4: 6,
+            5: 9,
+            6: 4,
+            7: 10,
+            8: 1,
+            9: 5,
+            10: 7,
+            11: 12,
+            12: 11,
+        }
+        self.assertEqual(
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x),
+            expected)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
   networkx>=2.5
 changedir = {toxinidir}/tests
 commands =
-  python -m unittest discover . --verbose --buffer
+  python -m unittest discover .
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   ARGS="-V"
-deps = setuptools-rust
+deps =
+  setuptools-rust
+  networkx>=2.5
 changedir = {toxinidir}/tests
 commands =
   python -m unittest discover .

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
   networkx>=2.5
 changedir = {toxinidir}/tests
 commands =
-  python -m unittest discover .
+  python -m unittest discover . --verbose --buffer
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
This commit adds a new python function max_weight_matching() for
computing the maximum-weighted matching of a PyGraph object. The
implementation of this function is based on “Efficient Algorithms for
Finding Maximum Matching in Graphs”, Zvi Galil, ACM Computing Surveys,
1986. [1] It is basically a porting of the networkx implementation of
the algorithm [2] with some additional inspiration from the prototype for
the networkx version (it's basically the same code but some aspects were
a bit clearer to figure out from the prototype rather than networkx's
copy of it). [3][4]

Fixes #216

[1] https://dl.acm.org/doi/10.1145/6462.6502
[2] https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/matching.py
[3] http://jorisvr.nl/article/maximum-matching
[4] http://jorisvr.nl/files/graphmatching/20130407/mwmatching.py

TODO:

- [x] Fix test failures
- [x] Change output from function to be set of tuples for each matching pair instead of dict?

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
