### PR TITLE
Use full LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ features = ["rayon"]
 [dependencies.ndarray]
 version = "^0.14.0"
 features = ["rayon"]
+
+[profile.release]
+lto = 'fat'
+codegen-units = 1


### PR DESCRIPTION
This commit changes the release build configuration to use full LTO for
retworkx release builds. The tradeoff this makes is compile time vs
optimization. It basically serializes the compilation of retworkx's
dependencies so that it can do link time optimization. From benchmarking
the performance gains are modest (in the best case ~2-5%), but it
still seems worth it since most users don't constantly rebuild retworkx
and just use the prebuilt binaries that are included in the wheels on
PyPI so tuning the release builds at the cost of compile time seems
worth it.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
