### PR TITLE
Avoid allocation overhead with_capacity() instead of new()

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -393,7 +393,8 @@ impl PyDiGraph {
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         let out_dict = PyDict::new(py);
         let node_dict = PyDict::new(py);
-        let mut out_list: Vec<PyObject> = Vec::new();
+        let mut out_list: Vec<PyObject> =
+            Vec::with_capacity(self.graph.edge_count());
         out_dict.set_item("nodes", node_dict)?;
 
         let dir = petgraph::Direction::Incoming;
@@ -822,7 +823,7 @@ impl PyDiGraph {
         &mut self,
         obj_list: Vec<(usize, usize, PyObject)>,
     ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
         for obj in obj_list {
             let p_index = NodeIndex::new(obj.0);
             let c_index = NodeIndex::new(obj.1);
@@ -848,7 +849,7 @@ impl PyDiGraph {
         py: Python,
         obj_list: Vec<(usize, usize)>,
     ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
         for obj in obj_list {
             let p_index = NodeIndex::new(obj.0);
             let c_index = NodeIndex::new(obj.1);
@@ -1443,7 +1444,7 @@ impl PyDiGraph {
     /// :rtype: NodeIndices
     #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(self.node_count());
         for obj in obj_list {
             let node_index = self.graph.add_node(obj);
             out_list.push(node_index.index());
@@ -1821,7 +1822,8 @@ impl PyDiGraph {
         node_map_func: Option<PyObject>,
         edge_map_func: Option<PyObject>,
     ) -> PyResult<PyObject> {
-        let mut new_node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let mut new_node_map: HashMap<NodeIndex, NodeIndex> =
+            HashMap::with_capacity(other.node_count());
 
         // TODO: Reimplement this without looping over the graphs
         // Loop over other nodes add add to self graph
@@ -1874,7 +1876,8 @@ impl PyDiGraph {
     #[text_signature = "(self, nodes, /)"]
     pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyDiGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
-        let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let mut node_map: HashMap<NodeIndex, NodeIndex> =
+            HashMap::with_capacity(nodes.len());
         let node_filter =
             |node: NodeIndex| -> bool { node_set.contains(&node.index()) };
         let mut out_graph = StableDiGraph::<PyObject, PyObject>::new();
@@ -1937,7 +1940,8 @@ impl PyDiGraph {
     #[text_signature = "(self)"]
     pub fn to_undirected(&self, py: Python) -> crate::graph::PyGraph {
         let mut new_graph = StableUnGraph::<PyObject, PyObject>::default();
-        let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let mut node_map: HashMap<NodeIndex, NodeIndex> =
+            HashMap::with_capacity(self.node_count());
         for node_index in self.graph.node_indices() {
             let node = self.graph[node_index].clone_ref(py);
             let new_index = new_graph.add_node(node);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -263,7 +263,8 @@ impl PyGraph {
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         let out_dict = PyDict::new(py);
         let node_dict = PyDict::new(py);
-        let mut out_list: Vec<PyObject> = Vec::new();
+        let mut out_list: Vec<PyObject> =
+            Vec::with_capacity(self.graph.edge_count());
         out_dict.set_item("nodes", node_dict)?;
         for node_index in self.graph.node_indices() {
             let node_data = self.graph.node_weight(node_index).unwrap();
@@ -550,7 +551,7 @@ impl PyGraph {
         &mut self,
         obj_list: Vec<(usize, usize, PyObject)>,
     ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
         for obj in obj_list {
             let p_index = NodeIndex::new(obj.0);
             let c_index = NodeIndex::new(obj.1);
@@ -576,7 +577,7 @@ impl PyGraph {
         py: Python,
         obj_list: Vec<(usize, usize)>,
     ) -> PyResult<Vec<usize>> {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
         for obj in obj_list {
             let p_index = NodeIndex::new(obj.0);
             let c_index = NodeIndex::new(obj.1);
@@ -731,7 +732,7 @@ impl PyGraph {
     /// :rtype: NodeIndices
     #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
-        let mut out_list: Vec<usize> = Vec::new();
+        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
         for obj in obj_list {
             let node_index = self.graph.add_node(obj);
             out_list.push(node_index.index());
@@ -1103,7 +1104,8 @@ impl PyGraph {
         node_map_func: Option<PyObject>,
         edge_map_func: Option<PyObject>,
     ) -> PyResult<PyObject> {
-        let mut new_node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let mut new_node_map: HashMap<NodeIndex, NodeIndex> =
+            HashMap::with_capacity(other.node_count());
 
         // TODO: Reimplement this without looping over the graphs
         // Loop over other nodes add add to self graph
@@ -1156,7 +1158,8 @@ impl PyGraph {
     #[text_signature = "(self, nodes, /)"]
     pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
-        let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
+        let mut node_map: HashMap<NodeIndex, NodeIndex> =
+            HashMap::with_capacity(nodes.len());
         let node_filter =
             |node: NodeIndex| -> bool { node_set.contains(&node.index()) };
         let mut out_graph = StableUnGraph::<PyObject, PyObject>::default();

--- a/src/k_shortest_path.rs
+++ b/src/k_shortest_path.rs
@@ -59,7 +59,7 @@ where
     F: FnMut(&PyObject) -> PyResult<f64>,
 {
     let mut counter: Vec<usize> = vec![0; graph.node_count()];
-    let mut scores = HashMap::new();
+    let mut scores = HashMap::with_capacity(graph.node_count());
     let mut visit_next = BinaryHeap::new();
     let zero_score = 0.0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,8 @@ fn number_weakly_connected_components(graph: &digraph::PyDiGraph) -> usize {
 pub fn weakly_connected_components(
     graph: &digraph::PyDiGraph,
 ) -> Vec<BTreeSet<usize>> {
-    let mut seen: HashSet<NodeIndex> = HashSet::new();
+    let mut seen: HashSet<NodeIndex> =
+        HashSet::with_capacity(graph.node_count());
     let mut out_vec: Vec<BTreeSet<usize>> = Vec::new();
     for node in graph.graph.node_indices() {
         if !seen.contains(&node) {
@@ -371,7 +372,11 @@ fn topological_sort(graph: &digraph::PyDiGraph) -> PyResult<NodeIndices> {
     })
 }
 
-fn dfs_edges<G>(graph: G, source: Option<usize>) -> Vec<(usize, usize)>
+fn dfs_edges<G>(
+    graph: G,
+    source: Option<usize>,
+    edge_count: usize,
+) -> Vec<(usize, usize)>
 where
     G: GraphBase<NodeId = NodeIndex>
         + IntoNodeIdentifiers
@@ -388,8 +393,9 @@ where
             .map(|ind| NodeIndex::new(graph.to_index(ind)))
             .collect(),
     };
-    let mut visited: HashSet<NodeIndex> = HashSet::new();
-    let mut out_vec: Vec<(usize, usize)> = Vec::new();
+    let node_count = graph.node_count();
+    let mut visited: HashSet<NodeIndex> = HashSet::with_capacity(node_count);
+    let mut out_vec: Vec<(usize, usize)> = Vec::with_capacity(edge_count);
     for start in nodes {
         if visited.contains(&start) {
             continue;
@@ -400,7 +406,8 @@ where
         let mut stack: Vec<(NodeIndex, Vec<NodeIndex>)> =
             vec![(start, children)];
         // Used to track the last position in children vec across iterations
-        let mut index_map: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut index_map: HashMap<NodeIndex, usize> =
+            HashMap::with_capacity(node_count);
         index_map.insert(start, 0);
         while !stack.is_empty() {
             let temp_parent = stack.last().unwrap();
@@ -451,7 +458,7 @@ fn digraph_dfs_edges(
     source: Option<usize>,
 ) -> EdgeList {
     EdgeList {
-        edges: dfs_edges(graph, source),
+        edges: dfs_edges(graph, source, graph.graph.edge_count()),
     }
 }
 
@@ -471,7 +478,7 @@ fn digraph_dfs_edges(
 #[text_signature = "(graph, /, source=None)"]
 fn graph_dfs_edges(graph: &graph::PyGraph, source: Option<usize>) -> EdgeList {
     EdgeList {
-        edges: dfs_edges(graph, source),
+        edges: dfs_edges(graph, source, graph.graph.edge_count()),
     }
 }
 
@@ -497,7 +504,8 @@ fn bfs_successors(
 ) -> PyResult<iterators::BFSSuccessors> {
     let index = NodeIndex::new(node);
     let mut bfs = Bfs::new(graph, index);
-    let mut out_list: Vec<(PyObject, Vec<PyObject>)> = Vec::new();
+    let mut out_list: Vec<(PyObject, Vec<PyObject>)> =
+        Vec::with_capacity(graph.node_count());
     while let Some(nx) = bfs.next(graph) {
         let children = graph
             .graph
@@ -535,7 +543,8 @@ fn bfs_successors(
 #[text_signature = "(graph, node, /)"]
 fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
-    let mut out_set: HashSet<usize> = HashSet::new();
+    let mut out_set: HashSet<usize> =
+        HashSet::with_capacity(graph.node_count());
     let reverse_graph = Reversed(graph);
     let res = algo::dijkstra(reverse_graph, index, None, |_| 1);
     for n in res.keys() {
@@ -562,7 +571,8 @@ fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 #[text_signature = "(graph, node, /)"]
 fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
-    let mut out_set: HashSet<usize> = HashSet::new();
+    let mut out_set: HashSet<usize> =
+        HashSet::with_capacity(graph.node_count());
     let res = algo::dijkstra(graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();
@@ -596,7 +606,9 @@ fn lexicographical_topological_sort(
         Ok(res.to_object(py))
     };
     // HashMap of node_index indegree
-    let mut in_degree_map: HashMap<NodeIndex, usize> = HashMap::new();
+    let node_count = dag.node_count();
+    let mut in_degree_map: HashMap<NodeIndex, usize> =
+        HashMap::with_capacity(node_count);
     for node in dag.graph.node_indices() {
         in_degree_map.insert(node, dag.in_degree(node.index()));
     }
@@ -625,7 +637,7 @@ fn lexicographical_topological_sort(
             Some(self.cmp(other))
         }
     }
-    let mut zero_indegree = BinaryHeap::new();
+    let mut zero_indegree = BinaryHeap::with_capacity(node_count);
     for (node, degree) in in_degree_map.iter() {
         if *degree == 0 {
             let map_key_raw = key_callable(&dag.graph[*node])?;
@@ -636,7 +648,7 @@ fn lexicographical_topological_sort(
             });
         }
     }
-    let mut out_list: Vec<&PyObject> = Vec::new();
+    let mut out_list: Vec<&PyObject> = Vec::with_capacity(node_count);
     let dir = petgraph::Direction::Outgoing;
     while let Some(State { node, .. }) = zero_indegree.pop() {
         let neighbors = dag.graph.neighbors_directed(node, dir);
@@ -673,7 +685,8 @@ fn graph_greedy_color(
 ) -> PyResult<PyObject> {
     let mut colors: HashMap<usize, usize> = HashMap::new();
     let mut node_vec: Vec<NodeIndex> = graph.graph.node_indices().collect();
-    let mut sort_map: HashMap<NodeIndex, usize> = HashMap::new();
+    let mut sort_map: HashMap<NodeIndex, usize> =
+        HashMap::with_capacity(graph.node_count());
     for k in node_vec.iter() {
         sort_map.insert(*k, graph.graph.edges(*k).count());
     }
@@ -847,7 +860,8 @@ fn graph_k_shortest_path_lengths(
 #[pyfunction]
 #[text_signature = "(dag, /)"]
 fn floyd_warshall(py: Python, dag: &digraph::PyDiGraph) -> PyResult<PyObject> {
-    let mut dist: HashMap<(usize, usize), usize> = HashMap::new();
+    let mut dist: HashMap<(usize, usize), usize> =
+        HashMap::with_capacity(dag.node_count());
     for node in dag.graph.node_indices() {
         // Distance from a node to itself is zero
         dist.insert((node.index(), node.index()), 0);
@@ -917,13 +931,15 @@ where
         + IntoEdgeReferences
         + IntoNodeIdentifiers
         + NodeIndexable
+        + NodeCount
         + GraphProp
         + NodesRemoved,
     G: Data<NodeWeight = PyObject, EdgeWeight = PyObject>,
 {
     let node_map: Option<HashMap<NodeIndex, usize>>;
     if graph.nodes_removed() {
-        let mut node_hash_map: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut node_hash_map: HashMap<NodeIndex, usize> =
+            HashMap::with_capacity(graph.node_count());
         for (count, node) in graph.node_identifiers().enumerate() {
             let index = NodeIndex::new(graph.to_index(node));
             node_hash_map.insert(index, count);
@@ -1108,7 +1124,8 @@ fn collect_runs(
     filter_fn: PyObject,
 ) -> PyResult<Vec<Vec<PyObject>>> {
     let mut out_list: Vec<Vec<PyObject>> = Vec::new();
-    let mut seen: HashSet<NodeIndex> = HashSet::new();
+    let mut seen: HashSet<NodeIndex> =
+        HashSet::with_capacity(graph.node_count());
 
     let filter_node = |node: &PyObject| -> PyResult<bool> {
         let res = filter_fn.call1(py, (node,))?;
@@ -1278,7 +1295,7 @@ pub fn digraph_distance_matrix(
     let n = graph.node_count();
     let mut matrix = Array2::<f64>::zeros((n, n));
     let bfs_traversal = |index: usize, mut row: ArrayViewMut1<f64>| {
-        let mut seen: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut seen: HashMap<NodeIndex, usize> = HashMap::with_capacity(n);
         let start_index = NodeIndex::new(index);
         let mut level = 0;
         let mut next_level: HashSet<NodeIndex> = HashSet::new();
@@ -1360,7 +1377,7 @@ pub fn graph_distance_matrix(
     let n = graph.node_count();
     let mut matrix = Array2::<f64>::zeros((n, n));
     let bfs_traversal = |index: usize, mut row: ArrayViewMut1<f64>| {
-        let mut seen: HashMap<NodeIndex, usize> = HashMap::new();
+        let mut seen: HashMap<NodeIndex, usize> = HashMap::with_capacity(n);
         let start_index = NodeIndex::new(index);
         let mut level = 0;
         let mut next_level: HashSet<NodeIndex> = HashSet::new();
@@ -1654,7 +1671,8 @@ pub fn graph_dijkstra_shortest_paths(
         Some(node) => Some(NodeIndex::new(node)),
         None => None,
     };
-    let mut paths: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+    let mut paths: HashMap<NodeIndex, Vec<NodeIndex>> =
+        HashMap::with_capacity(graph.node_count());
     dijkstra::dijkstra(
         graph,
         start,
@@ -1719,7 +1737,8 @@ pub fn digraph_dijkstra_shortest_paths(
         Some(node) => Some(NodeIndex::new(node)),
         None => None,
     };
-    let mut paths: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+    let mut paths: HashMap<NodeIndex, Vec<NodeIndex>> =
+        HashMap::with_capacity(graph.node_count());
     if as_undirected {
         dijkstra::dijkstra(
             // TODO: Use petgraph undirected adapter after
@@ -2513,7 +2532,8 @@ pub fn digraph_find_cycle(
 ) -> EdgeList {
     let mut graph_nodes: HashSet<NodeIndex> =
         graph.graph.node_indices().collect();
-    let mut cycle: Vec<(usize, usize)> = Vec::new();
+    let mut cycle: Vec<(usize, usize)> =
+        Vec::with_capacity(graph.graph.edge_count());
     let temp_value: NodeIndex;
     // If source is not set get an arbitrary node from the set of graph
     // nodes we've not "examined"

--- a/src/union.rs
+++ b/src/union.rs
@@ -49,8 +49,8 @@ pub fn digraph_union(
         check_cycle: false,
         node_removed: false,
     };
-    let mut node_map = HashMap::new();
-    let mut edge_map = HashSet::new();
+    let mut node_map = HashMap::with_capacity(second.node_count());
+    let mut edge_map = HashSet::with_capacity(second.edge_count());
 
     let compare_weights = |a: &PyAny, b: &PyAny| -> PyResult<bool> {
         let res = a.compare(b)?;


### PR DESCRIPTION
This commit replaces uses of ::new() for container types (like Vec and
HashMap) with with_capacity(). The difference between the 2 is that
with_capacity() makes the initial memory allocation with N elements of
the given type in the container (and still grows when it's exceeded)
while new() just makes a minimal initial memory allocation and relies on
more allocations. So it becomes a tradeoff between using potentially
excess memory vs th overhead of additional memory allocations. So for
cases where we have an idea of the final size of the container object it
makes sense to avoid the memory allocation and just do a large one up
front.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
