### PR TITLE
Fix regressions from incorrect switch to with_capacity()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c88d9506e2e9230f6107701b7d8425f4cb3f6df108ec3042a26e936666da5"
+checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
 dependencies = [
  "quote",
  "syn",
@@ -100,9 +100,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "getrandom"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1444,11 +1444,10 @@ impl PyDiGraph {
     /// :rtype: NodeIndices
     #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
-        let mut out_list: Vec<usize> = Vec::with_capacity(self.node_count());
-        for obj in obj_list {
-            let node_index = self.graph.add_node(obj);
-            out_list.push(node_index.index());
-        }
+        let out_list: Vec<usize> = obj_list
+            .into_iter()
+            .map(|obj| self.graph.add_node(obj).index())
+            .collect();
         NodeIndices { nodes: out_list }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -732,11 +732,10 @@ impl PyGraph {
     /// :rtype: NodeIndices
     #[text_signature = "(self, obj_list, /)"]
     pub fn add_nodes_from(&mut self, obj_list: Vec<PyObject>) -> NodeIndices {
-        let mut out_list: Vec<usize> = Vec::with_capacity(obj_list.len());
-        for obj in obj_list {
-            let node_index = self.graph.add_node(obj);
-            out_list.push(node_index.index());
-        }
+        let out_list: Vec<usize> = obj_list
+            .into_iter()
+            .map(|obj| self.graph.add_node(obj).index())
+            .collect();
         NodeIndices { nodes: out_list }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,8 +543,7 @@ fn bfs_successors(
 #[text_signature = "(graph, node, /)"]
 fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
-    let mut out_set: HashSet<usize> =
-        HashSet::with_capacity(graph.node_count());
+    let mut out_set: HashSet<usize> = HashSet::new();
     let reverse_graph = Reversed(graph);
     let res = algo::dijkstra(reverse_graph, index, None, |_| 1);
     for n in res.keys() {
@@ -571,8 +570,7 @@ fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 #[text_signature = "(graph, node, /)"]
 fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
     let index = NodeIndex::new(node);
-    let mut out_set: HashSet<usize> =
-        HashSet::with_capacity(graph.node_count());
+    let mut out_set: HashSet<usize> = HashSet::new();
     let res = algo::dijkstra(graph, index, None, |_| 1);
     for n in res.keys() {
         let n_int = n.index();


### PR DESCRIPTION
In the recently merged #233 there were a couple of places we incorrectly
used with_capacity() which caused a regression since we were allocating
a lot memory than actually was needed and took longer than the dynamic
reallocation which was done before.[1][2][3] This commit fixes those
regressions by either switching back to new() or using an iterator with
collect().

[1]https://mtreinish.github.io/retworkx-bench/#predecessors_successors.PredecessorsSuccessorBenchmarks.time_descendants?p-Number%20of%20Nodes=1000000&p-Number%20of%20Edges=1000000&commits=a3249f08-dd220ea5
[2]https://mtreinish.github.io/retworkx-bench/#predecessors_successors.PredecessorsSuccessorBenchmarks.time_ancestors?p-Number%20of%20Nodes=1000000&p-Number%20of%20Edges=1000000&commits=a3249f08-dd220ea5
[3] https://mtreinish.github.io/retworkx-bench/#node_benchmarks.DiGraphNodeAddition.time_add_from?p-Graph%20Size=1000000&p-Number%20of%20Nodes=100000&commits=a3249f08-dd220ea5

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
