### PR TITLE
Fix read the docs builds by updating rust compiler version

### DIFF
--- a/.conda-rtd-environment.yml
+++ b/.conda-rtd-environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - rust=1.40.0=1
+  - rust=1.49.0
   - graphviz
   - pip
   - pip:


### PR DESCRIPTION
The read the docs builds are using conda to install rust and other
system dependencies required to install retworkx and build the docs.
However, the version of rust was pinned at 1.40 which is now too old
after #224 merged which bumped the minimum supported rust version from
1.39.0 to 1.45.0 because of a newer version of pyo3. This commit updates
the read the docs conda env to use the latest stable rust release 1.49.0
so that we can build retworkx for docs builds again.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
