### PR TITLE
Revert "Bump pyo3 from 0.12.4 to 0.13.1 (#224)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.45.0
+          - rust: 1.39.0
             python-version: 3.8
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,10 +151,24 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+checksum = "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8"
 dependencies = [
+ "indoc-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
  "unindent",
 ]
 
@@ -230,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.14.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0d5c9540a691d153064dc47a4db2504587a75eae07bf1d73f7a596ebc73c04"
+checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -244,10 +258,11 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
@@ -282,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.13.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f65308af05bc6952d28e2d51c730dedf6e16d48699795cb7c33d6a9db59f850"
+checksum = "9fd9e8e652becf4ba6c11803945f8bf463c23f482f704bb33f70ae9d22482d10"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -321,9 +336,22 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
 
 [[package]]
 name = "petgraph"
@@ -342,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,11 +386,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.13.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ca634cf3acd58a599b535ed6cb188223298977d471d146121792bfa23b754c"
+checksum = "bf6bbbe8f70d179260b3728e5d04eb012f4f0c7988e58c11433dd689cecaa72e"
 dependencies = [
- "cfg-if 1.0.0",
  "ctor",
  "hashbrown",
  "indoc",
@@ -364,28 +397,28 @@ dependencies = [
  "libc",
  "parking_lot",
  "paste",
- "pyo3-macros",
+ "pyo3cls",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-macros"
-version = "0.13.1"
+name = "pyo3-derive-backend"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483ac516dbda6789a5b4be0271e7a31b9ad4ec8c0a5955050e8076f72bdbef8f"
+checksum = "10ecd0eb6ed7b3d9965b4f4370b5b9e99e3e5e8742000e1c452c018f8c2a322f"
 dependencies = [
- "pyo3-macros-backend",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "pyo3-macros-backend"
-version = "0.13.1"
+name = "pyo3cls"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15230cabcda008f03565ed8bac40f094cbb5ee1b46e6551f1ec3a0e922cf7df9"
+checksum = "d344fdaa6a834a06dd1720ff104ea12fe101dad2e8db89345af9db74c0bb11a0"
 dependencies = [
- "proc-macro2",
+ "pyo3-derive-backend",
  "quote",
  "syn",
 ]
@@ -514,9 +547,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "07cb8b1b4ebf86a89ee88cbd201b022b94138c623644d035185c84d3f41b7e66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ crate-type = ["cdylib"]
 [dependencies]
 petgraph = "0.5.1"
 fixedbitset = "0.2.0"
-numpy = "0.13.0"
+numpy = "0.12.1"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1.5"
 
 [dependencies.pyo3]
-version = "0.13.0"
+version = "0.12.3"
 features = ["extension-module", "hashbrown"]
 
 [dependencies.hashbrown]
@@ -33,7 +33,7 @@ version = "0.9"
 features = ["rayon"]
 
 [dependencies.ndarray]
-version = "^0.14.0"
+version = "^0.13.0"
 features = ["rayon"]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://img.shields.io/github/release/Qiskit/retworkx.svg?style=popout-square)](https://github.com/Qiskit/retworkx/releases)
 [![](https://img.shields.io/pypi/dm/retworkx.svg?style=popout-square)](https://pypi.org/project/retworkx/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/retworkx/badge.svg?branch=master)](https://coveralls.io/github/Qiskit/retworkx?branch=master)
-[![Minimum rustc 1.45](https://img.shields.io/badge/rustc-1.45+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.39](https://img.shields.io/badge/rustc-1.39+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 
   - You can see the full rendered docs at:
     <https://retworkx.readthedocs.io/en/latest/index.html>
@@ -37,7 +37,7 @@ environment.
 
 If there are no precompiled binaries published for your system you'll have to
 build the package from source. However, to be able able to build the package
-from the published source package you need to have rust >=1.45 installed (and
+from the published source package you need to have rust >=1.39 installed (and
 also [cargo](https://doc.rust-lang.org/cargo/) which is normally included with
 rust) You can use [rustup](https://rustup.rs/) (a cross platform installer for
 rust) to make this simpler, or rely on

--- a/releasenotes/notes/bump-msrv-d581a8cbeff8915b.yaml
+++ b/releasenotes/notes/bump-msrv-d581a8cbeff8915b.yaml
@@ -1,8 +1,0 @@
----
-upgrade:
-  - |
-    The minimum supported Rust version has increased to 1.45.0, you will need
-    rustc >=1.45.0 now to build retworkx. The previous minimum supported Rust
-    version 1.39.0 will no longer be able to compile retworkx. This is due to a
-    change in in the new version of the `pyo3 <https://github.com/PyO3/pyo3>`__
-    library which is used to build the Python bindings.


### PR DESCRIPTION
This commit reverts the version bumps for pyo3, numpy, and ndarray. The
3 changes here required increasing the minimum supported rust version
from 1.39.0 to 1.45.0. While for most developers and use cases this is
fine since 1.45.0 is > 6 months old and most packagers/distributors keep
the rust version up-to-date. One known exception to this though is the
debian 10 rustc package is at 1.41.0. This becomes an issue for
raspberry pi users running a 32bit operating system (the aarch64
manylinux wheels on PyPI work fine for 64bit OS rasberry pi users).
The piwheels project is using the debian 10 package which means to
provide prebuilt wheels of retworkx they need to be able to use rustc
1.41.0 to build.

When weighing the features of this version bump (the big thing for our
use case are better type error messages when calling retworkx from
python) that this version bump would require all raspberry pi users
to switch back to building retworkx from source on 32bit Raspberry Pi OS
when retworkx on piwheels was only a recent addition we should wait at
least one more release before bumping the minimum support rust version.
Hopefully the debian rustc version will be bumped to >=1.45.0 at some
point soon and then this issue goes away.

This reverts commit a3249f0825028c1799984547e9c62bcd2cef89ab.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
