### PR TITLE
Add constructor to build graphs from adjacency matrices

### DIFF
--- a/releasenotes/notes/add-from_adjacency_matrix-3a1122b86aeb4dd8.yaml
+++ b/releasenotes/notes/add-from_adjacency_matrix-3a1122b86aeb4dd8.yaml
@@ -1,0 +1,39 @@
+---
+features:
+  - |
+    A new constructor method :meth:`~retworkx.PyDiGraph.from_adjacency_matrix`
+    has been added to the :class:`~retworkx.PyDiGraph` and
+    :class:`~retworkx.PyGraph` (:meth:`~retworkx.PyGraph.from_adjacency_matrix`)
+    classes. It enables creating a new graph from an input adjacency_matrix.
+    For example:
+
+    .. jupyter-execute::
+
+      import numpy as np
+      import pydot
+      from PIL import Image
+
+      import retworkx
+
+
+      # Adjacency matrix for directed outward star graph:
+      adjacency_matrix = np.array([
+          [0., 1., 1., 1., 1.],
+          [0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0.]])
+      # Create a graph from the adjacency_matrix:
+      graph = retworkx.PyDiGraph.from_adjacency_matrix(adjacency_matrix)
+      # Draw graph
+      dot_str = graph.to_dot(
+          lambda node: dict(
+          color='black', fillcolor='lightblue', style='filled'))
+      dot = pydot.graph_from_dot_data(dot_str)[0]
+      with tempfile.TemporaryDirectory() as tmpdirname:
+          tmp_path = os.path.join(tmpdirname, 'dag.png')
+          dot.write_png(tmp_path)
+          image = Image.open(tmp_path)
+          os.remove(tmp_path)
+      image
+

--- a/releasenotes/notes/add-from_adjacency_matrix-3a1122b86aeb4dd8.yaml
+++ b/releasenotes/notes/add-from_adjacency_matrix-3a1122b86aeb4dd8.yaml
@@ -9,6 +9,9 @@ features:
 
     .. jupyter-execute::
 
+      import os
+      import tempfile
+
       import numpy as np
       import pydot
       from PIL import Image

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -27,6 +27,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyLong, PyString, PyTuple};
 use pyo3::Python;
 
+use ndarray::prelude::*;
+use numpy::PyReadonlyArray2;
+
 use petgraph::algo;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::*;
@@ -1653,7 +1656,7 @@ impl PyDiGraph {
     ///   image
     ///
     #[staticmethod]
-    #[text_signature = "(self, path, /, comment=None, deliminator=None)"]
+    #[text_signature = "(path, /, comment=None, deliminator=None)"]
     pub fn read_edge_list(
         py: Python,
         path: &str,
@@ -1714,6 +1717,56 @@ impl PyDiGraph {
             check_cycle: false,
             node_removed: false,
         })
+    }
+
+    /// Create a new :class:`~retworkx.PyDiGraph` object from an adjacency matrix
+    ///
+    /// This method can be used to construct a new :class:`~retworkx.PyDiGraph`
+    /// object from an input adjacency matrix. The node weights will be the
+    /// index from the matrix. The edge weights will be a float value of the
+    /// value from the matrix.
+    ///
+    /// :param ndarray matrix: The input numpy array adjacency matrix to create
+    ///     a new :class:`~retworkx.PyDiGraph` object from. It must be a 2
+    ///     dimensional array and be a ``float``/``np.float64`` data type.
+    ///
+    ///
+    /// :returns: A new graph object generated from the adjacency matrix
+    /// :rtype: PyDiGraph
+    #[staticmethod]
+    #[text_signature = "(matrix, /)"]
+    pub fn from_adjacency_matrix<'p>(
+        py: Python<'p>,
+        matrix: PyReadonlyArray2<'p, f64>,
+    ) -> PyDiGraph {
+        let array = matrix.as_array();
+        let shape = array.shape();
+        let mut out_graph = StableDiGraph::<PyObject, PyObject>::new();
+        let _node_indices: Vec<NodeIndex> = (0..shape[0])
+            .map(|node| out_graph.add_node(node.to_object(py)))
+            .collect();
+        array
+            .axis_iter(Axis(0))
+            .enumerate()
+            .for_each(|(index, row)| {
+                let source_index = NodeIndex::new(index);
+                for target_index in 0..row.len() {
+                    if row[[target_index]] > 0.0 {
+                        out_graph.add_edge(
+                            source_index,
+                            NodeIndex::new(target_index),
+                            row[[target_index]].to_object(py),
+                        );
+                    }
+                }
+            });
+
+        PyDiGraph {
+            graph: out_graph,
+            cycle_state: algo::DfsSpace::default(),
+            check_cycle: false,
+            node_removed: false,
+        }
     }
 
     /// Add another PyDiGraph object into this PyDiGraph

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -118,7 +118,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
             [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
             dtype=np.int64)
         with self.assertRaises(TypeError):
-            graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
+            retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_float_dtype(self):
         input_matrix = np.array(
@@ -127,6 +127,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
+
 
 class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_single_neighbor(self):
@@ -240,7 +241,7 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
             [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
             dtype=np.int64)
         with self.assertRaises(TypeError):
-            graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
+            retworkx.PyGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_float_dtype(self):
         input_matrix = np.array(

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -120,6 +120,15 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         with self.assertRaises(TypeError):
             retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
 
+    def test_random_graph_different_dtype_astype_no_copy(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=np.int64)
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(
+            input_matrix.astype(np.float64, copy=False))
+        adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))
+
     def test_random_graph_float_dtype(self):
         input_matrix = np.array(
             [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
@@ -242,6 +251,15 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
             dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyGraph.from_adjacency_matrix(input_matrix)
+
+    def test_random_graph_different_dtype_astype_no_copy(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=np.int64)
+        graph = retworkx.PyGraph.from_adjacency_matrix(
+            input_matrix.astype(np.float64, copy=False))
+        adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 
     def test_random_graph_float_dtype(self):
         input_matrix = np.array(

--- a/tests/test_adjacency_matrix.py
+++ b/tests/test_adjacency_matrix.py
@@ -97,6 +97,36 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(
             np.array([[0, 1], [0, 0]]), res))
 
+    def test_from_adjacency_matrix(self):
+        input_array = np.array(
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
+            dtype=np.float64)
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(input_array)
+        out_array = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(input_array, out_array))
+
+    def test_random_graph_full_path(self):
+        graph = retworkx.directed_gnp_random_graph(100, .95, seed=42)
+        adjacency_matrix = retworkx.digraph_adjacency_matrix(graph)
+        new_graph = retworkx.PyDiGraph.from_adjacency_matrix(adjacency_matrix)
+        new_adjacency_matrix = retworkx.digraph_adjacency_matrix(new_graph)
+        self.assertTrue(np.array_equal(adjacency_matrix,
+                                       new_adjacency_matrix))
+
+    def test_random_graph_different_dtype(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=np.int64)
+        with self.assertRaises(TypeError):
+            graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
+
+    def test_random_graph_float_dtype(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=float)
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
+        adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 
 class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_single_neighbor(self):
@@ -188,3 +218,34 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(
             np.array([[0, 1], [1, 0]]), res))
+
+    def test_from_adjacency_matrix(self):
+        input_array = np.array(
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
+            dtype=np.float64)
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_array)
+        out_array = retworkx.graph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(input_array, out_array))
+
+    def test_random_graph_full_path(self):
+        graph = retworkx.undirected_gnp_random_graph(100, .95, seed=42)
+        adjacency_matrix = retworkx.graph_adjacency_matrix(graph)
+        new_graph = retworkx.PyGraph.from_adjacency_matrix(adjacency_matrix)
+        new_adjacency_matrix = retworkx.graph_adjacency_matrix(new_graph)
+        self.assertTrue(np.array_equal(adjacency_matrix,
+                                       new_adjacency_matrix))
+
+    def test_random_graph_different_dtype(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=np.int64)
+        with self.assertRaises(TypeError):
+            graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
+
+    def test_random_graph_float_dtype(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
+            dtype=float)
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
+        adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))


### PR DESCRIPTION
This commit adds a new constructor method from_adjacency_matrix() to
PyGraph and PyDiGraph classes. This enables creating a new graph from an
input adjacency matrix.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
