### PR TITLE
Add release job to publish macOS arm64 binaries

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,8 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [ master ]
 jobs:
   sdist:
     name: Build sdist
@@ -21,11 +20,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./dist/*
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -60,11 +59,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm
     runs-on: macos-10.15
@@ -79,11 +78,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -115,8 +114,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,6 +80,13 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install twine
       - name: Upload to PyPI
         run: twine upload ./wheelhouse/*.whl
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0
         env:
+          CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,7 +75,7 @@ jobs:
           CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin"
+          CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin" PYO3_CROSS_LIB_DIR="/Library/Frameworks/Python.framework/Versions/3.9/"
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.3 twine
+          python -m pip install cibuildwheel==1.9.0 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -57,7 +57,25 @@ jobs:
           CIBW_SKIP: cp27-* cp34-* cp35-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
-
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
+  build-mac-arm-wheels:
+    name: Build wheels on macos for arm
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.9.0
+        env:
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
+          CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin"
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -85,7 +103,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.6.3 twine
+          python -m pip install cibuildwheel==1.9.0 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,9 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: [ master ]
+  push:
+    tags:
+      - '*'
 jobs:
   sdist:
     name: Build sdist
@@ -20,11 +21,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-#      - name: Upload to PyPI
-#        run: twine upload ./dist/*
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -59,11 +60,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm
     runs-on: macos-10.15
@@ -79,11 +80,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -115,8 +116,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,7 +75,7 @@ jobs:
           CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin" PYO3_CROSS_LIB_DIR="/Library/Frameworks/Python.framework/Versions/3.9/"
+          CIBW_ENVIRONMENT: CARGO_BUILD_TARGET="aarch64-apple-darwin" PYO3_CROSS_LIB_DIR="/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9"
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/releasenotes/notes/arm64-mac-d45deda145e37b8f.yaml
+++ b/releasenotes/notes/arm64-mac-d45deda145e37b8f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Starting with this release wheels will be published for macOS arm64. Only
+    Python 3.9 is supported at first, because it is the only version of
+    Python with native support for arm64 macOS.


### PR DESCRIPTION
With the recent release of cibuildwheel 1.9.0 support for building arm64
binaries on macOS was added. This enables us to build release binaries
for this new platform. However, these binaries will be cross-compiled
and not tested since there are no CI resources with the platform
available. This commit adds a new release wheel job to build a aarch64
binary and publish an arm64 wheel for macOS. This will enable users who
have an arm64 mac to run retworkx without having to either build from
source or run under rosetta 2.

Fixes #231

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
