### PR TITLE
Ensure uniqueness of neighbor indices returned by `neighbors()`

### DIFF
--- a/releasenotes/notes/neighbors-fn-returns-unique-indices-00109eda7e3c9ee7.yaml
+++ b/releasenotes/notes/neighbors-fn-returns-unique-indices-00109eda7e3c9ee7.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    If you are using the method :meth:`~retworkx.PyDiGraph.neighbors`, notice
+    the returned iterator now removes repeated node indices. See
+    `#250 <https://github.com/Qiskit/retworkx/issues/250>`__ for more details.
+fixes:
+  - |
+    The iterator returned by the method :meth:`~retworkx.PyDiGraph.neighbors`
+    now goes throw all the node indices without repetition. See
+    `#250 <https://github.com/Qiskit/retworkx/issues/250>`__ for more details.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1391,7 +1391,7 @@ impl PyDiGraph {
     ///
     /// :param int node: The index of the node to get the neighbors of
     ///
-    /// :returns: A list of the neighbor node indicies
+    /// :returns: A list of the neighbor node indices
     /// :rtype: NodeIndices
     #[text_signature = "(self, node, /)"]
     pub fn neighbors(&self, node: usize) -> NodeIndices {
@@ -1400,6 +1400,8 @@ impl PyDiGraph {
                 .graph
                 .neighbors(NodeIndex::new(node))
                 .map(|node| node.index())
+                .collect::<HashSet<usize>>()
+                .drain()
                 .collect(),
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -857,6 +857,8 @@ impl PyGraph {
                 .graph
                 .neighbors(NodeIndex::new(node))
                 .map(|node| node.index())
+                .collect::<HashSet<usize>>()
+                .drain()
                 .collect(),
         }
     }

--- a/tests/graph/test_neighbors.py
+++ b/tests/graph/test_neighbors.py
@@ -24,7 +24,7 @@ class TestNeighbors(unittest.TestCase):
         node_c = graph.add_node('c')
         graph.add_edge(node_a, node_c, {'a': 2})
         res = graph.neighbors(node_a)
-        self.assertEqual([node_c, node_b], res)
+        self.assertCountEqual([node_c, node_b], res)
 
     def test_no_neighbor(self):
         graph = retworkx.PyGraph()

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -22,7 +22,27 @@ class TestAdj(unittest.TestCase):
         node_b = dag.add_child(node_a, 'b', {'a': 1})
         node_c = dag.add_child(node_a, 'c', {'a': 2})
         res = dag.neighbors(node_a)
-        self.assertEqual([node_c, node_b], res)
+        self.assertCountEqual([node_c, node_b], res)
+
+    def test_unique_neighbors_on_dags(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node('a')
+        node_b = dag.add_child(node_a, 'b', ['edge a->b'])
+        node_c = dag.add_child(node_a, 'c', ['edge a->c'])
+        dag.add_edge(node_a, node_b, ['edge a->b bis'])
+        res = dag.neighbors(node_a)
+        self.assertCountEqual([node_c, node_b], res)
+
+    def test_unique_neighbors_on_graphs(self):
+        dag = retworkx.PyGraph()
+        node_a = dag.add_node('a')
+        node_b = dag.add_node('b')
+        node_c = dag.add_node('c')
+        dag.add_edge(node_a, node_b, ['edge a->b'])
+        dag.add_edge(node_a, node_b, ['edge a->b bis'])
+        dag.add_edge(node_a, node_c, ['edge a->c'])
+        res = dag.neighbors(node_a)
+        self.assertCountEqual([node_c, node_b], res)
 
     def test_single_neighbor_dir(self):
         dag = retworkx.PyDAG()


### PR DESCRIPTION
Fixes #249 

petgraph's underlaying `neighbors()` method returns duplicated
nodes in multigraphs (on a per-edge basis). The desired behavior
for the public API is not to include these repetitions though.

This commit collects the returned indices in a HashSet to remove
duplications, then it exhausts the set with `drain()` and
collect it into a list.

This commit also adds new tests to check there is no duplication
in the list of neighbors indices and adapt the existing tests to
ignore the order.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
