### PR TITLE
Try using arm64 graviton2 instead of arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ jobs:
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64
       python: 3.7
-      arch: arm64
+      arch: arm64-graviton2
     - stage: deploy
-      arch: arm64
+      arch: arm64-graviton2
       services:
         - docker
       before_install:


### PR DESCRIPTION
This commit switches the architecture tag for the arm64 travis jobs to
use arm64-graviton2 instead. The arm64-graviton jobs are hosted on
Amazon's graviton2 CPU ec2 nodes which should be faster (not that the
regular arm64 nodes were slow).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
