### PR TITLE
Pin rust in s390x test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,12 @@ jobs:
       stage: Linux non-x86_64
       python: 3.7
       arch: s390x
-      before_script:
+      before_install:
+        - which python
+        - sh tools/install_rust.sh
+        - export PATH=~/.cargo/bin:$PATH
+        - which python
+        - pip install -U pip virtualenv
         - rustup default 1.49.0
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
       stage: Linux non-x86_64
       python: 3.7
       arch: s390x
+      before_script:
+        - rustup default 1.49.0
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64
       python: 3.7


### PR DESCRIPTION
Since the Rust 1.50.0 the s390x CI test job has been failing. This looks
to be caused by rust-lang/rust#80810. Until the issue is resolved in a
released version of rust this pins the rust version used in the job to
the previous release 1.49.0 which does not have this issue and should
work fine.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
