### PR TITLE
Fix issues found with newer cargo clippy versions

### DIFF
--- a/src/dot_utils.rs
+++ b/src/dot_utils.rs
@@ -80,7 +80,7 @@ fn attr_map_to_string<'a>(
     let attr_callable =
         |node: &'a PyObject| -> PyResult<BTreeMap<String, String>> {
             let res = attrs.unwrap().call1(py, (node,))?;
-            Ok(res.extract(py)?)
+            res.extract(py)
         };
 
     let attrs = attr_callable(weight)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,7 @@ fn is_isomorphic_node_match(
         Ok(res.is_true(py).unwrap())
     };
 
+    #[allow(clippy::unnecessary_wraps)]
     fn compare_edges(_a: &PyObject, _b: &PyObject) -> PyResult<bool> {
         Ok(true)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,7 +750,7 @@ fn digraph_k_shortest_path_lengths(
     };
     let edge_cost_callable = |edge: &PyObject| -> PyResult<f64> {
         let res = edge_cost.call1(py, (edge,))?;
-        Ok(res.extract(py)?)
+        res.extract(py)
     };
 
     let out_map = k_shortest_path::k_shortest_path(
@@ -805,7 +805,7 @@ fn graph_k_shortest_path_lengths(
     };
     let edge_cost_callable = |edge: &PyObject| -> PyResult<f64> {
         let res = edge_cost.call1(py, (edge,))?;
-        Ok(res.extract(py)?)
+        res.extract(py)
     };
 
     let out_map = k_shortest_path::k_shortest_path(
@@ -1128,7 +1128,7 @@ fn collect_runs(
 
     let filter_node = |node: &PyObject| -> PyResult<bool> {
         let res = filter_fn.call1(py, (node,))?;
-        Ok(res.extract(py)?)
+        res.extract(py)
     };
 
     let nodes = match algo::toposort(graph, None) {
@@ -1810,7 +1810,7 @@ fn graph_dijkstra_shortest_path_lengths(
     let edge_cost_callable = |a: &PyObject| -> PyResult<f64> {
         let res = edge_cost_fn.call1(py, (a,))?;
         let raw = res.to_object(py);
-        Ok(raw.extract(py)?)
+        raw.extract(py)
     };
 
     let start = NodeIndex::new(node);
@@ -1869,7 +1869,7 @@ fn digraph_dijkstra_shortest_path_lengths(
     let edge_cost_callable = |a: &PyObject| -> PyResult<f64> {
         let res = edge_cost_fn.call1(py, (a,))?;
         let raw = res.to_object(py);
-        Ok(raw.extract(py)?)
+        raw.extract(py)
     };
 
     let start = NodeIndex::new(node);

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -334,7 +334,7 @@ fn add_blossom(
         blossom_best_edges[bv].clear();
         best_edge[bv] = None;
     }
-    blossom_best_edges[blossom] = best_edge_to.values().map(|x| *x).collect();
+    blossom_best_edges[blossom] = best_edge_to.values().copied().collect();
     //select best_edge[blossom]
     best_edge[blossom] = None;
     for edge_index in &blossom_best_edges[blossom] {
@@ -833,9 +833,9 @@ fn verify_optimum(
         }
     }
     // 2. all single vertices have zero dual value;
-    for node in 0..num_nodes {
+    for (node, dual_var_node) in dual_var.iter().enumerate().take(num_nodes) {
         assert!(
-            mate.get(&node).is_some() || dual_var[node] + node_dual_offset == 0
+            mate.get(&node).is_some() || dual_var_node + node_dual_offset == 0
         );
     }
     // 3. all blossoms with positive dual value are full.


### PR DESCRIPTION
In rust 1.50.0 the new version of cargo clippy is highlighting a warning
on an unecessary result on the output for a closure, since the closure
is always returning true (so there is no possibility of an error output.
However, this is ignoring that the closure is passed to a function and
the return type expected by that function has a Result<> return. If we
were to remove the result from the closure that would become a type
mismatch. To avoid clippy raising an issue in this instance this commit
adds allow on that lint rule for that line.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
