### PR TITLE
Add GC support to graph objects

### DIFF
--- a/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
+++ b/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
@@ -7,4 +7,4 @@ fixes:
     To fix this issue, the :class:`~retworkx.PyDiGraph` and
     :class:`~retworkx.PyGraph` classes now are integrated with Python's garbage
     collector so they'll properly be cleared when there are no more references
-    to an graph object.
+    to a graph object.

--- a/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
+++ b/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    The :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph` classes
+    now are integrated with Python's garbage collector so they'll properly
+    be cleared when there are no more Python references to an object.
+    In previous releases the Python garbage collector did not know how to
+    interact with :class:`~retworkx.PyDiGraph` or :class:`~retworkx.PyGraph`
+    objects and as a result they would never be freed until Python exited.
+    This has been fixed by adding the garbage collection integration.

--- a/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
+++ b/releasenotes/notes/add-gc-integration-87f0d20a92b3e614.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    The :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph` classes
-    now are integrated with Python's garbage collector so they'll properly
-    be cleared when there are no more Python references to an object.
     In previous releases the Python garbage collector did not know how to
     interact with :class:`~retworkx.PyDiGraph` or :class:`~retworkx.PyGraph`
     objects and as a result they would never be freed until Python exited.
-    This has been fixed by adding the garbage collection integration.
+    To fix this issue, the :class:`~retworkx.PyDiGraph` and
+    :class:`~retworkx.PyGraph` classes now are integrated with Python's garbage
+    collector so they'll properly be cleared when there are no more references
+    to an graph object.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2170,8 +2170,14 @@ fn weight_transform_callable(
     }
 }
 
+// Functions to enable Python Garbage Collection
 #[pyproto]
 impl PyGCProtocol for PyDiGraph {
+    // Function for PyTypeObject.tp_traverse [1][2] used to tell Python what
+    // objects the PyDiGraph has strong references to.
+    //
+    // [1] https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse
+    // [2] https://pyo3.rs/v0.12.4/class/protocols.html#garbage-collector-integration
     fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
         for node in self
             .graph
@@ -2190,6 +2196,12 @@ impl PyGCProtocol for PyDiGraph {
         Ok(())
     }
 
+    // Function for PyTypeObject.tp_clear [1][2] used to tell Python's GC how
+    // to drop all references held by a PyDiGraph object when the GC needs to
+    // break reference cycles.
+    //
+    // ]1] https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_clear
+    // [2] https://pyo3.rs/v0.12.4/class/protocols.html#garbage-collector-integration
     fn __clear__(&mut self) {
         self.graph = StableDiGraph::<PyObject, PyObject>::new();
         self.node_removed = false;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1427,8 +1427,14 @@ impl PyMappingProtocol for PyGraph {
     }
 }
 
+// Functions to enable Python Garbage Collection
 #[pyproto]
 impl PyGCProtocol for PyGraph {
+    // Function for PyTypeObject.tp_traverse [1][2] used to tell Python what
+    // objects the PyGraph has strong references to.
+    //
+    // [1] https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_traverse
+    // [2] https://pyo3.rs/v0.12.4/class/protocols.html#garbage-collector-integration
     fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
         for node in self
             .graph
@@ -1447,6 +1453,12 @@ impl PyGCProtocol for PyGraph {
         Ok(())
     }
 
+    // Function for PyTypeObject.tp_clear [1][2] used to tell Python's GC how
+    // to drop all references held by a PyGraph object when the GC needs to
+    // break reference cycles.
+    //
+    // ]1] https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_clear
+    // [2] https://pyo3.rs/v0.12.4/class/protocols.html#garbage-collector-integration
     fn __clear__(&mut self) {
         self.graph = StableUnGraph::<PyObject, PyObject>::default();
         self.node_removed = false;


### PR DESCRIPTION
Right now the 2 graph classes in retworkx, PyGraph and PyDiGraph, did
not integrate with the Python garbage collector. This would result in
memory not being cleared in a running python process even if retworkx
objects were only created in temporary context. This commit attempts to
fix this by implementing the garbage collection protocol [1] which
should enable python to clean up retworkx objects when they're no longer
being used.

[1] https://pyo3.rs/v0.12.4/class/protocols.html?highlight=garbage#garbage-collector-integration

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
