### PR TITLE
Revert "Try using arm64 graviton2 instead of arm64 (#253)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ jobs:
     - name: Python 3.7 Tests arm64 Linux
       stage: Linux non-x86_64
       python: 3.7
-      arch: arm64-graviton2
+      arch: arm64
     - stage: deploy
-      arch: arm64-graviton2
+      arch: arm64
       services:
         - docker
       before_install:


### PR DESCRIPTION
The arm64-graviton2 nodes are not being correctly allocated and are
showing as an x86_64 architecture (it looks like they're not even
running on amazon ec2). Since this defeats the purpose of the arm64
ci jobs (to test on arm64) this commit reverts the change to graviton2
and uses the regular slower arm64 nodes, which are actually run on arm
cpus.

This reverts commit bbcb0d55c1dbb0c575b1be3a29a9594e3bb68a14.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
