### PR TITLE
Add more object protocol methods to custom return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cc"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,28 +53,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60ab4a8dba064f2fbb5aa270c28da5cf4bbd0e72dae1140a6b0353a779dbe00"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
- "loom",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae8f328835f8f5a6ceb6a7842a7f2d0c03692adb5c889347235d59194731fe3"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -104,19 +96,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "generator"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fed24fd1e18827652b4d55652899a1e9da8e54d91624dc3437a5bc3a9f9a9c"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi",
-]
 
 [[package]]
 name = "getrandom"
@@ -242,26 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loom"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44c73b4636e497b4917eb21c33539efa3816741a2d3ff26c6316f1b529481a4"
-dependencies = [
- "cfg-if 1.0.0",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -575,18 +534,6 @@ dependencies = [
  "rand_pcg",
  "rayon",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/releasenotes/notes/return-class-object-methods-d8b19d952639118a.yaml
+++ b/releasenotes/notes/return-class-object-methods-d8b19d952639118a.yaml
@@ -10,7 +10,7 @@ features:
   - |
     The custom return types :class:`~retworkx.BFSSuccessors`,
     :class:`~retworkx.NodeIndices`, :class:`~retworkx.EdgeList`, and
-    :class:`~retworkx.WeightedEdgeList` now implement ``_str__`` so that
+    :class:`~retworkx.WeightedEdgeList` now implement ``__hash__`` so that
     running ``hash()`` (for example when insert them into a ``dict``) will
     return a valid hash for the object. The only exception to this is for
     :class:`~retworkx.BFSSuccessors` and :class:`~retworkx.WeightedEdgeList`

--- a/releasenotes/notes/return-class-object-methods-d8b19d952639118a.yaml
+++ b/releasenotes/notes/return-class-object-methods-d8b19d952639118a.yaml
@@ -1,0 +1,29 @@
+---
+features:
+  - |
+    The custom return types :class:`~retworkx.BFSSuccessors`,
+    :class:`~retworkx.NodeIndices`, :class:`~retworkx.EdgeList`, and
+    :class:`~retworkx.WeightedEdgeList` now implement ``_str__`` so that
+    running ``str()`` (for example when calling ``print()`` on the object) it
+    will return a human readable string with the contents of the custom return
+    type.
+  - |
+    The custom return types :class:`~retworkx.BFSSuccessors`,
+    :class:`~retworkx.NodeIndices`, :class:`~retworkx.EdgeList`, and
+    :class:`~retworkx.WeightedEdgeList` now implement ``_str__`` so that
+    running ``hash()`` (for example when insert them into a ``dict``) will
+    return a valid hash for the object. The only exception to this is for
+    :class:`~retworkx.BFSSuccessors` and :class:`~retworkx.WeightedEdgeList`
+    if they contain a Python object that is not hashable, in those cases
+    calling ``hash()`` will raise a ``TypeError``, just like as you called
+    ``hash()`` on the inner unhashable object.
+fixes:
+  - |
+    The custom return types :class:`~retworkx.BFSSuccessors`,
+    :class:`~retworkx.NodeIndices`, :class:`~retworkx.EdgeList`, and
+    :class:`~retworkx.WeightedEdgeList` now are integrated with Python's
+    garbage collector so they'll properly be cleared when there are no more
+    Python references to an object. In previous releases the Python garbage
+    collector did not know how to interact with the custom return types and as
+    a result they would never be freed until Python exited. This has been fixed
+    by adding the garbage collection integration.

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -76,6 +76,23 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         bfs_copy = pickle.loads(bfs_pickle)
         self.assertEqual(bfs, bfs_copy)
 
+    def test_str(self):
+        res = retworkx.bfs_successors(self.dag, 0)
+        self.assertEqual("BFSSuccessors[(a, [b])]", str(res))
+
+    def test_hash(self):
+        res = retworkx.bfs_successors(self.dag, 0)
+        hash_res = hash(res)
+        self.assertIsInstance(hash_res, int)
+        # Assert hash is stable
+        self.assertEqual(hash_res, hash(res))
+
+    def test_hash_invalid_type(self):
+        self.dag.add_child(0, [1, 2, 3], 'edgy')
+        res = retworkx.bfs_successors(self.dag, 0)
+        with self.assertRaises(TypeError):
+            hash(res)
+
 
 class TestNodeIndicesComparisons(unittest.TestCase):
 
@@ -125,6 +142,17 @@ class TestNodeIndicesComparisons(unittest.TestCase):
         nodes_copy = pickle.loads(nodes_pickle)
         self.assertEqual(nodes, nodes_copy)
 
+    def test_str(self):
+        res = self.dag.node_indexes()
+        self.assertEqual("NodeIndices[0, 1]", str(res))
+
+    def test_hash(self):
+        res = self.dag.node_indexes()
+        hash_res = hash(res)
+        self.assertIsInstance(hash_res, int)
+        # Assert hash is stable
+        self.assertEqual(hash_res, hash(res))
+
 
 class TestEdgeListComparisons(unittest.TestCase):
 
@@ -171,6 +199,17 @@ class TestEdgeListComparisons(unittest.TestCase):
         edges_pickle = pickle.dumps(edges)
         edges_copy = pickle.loads(edges_pickle)
         self.assertEqual(edges, edges_copy)
+
+    def test_str(self):
+        res = self.dag.edge_list()
+        self.assertEqual("EdgeList[(0, 1)]", str(res))
+
+    def test_hash(self):
+        res = self.dag.edge_list()
+        hash_res = hash(res)
+        self.assertIsInstance(hash_res, int)
+        # Assert hash is stable
+        self.assertEqual(hash_res, hash(res))
 
 
 class TestWeightedEdgeListComparisons(unittest.TestCase):
@@ -220,3 +259,20 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         edges_pickle = pickle.dumps(edges)
         edges_copy = pickle.loads(edges_pickle)
         self.assertEqual(edges, edges_copy)
+
+    def test_str(self):
+        res = self.dag.weighted_edge_list()
+        self.assertEqual("WeightedEdgeList[(0, 1, Edgy)]", str(res))
+
+    def test_hash(self):
+        res = self.dag.weighted_edge_list()
+        hash_res = hash(res)
+        self.assertIsInstance(hash_res, int)
+        # Assert hash is stable
+        self.assertEqual(hash_res, hash(res))
+
+    def test_hash_invalid_type(self):
+        self.dag.add_child(0, 'c', ['edgy', 'not_edgy'])
+        res = self.dag.weighted_edge_list()
+        with self.assertRaises(TypeError):
+            hash(res)


### PR DESCRIPTION
This commit adds a few more methods from the Python object protocol to the
custom return types. All the classes now have a `__str__` method so you can
see the contents of the custom returns with a `print()`. Additionally, a
`__hash__` is added to each class since the return types are immutable.
However, for return types that contain `PyObject`s (`WeightedEdgeList` and
`BFSSuccessors`) if any of the objects contained are not hashable this
will raise an exception (just as if you called `hash()` on that object).
The last methods are related to garbage collection in python which
enables the Python garbage collector to cleanup the custom return types.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
