### PR TITLE
Fix CI wheel jobs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,11 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [master]
+#  push:
+#    tags:
+#      - '*'
 jobs:
   sdist:
     name: Build sdist
@@ -22,11 +24,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./dist/*
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -62,11 +64,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm
     runs-on: macos-10.15
@@ -89,11 +91,11 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -126,8 +128,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+#      - name: Upload to PyPI
+#        run: twine upload ./wheelhouse/*.whl
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,7 @@ jobs:
   sdist:
     name: Build sdist
     runs-on: ubuntu-latest
+    needs: ["build_wheels", "build-win32-wheels"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,6 +56,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
           CIBW_SKIP: cp27-* cp34-* cp35-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
+          CIBW_TEST_REQUIRES: networkx
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2
         with:
@@ -119,6 +120,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_SKIP: cp27-* cp34-* cp35-* pp* *amd64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
+          CIBW_TEST_REQUIRES: networkx
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,11 +1,9 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: [master]
-#  push:
-#    tags:
-#      - '*'
+  push:
+    tags:
+      - '*'
 jobs:
   sdist:
     name: Build sdist
@@ -24,11 +22,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-#      - name: Upload to PyPI
-#        run: twine upload ./dist/*
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -64,11 +62,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm
     runs-on: macos-10.15
@@ -91,11 +89,11 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install twine
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -128,8 +126,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-#      - name: Upload to PyPI
-#        run: twine upload ./wheelhouse/*.whl
-#        env:
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          TWINE_USERNAME: retworkx-ci
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
   - tox -epy
 stages:
   - name: Linux non-x86_64
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -62,11 +62,11 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+#      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
+#        - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
       python: 3.7
@@ -88,11 +88,11 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+#      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
+#        - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
       python: 3.7
@@ -110,8 +110,8 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+#      if: tag IS present
       script:
         - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
+#        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ script:
   - tox -epy
 stages:
   - name: Linux non-x86_64
-    if: tag IS present
-  - name: deploy
     if: tag IS blank
+  - name: deploy
+    if: tag IS present
 
 jobs:
   fast_finish: true
@@ -62,11 +62,11 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-#      if: tag IS present
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
       python: 3.7
@@ -88,11 +88,11 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-#      if: tag IS present
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
       python: 3.7
@@ -110,8 +110,8 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-#      if: tag IS present
+      if: tag IS present
       script:
         - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,8 @@ jobs:
       install:
         - echo ""
       env:
-        - CIBW_BEFORE_ALL="yum install -y wget && {package}/tools/install_rust.sh"
-        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
+        - CIBW_BEFORE_ALL="yum install -y wget && rm -rf rust-installer"
+        - CIBW_BEFORE_BUILD="bash {project}/tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
         - CIBW_TEST_REQUIRES=networkx

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
       arch: arm64
     - stage: deploy
       arch: arm64
+      python: 3.7
       services:
         - docker
       before_install:
@@ -58,19 +59,25 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
+      python: 3.7
       services:
         - docker
       before_install:
-        - echo ""
+        - which python
+        - sh tools/install_rust.sh
+        - export PATH=~/.cargo/bin:$PATH
+        - which python
+        - pip install -U pip virtualenv tox
       install:
         - echo ""
       env:
@@ -78,15 +85,17 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
+      python: 3.7
       services:
         - docker
       before_install:
@@ -98,10 +107,11 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
+        - CIBW_TEST_REQUIRES=networkx
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.6.4
+        - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*


### PR DESCRIPTION
For the recent 0.8.0 release all the wheel jobs failed because we added
networkx as a test requirement (for comparing the outputs of
max_weight_matching()) but were not installing networkx before running
unit tests. This made all the wheels come back as broken because
unittests failed. This commit fixes that issue by adding networkx as an
explicit test requirement in all the cibuildwheel job configurations.

Additionally, the ppc64le wheel jobs started failed for an additional
reason, it appears that the travis CI images aren't up to date and need
the rust compiler to install cryptography (which is required for pip and
other packages). This commit fixes those jobs so we can install
cibuildwheel and also build the packages.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
