### PR TITLE
Use stestr for test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Download grcov
         run: curl -L https://github.com/mozilla/grcov/releases/download/v0.6.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - name: Install deps
-        run: pip install -U setuptools-rust networkx
+        run: pip install -U setuptools-rust networkx testtools fixtures
       - name: Build retworkx
         run: python setup.py develop
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
           CIBW_SKIP: cp27-* cp34-* cp35-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx
+          CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2
         with:
@@ -121,7 +121,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_SKIP: cp27-* cp34-* cp35-* pp* *amd64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx
+          CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
       - uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/source/stubs/
 .tox/
 retworkx/*.so
 retworkx/*pyd
+*.stestr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx
+        - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
@@ -85,7 +85,7 @@ jobs:
         - CIBW_BEFORE_BUILD="bash {project}/tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx
+        - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
@@ -107,7 +107,7 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx
+        - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,54 @@ The easiest way to run the test suite is to use
 [**tox**](https://tox.readthedocs.io/en/latest/#). You can install tox
 with pip: `pip install -U tox`. Tox provides several advantages, but the
 biggest one is that it builds an isolated virtualenv for running tests. This
-means it does not pollute your system python when running.
+means it does not pollute your system python when running. However, by default
+tox will recompile retworkx from source every time it is run even if there
+are no changes made to the rust code. To avoid this you can use the
+`--skip-pkg-install` package if you'd like to rerun tests without recompiling.
+Note, you only want to use this flag if you recently ran tox and there are no
+rust code (or packaged python code) changes to the repo since then. Otherwise
+the retworkx package tox installs in it's virtualenv will be out of date (or
+missing).
 
 Note, if you run tests outside of tox that you can **not** run the tests from
 the root of the repo, this is because retworkx packaging shim will conflict
 with imports from retworkx the installed version of retworkx (which contains
 the compiled extension).
+
+#### Running subsets of tests
+
+f you just want to run a subset of tests you can pass a selection regex to the
+test runner. For example, if you want to run all tests that have "dag" in the
+test id you can run: `tox -epy -- dag`. You can pass arguments directly to the
+test runner after the bare `--`. To see all the options on test selection you
+can refer to the stestr manual:
+
+https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection
+
+If you want to run a single test module, test class, or individual test method
+you can do this faster with the `-n`/`--no-discover` option. For example:
+
+to run a module:
+```
+tox -epy -- -n test_max_weight_matching
+```
+or to run the same module by path:
+```
+tox -epy -- -n graph/test_nodes.py
+```
+to run a class:
+```
+tox -epy -- -n graph.test_nodes.TestNodes
+```
+to run a method:
+```
+tox -epy -- -n graph.test_nodes.TestNodes.test_no_nodes
+```
+
+It's important to note that tox will be running from the `tests/` directory in
+the repo, so any paths you pass to the test runner via path need to be relative
+to that directory.
+
 
 ### Style
 

--- a/tests/.stestr.conf
+++ b/tests/.stestr.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+test_path=./

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -14,7 +14,6 @@
 # https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/tests/test_matching.py
 
 import random
-import unittest
 
 import fixtures
 import networkx

--- a/tests/test_max_weight_matching.py
+++ b/tests/test_max_weight_matching.py
@@ -16,15 +16,25 @@
 import random
 import unittest
 
-import retworkx
+import fixtures
 import networkx
+import testtools
+
+import retworkx
 
 
 def match_dict_to_set(match):
     return {(u, v) for (u, v) in set(map(frozenset, match.items()))}
 
 
-class TestMaxWeightMatching(unittest.TestCase):
+class TestMaxWeightMatching(testtools.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        stdout = self.useFixture(fixtures.StringStream('stdout')).stream
+        self.useFixture(fixtures.MonkeyPatch('sys.stdout', stdout))
+        stderr = self.useFixture(fixtures.StringStream('stderr')).stream
+        self.useFixture(fixtures.MonkeyPatch('sys.stderr', stderr))
 
     def compare_match_sets(self, rx_match, expected_match):
         for (u, v) in rx_match:
@@ -424,49 +434,49 @@ class TestMaxWeightMatching(unittest.TestCase):
 
     def test_gnp_random_against_networkx(self):
         for i in range(1024):
-            with self.subTest(i=i):
-                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                                seed=42 + i)
-                nx_graph = networkx.Graph(list(rx_graph.edge_list()))
-                nx_matches = networkx.max_weight_matching(nx_graph)
-                rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                          verify_optimum=True)
-                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                        42 + i, nx_graph)
+            # TODO: add back subTest usage on new testtools release
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            nx_graph = networkx.Graph(list(rx_graph.edge_list()))
+            nx_matches = networkx.max_weight_matching(nx_graph)
+            rx_matches = retworkx.max_weight_matching(rx_graph,
+                                                      verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                    42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_weight(self):
         for i in range(1024):
-            with self.subTest(i=i):
-                random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                                seed=42 + i)
-                for edge in rx_graph.edge_list():
-                    rx_graph.update_edge(*edge, random.randint(0, 5000))
-                nx_graph = networkx.Graph(
-                    [(x[0], x[1],
-                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-                nx_matches = networkx.max_weight_matching(nx_graph)
-                rx_matches = retworkx.max_weight_matching(
-                    rx_graph, weight_fn=lambda x: x, verify_optimum=True)
-                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                        42 + i, nx_graph)
+            # TODO: add back subTest usage on new testtools release
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(0, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph)
+            rx_matches = retworkx.max_weight_matching(
+                rx_graph, weight_fn=lambda x: x, verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                    42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_negative_weight(self):
         for i in range(1024):
-            with self.subTest(i=i):
-                random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                                seed=42 + i)
-                for edge in rx_graph.edge_list():
-                    rx_graph.update_edge(*edge, random.randint(-5000, 5000))
-                nx_graph = networkx.Graph(
-                    [(x[0], x[1],
-                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-                nx_matches = networkx.max_weight_matching(nx_graph)
-                rx_matches = retworkx.max_weight_matching(
-                    rx_graph, weight_fn=lambda x: x, verify_optimum=True)
-                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                        42 + i, nx_graph)
+            # TODO: add back subTest usage on new testtools release
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph)
+            rx_matches = retworkx.max_weight_matching(
+                rx_graph, weight_fn=lambda x: x, verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                    42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
@@ -480,41 +490,41 @@ class TestMaxWeightMatching(unittest.TestCase):
 
     def test_gnp_random_against_networkx_with_weight_max_cardinality(self):
         for i in range(1024):
-            with self.subTest(i=i):
-                random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                                seed=42 + i)
-                for edge in rx_graph.edge_list():
-                    rx_graph.update_edge(*edge, random.randint(0, 5000))
-                nx_graph = networkx.Graph(
-                    [(x[0], x[1],
-                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-                nx_matches = networkx.max_weight_matching(nx_graph,
-                                                          maxcardinality=True)
-                rx_matches = retworkx.max_weight_matching(
-                    rx_graph, weight_fn=lambda x: x, max_cardinality=True,
-                    verify_optimum=True)
-                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                        42 + i, nx_graph)
+            # TODO: add back subTest usage on new testtools release
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(0, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph,
+                                                      maxcardinality=True)
+            rx_matches = retworkx.max_weight_matching(
+                rx_graph, weight_fn=lambda x: x, max_cardinality=True,
+                verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                    42 + i, nx_graph)
 
     def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
         for i in range(1024):
-            with self.subTest(i=i):
-                random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                                seed=42 + i)
-                for edge in rx_graph.edge_list():
-                    rx_graph.update_edge(*edge, random.randint(-5000, 5000))
-                nx_graph = networkx.Graph(
-                    [(x[0], x[1],
-                     {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-                nx_matches = networkx.max_weight_matching(nx_graph,
-                                                          maxcardinality=True)
-                rx_matches = retworkx.max_weight_matching(
-                    rx_graph, weight_fn=lambda x: x, max_cardinality=True,
-                    verify_optimum=True)
-                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                        42 + i, nx_graph)
+            # TODO: add back subTest usage on new testtools release
+            random.seed(i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
+                                                            seed=42 + i)
+            for edge in rx_graph.edge_list():
+                rx_graph.update_edge(*edge, random.randint(-5000, 5000))
+            nx_graph = networkx.Graph(
+                [(x[0], x[1],
+                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+            nx_matches = networkx.max_weight_matching(nx_graph,
+                                                      maxcardinality=True)
+            rx_matches = retworkx.max_weight_matching(
+                rx_graph, weight_fn=lambda x: x, max_cardinality=True,
+                verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
+                                    42 + i, nx_graph)
 
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,13 @@ setenv =
   ARGS="-V"
 deps =
   setuptools-rust
+  fixtures
+  testtools
   networkx>=2.5
+  stestr
 changedir = {toxinidir}/tests
 commands =
-  python -m unittest discover .
+  stestr run {posargs}
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Since #229 our test runs take significantly longer. This is mostly a
function of the tests added in that function running over numerous
random graphs and comparing the output against networkx to verify it
works in all cases. However, this validation comes with a runtime cost.
In an attempt to mitigate this partially this commit changes the test
runner from stdlib's unittest runner to use stestr. [1][2][3] stestr
provides a performance improvement by running tests on parallel workers
and also provides an easier to use UI that enables test selection a
history of previous runs, and many other features. The test suite in
retworkx will still need to be strictly unittest compatible so anyone
can run with stestr, stdlib unittest, pytest, or any other test runner
of their choice. But the default in tox and CI will be to use stestr
for the performance benefit.

[1] https://pypi.org/project/stestr/
[2] https://github.com/mtreinish/stestr
[3] https://stestr.readthedocs.io/en/stable/README.html

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
