### PR TITLE
improve vf2 to handle StableGraph node index holes

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -300,7 +300,9 @@ impl GetAdjacencyMatrix for PyDiGraph {
         a: NodeIndex,
         b: NodeIndex,
     ) -> bool {
-        self.graph.is_adjacent(matrix, a, b)
+        let n = self.node_bound();
+        let index = n * a.index() + b.index();
+        matrix.contains(index)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -258,7 +258,9 @@ impl GetAdjacencyMatrix for PyGraph {
         a: NodeIndex,
         b: NodeIndex,
     ) -> bool {
-        self.graph.is_adjacent(matrix, a, b)
+        let n = self.node_bound();
+        let index = n * a.index() + b.index();
+        matrix.contains(index)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,6 @@ fn is_isomorphic_node_match(
         Ok(true)
     }
     let res = dag_isomorphism::is_isomorphic_matching(
-        py,
         first,
         second,
         compare_nodes,


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
Resolves #125.
Improves `Vf2State` to use `HashMap` instead of `Vec` that was assuming contiguous node indices.
As it turns out, `is_adjacent` implementation of `StableGraph` has a bug in petgraph (in [L69](https://github.com/petgraph/petgraph/blob/master/src/traits_graph.rs#L69)). This commit fixes this in retworkx.