### PR TITLE
Fix cargo builds on arm64 macOS systems

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Building the retworkx library on macOS requires some extra rustc linker
flags so that cargo and rustc are able to link the binary against python
correctly at build time. To do this by default we added the cargo config
for the x86_64 macOS target in #53 which fixed it for all users running
cargo on those platforms. However, now there are macOS systems that have
aarch64 CPUs. To ensure that people trying to use cargo to build
binaries on those systems don't need to manually specify the linker
flags this commit adds the config for that target as well.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
