### PR TITLE
Make vf2 generic

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -58,8 +58,10 @@ Specific Graph Type Methods
    retworkx.weakly_connected_components
    retworkx.is_weakly_connected
    retworkx.is_directed_acyclic_graph
-   retworkx.is_isomorphic
-   retworkx.is_isomorphic_node_match
+   retworkx.digraph_is_isomorphic
+   retworkx.graph_is_isomorphic
+   retworkx.digraph_is_isomorphic_node_match
+   retworkx.graph_is_isomorphic_node_match
    retworkx.topological_sort
    retworkx.descendants
    retworkx.ancestors
@@ -116,6 +118,8 @@ type functions in the algorithms API but can be run with a
    retworkx.dijkstra_shortest_path_lengths
    retworkx.k_shortest_path_lengths
    retworkx.dfs_edges
+   retworkx.is_isomorphic
+   retworkx.is_isomorphic_node_match
 
 Exceptions
 ----------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -60,8 +60,6 @@ Specific Graph Type Methods
    retworkx.is_directed_acyclic_graph
    retworkx.digraph_is_isomorphic
    retworkx.graph_is_isomorphic
-   retworkx.digraph_is_isomorphic_node_match
-   retworkx.graph_is_isomorphic_node_match
    retworkx.topological_sort
    retworkx.descendants
    retworkx.ancestors

--- a/releasenotes/notes/expand-isomorphism-cfb646cfef66fa25.yaml
+++ b/releasenotes/notes/expand-isomorphism-cfb646cfef66fa25.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :func:`~retworkx.is_isomorphic` can take in a :class:`~retworkx.PyGraph`
+    or :class:`~retworkx.PyDiGraph` and two functions to compare node 
+    and edge data.

--- a/releasenotes/notes/expand-isomorphism-cfb646cfef66fa25.yaml
+++ b/releasenotes/notes/expand-isomorphism-cfb646cfef66fa25.yaml
@@ -2,5 +2,8 @@
 features:
   - |
     :func:`~retworkx.is_isomorphic` can take in a :class:`~retworkx.PyGraph`
-    or :class:`~retworkx.PyDiGraph` and two functions to compare node 
-    and edge data.
+    or :class:`~retworkx.PyDiGraph`. You can optionally specify two functions
+    to compare node and edge data.
+  - |
+    :func:`~retworkx.is_isomorphic_node_match` can take in a :class:`~retworkx.PyGraph`
+    or :class:`~retworkx.PyDiGraph`.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -456,6 +456,7 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
     :param second: The second graph to compare. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+        It should be the same type as the first graph.
     :param callable node_matcher: A python callable object that takes 2 positional
         one for each node data object. If the return of this
         function evaluates to True then the nodes passed to it are vieded
@@ -499,6 +500,7 @@ def is_isomorphic_node_match(first, second, matcher):
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
     :param second: The second graph to compare. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+        It should be the same type as the first graph.
     :param callable matcher: A python callable object that takes 2 positional
         one for each node data object. If the return of this
         function evaluates to True then the nodes passed to it are vieded

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -439,16 +439,25 @@ def _graph_dfs_edges(graph, source):
     return graph_dfs_edges(graph, source)
 
 @functools.singledispatch
-def is_isomorphic(first, second):
-    """Determine if 2 graphs are structurally isomorphic
+def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
+    """Determine if 2 graphs are isomorphic
 
-    This checks if 2 graphs are structurally isomorphic (it doesn't match
-    the contents of the nodes or edges on the graphs).
+    This checks if 2 graphs are isomorphic both structurally and also
+    comparing the node and edge data using the provided matcher functions.
+    The matcher functions take in 2 data objects and will compare them.
 
     :param first: The first graph to compare. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
     :param second: The second graph to compare. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param callable node_matcher: A python callable object that takes 2 positional
+        one for each node data object. If the return of this
+        function evaluates to True then the nodes passed to it are vieded
+        as matching.
+    :param callable edge_matcher: A python callable object that takes 2 positional
+        one for each edge data object. If the return of this
+        function evaluates to True then the edges passed to it are vieded
+        as matching.
 
     :returns: ``True`` if the 2 graphs are structurally isomorphic, ``False``
         if they are not
@@ -458,13 +467,30 @@ def is_isomorphic(first, second):
 
 
 @is_isomorphic.register(PyDiGraph)
-def _digraph_is_isomorphic(first, second):
-    return digraph_is_isomorphic(first, second)
+def _digraph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
+    if (node_matcher is None) and (edge_matcher is None):
+        return digraph_is_isomorphic(first, second)
 
+    if node_matcher is None:
+        node_matcher = lambda x, y: True
+
+    if edge_matcher is None:
+        edge_matcher = lambda x, y: True
+
+    return digraph_is_isomorphic_node_match(first, second, node_matcher, edge_matcher)
 
 @is_isomorphic.register(PyGraph)
-def _graph_is_isomorphic(first, second):
-    return graph_is_isomorphic(first, second)
+def _graph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
+    if (node_matcher is None) and (edge_matcher is None):
+        return graph_is_isomorphic(first, second)
+
+    if node_matcher is None:
+        node_matcher = lambda x, y: True
+
+    if edge_matcher is None:
+        edge_matcher = lambda x, y: True
+
+    return graph_is_isomorphic_node_match(first, second, node_matcher, edge_matcher)
 
 
 @functools.singledispatch
@@ -498,9 +524,9 @@ def is_isomorphic_node_match(first, second, matcher):
 
 @is_isomorphic_node_match.register(PyDiGraph)
 def _digraph_is_isomorphic_node_match(first, second, matcher):
-    return digraph_is_isomorphic_node_match(first, second, matcher)
+    return digraph_is_isomorphic_node_match(first, second, matcher, lambda x, y: x == y)
 
 
 @is_isomorphic_node_match.register(PyGraph)
-def _graph_is_isomorphic_node_match(first, second):
-    return graph_is_isomorphic_node_match(first, second, matcher)
+def _graph_is_isomorphic_node_match(first, second, matcher):
+    return graph_is_isomorphic_node_match(first, second, matcher, lambda x, y: x == y)

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -437,3 +437,70 @@ def _digraph_dfs_edges(graph, source):
 @dfs_edges.register(PyGraph)
 def _graph_dfs_edges(graph, source):
     return graph_dfs_edges(graph, source)
+
+@functools.singledispatch
+def is_isomorphic(first, second):
+    """Determine if 2 graphs are structurally isomorphic
+
+    This checks if 2 graphs are structurally isomorphic (it doesn't match
+    the contents of the nodes or edges on the graphs).
+
+    :param first: The first graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param second: The second graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+
+    :returns: ``True`` if the 2 graphs are structurally isomorphic, ``False``
+        if they are not
+    :rtype: bool
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(first))
+
+
+@is_isomorphic.register(PyDiGraph)
+def _digraph_is_isomorphic(first, second):
+    return digraph_is_isomorphic(first, second)
+
+
+@is_isomorphic.register(PyGraph)
+def _graph_is_isomorphic(first, second):
+    return graph_is_isomorphic(first, second)
+
+
+@functools.singledispatch
+def is_isomorphic_node_match(first, second, matcher):
+    """Determine if 2 graphs are isomorphic
+
+    This checks if 2 graphs are isomorphic both structurally and also
+    comparing the node data using the provided matcher function. The matcher
+    function takes in 2 node data objects and will compare them. A simple
+    example that checks if they're just equal would be::
+
+        graph_a = retworkx.PyDAG()
+        graph_b = retworkx.PyDAG()
+        retworkx.is_isomorphic_node_match(graph_a, graph_b,
+                                        lambda x, y: x == y)
+
+    :param first: The first graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param second: The second graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param callable matcher: A python callable object that takes 2 positional
+        one for each node data object. If the return of this
+        function evaluates to True then the nodes passed to it are vieded
+        as matching.
+
+    :returns: ``True`` if the 2 graphs are isomorphic ``False`` if they are not.
+    :rtype: bool
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(first))
+
+
+@is_isomorphic_node_match.register(PyDiGraph)
+def _digraph_is_isomorphic_node_match(first, second, matcher):
+    return digraph_is_isomorphic_node_match(first, second, matcher)
+
+
+@is_isomorphic_node_match.register(PyGraph)
+def _graph_is_isomorphic_node_match(first, second):
+    return graph_is_isomorphic_node_match(first, second, matcher)

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -444,7 +444,13 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
 
     This checks if 2 graphs are isomorphic both structurally and also
     comparing the node and edge data using the provided matcher functions.
-    The matcher functions take in 2 data objects and will compare them.
+    The matcher functions take in 2 data objects and will compare them. A simple
+    example that checks if they're just equal would be::
+    
+            graph_a = retworkx.PyGraph()
+            graph_b = retworkx.PyGraph()
+            retworkx.is_isomorphic(graph_a, graph_b,
+                                lambda x, y: x == y)
 
     :param first: The first graph to compare. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
@@ -459,8 +465,8 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
         function evaluates to True then the edges passed to it are vieded
         as matching.
 
-    :returns: ``True`` if the 2 graphs are structurally isomorphic, ``False``
-        if they are not
+    :returns: ``True`` if the 2 graphs are isomorphic, ``False`` if they are 
+        not.
     :rtype: bool
     """
     raise TypeError("Invalid Input Type %s for graph" % type(first))
@@ -468,29 +474,11 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
 
 @is_isomorphic.register(PyDiGraph)
 def _digraph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
-    if (node_matcher is None) and (edge_matcher is None):
-        return digraph_is_isomorphic(first, second)
-
-    if node_matcher is None:
-        node_matcher = lambda x, y: True
-
-    if edge_matcher is None:
-        edge_matcher = lambda x, y: True
-
-    return digraph_is_isomorphic_node_match(first, second, node_matcher, edge_matcher)
+    return digraph_is_isomorphic(first, second, node_matcher, edge_matcher)
 
 @is_isomorphic.register(PyGraph)
 def _graph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
-    if (node_matcher is None) and (edge_matcher is None):
-        return graph_is_isomorphic(first, second)
-
-    if node_matcher is None:
-        node_matcher = lambda x, y: True
-
-    if edge_matcher is None:
-        edge_matcher = lambda x, y: True
-
-    return graph_is_isomorphic_node_match(first, second, node_matcher, edge_matcher)
+    return graph_is_isomorphic(first, second, node_matcher, edge_matcher)
 
 
 @functools.singledispatch
@@ -524,9 +512,9 @@ def is_isomorphic_node_match(first, second, matcher):
 
 @is_isomorphic_node_match.register(PyDiGraph)
 def _digraph_is_isomorphic_node_match(first, second, matcher):
-    return digraph_is_isomorphic_node_match(first, second, matcher, lambda x, y: x == y)
+    return digraph_is_isomorphic(first, second, matcher)
 
 
 @is_isomorphic_node_match.register(PyGraph)
 def _graph_is_isomorphic_node_match(first, second, matcher):
-    return graph_is_isomorphic_node_match(first, second, matcher, lambda x, y: x == y)
+    return graph_is_isomorphic(first, second, matcher)

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -459,11 +459,11 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None):
         It should be the same type as the first graph.
     :param callable node_matcher: A python callable object that takes 2 positional
         one for each node data object. If the return of this
-        function evaluates to True then the nodes passed to it are vieded
+        function evaluates to True then the nodes passed to it are viewed
         as matching.
     :param callable edge_matcher: A python callable object that takes 2 positional
         one for each edge data object. If the return of this
-        function evaluates to True then the edges passed to it are vieded
+        function evaluates to True then the edges passed to it are viewed
         as matching.
 
     :returns: ``True`` if the 2 graphs are isomorphic, ``False`` if they are 

--- a/src/dag_isomorphism.rs
+++ b/src/dag_isomorphism.rs
@@ -89,11 +89,7 @@ where
     }
 
     /// Add mapping **from** <-> **to** to the state.
-    pub fn push_mapping(
-        &mut self,
-        from: NodeIndex,
-        to: NodeIndex,
-    ) {
+    pub fn push_mapping(&mut self, from: NodeIndex, to: NodeIndex) {
         self.generation += 1;
         let s = self.generation;
         self.mapping[from.index()] = to;
@@ -117,10 +113,7 @@ where
     }
 
     /// Restore the state to before the last added mapping
-    pub fn pop_mapping(
-        &mut self,
-        from: NodeIndex,
-    ) {
+    pub fn pop_mapping(&mut self, from: NodeIndex) {
         let s = self.generation;
         self.generation -= 1;
 

--- a/src/dag_isomorphism.rs
+++ b/src/dag_isomorphism.rs
@@ -18,18 +18,33 @@ use std::marker;
 
 use hashbrown::HashMap;
 
-use super::digraph::PyDiGraph;
+use super::NodesRemoved;
 
 use pyo3::prelude::*;
 
-use petgraph::algo;
 use petgraph::stable_graph::NodeIndex;
-use petgraph::stable_graph::StableDiGraph;
-use petgraph::visit::{EdgeRef, GetAdjacencyMatrix, IntoEdgeReferences};
+use petgraph::stable_graph::StableGraph;
+use petgraph::visit::{
+    EdgeRef, GetAdjacencyMatrix, IntoEdgeReferences, NodeIndexable,
+};
+use petgraph::EdgeType;
 use petgraph::{Directed, Incoming};
 
+impl<'a, Ty> NodesRemoved for &'a StableGraph<PyObject, PyObject, Ty>
+where
+    Ty: EdgeType,
+{
+    fn nodes_removed(&self) -> bool {
+        self.node_bound() != self.node_count()
+    }
+}
+
 #[derive(Debug)]
-struct Vf2State {
+struct Vf2State<'a, Ty>
+where
+    Ty: EdgeType,
+{
+    graph: &'a StableGraph<PyObject, PyObject, Ty>,
     /// The current mapping M(s) of nodes from G0 → G1 and G1 → G0,
     /// NodeIndex::end() for no mapping.
     mapping: Vec<NodeIndex>,
@@ -49,26 +64,23 @@ struct Vf2State {
     _etype: marker::PhantomData<Directed>,
 }
 
-impl Vf2State {
-    pub fn new(dag: &PyDiGraph) -> Self {
-        let g = &dag.graph;
+impl<'a, Ty> Vf2State<'a, Ty>
+where
+    Ty: EdgeType,
+{
+    pub fn new(g: &'a StableGraph<PyObject, PyObject, Ty>) -> Self {
         let c0 = g.node_count();
-        let mut state = Vf2State {
-            mapping: Vec::with_capacity(c0),
-            out: Vec::with_capacity(c0),
-            ins: Vec::with_capacity(c0 * (g.is_directed() as usize)),
+        Vf2State {
+            graph: g,
+            mapping: vec![NodeIndex::end(); c0],
+            out: vec![0; c0],
+            ins: vec![0; c0 * (g.is_directed() as usize)],
             out_size: 0,
             ins_size: 0,
             adjacency_matrix: g.adjacency_matrix(),
             generation: 0,
             _etype: marker::PhantomData,
-        };
-        for _ in 0..c0 {
-            state.mapping.push(NodeIndex::end());
-            state.out.push(0);
-            state.ins.push(0);
         }
-        state
     }
 
     /// Return **true** if we have a complete mapping
@@ -81,23 +93,21 @@ impl Vf2State {
         &mut self,
         from: NodeIndex,
         to: NodeIndex,
-        dag: &PyDiGraph,
     ) {
-        let g = &dag.graph;
         self.generation += 1;
         let s = self.generation;
         self.mapping[from.index()] = to;
         // update T0 & T1 ins/outs
         // T0out: Node in G0 not in M0 but successor of a node in M0.
         // st.out[0]: Node either in M0 or successor of M0
-        for ix in g.neighbors(from) {
+        for ix in self.graph.neighbors(from) {
             if self.out[ix.index()] == 0 {
                 self.out[ix.index()] = s;
                 self.out_size += 1;
             }
         }
-        if g.is_directed() {
-            for ix in g.neighbors_directed(from, Incoming) {
+        if self.graph.is_directed() {
+            for ix in self.graph.neighbors_directed(from, Incoming) {
                 if self.ins[ix.index()] == 0 {
                     self.ins[ix.index()] = s;
                     self.ins_size += 1;
@@ -107,8 +117,10 @@ impl Vf2State {
     }
 
     /// Restore the state to before the last added mapping
-    pub fn pop_mapping(&mut self, from: NodeIndex, dag: &PyDiGraph) {
-        let g = &dag.graph;
+    pub fn pop_mapping(
+        &mut self,
+        from: NodeIndex,
+    ) {
         let s = self.generation;
         self.generation -= 1;
 
@@ -116,14 +128,14 @@ impl Vf2State {
         self.mapping[from.index()] = NodeIndex::end();
 
         // unmark in ins and outs
-        for ix in g.neighbors(from) {
+        for ix in self.graph.neighbors(from) {
             if self.out[ix.index()] == s {
                 self.out[ix.index()] = 0;
                 self.out_size -= 1;
             }
         }
-        if g.is_directed() {
-            for ix in g.neighbors_directed(from, Incoming) {
+        if self.graph.is_directed() {
+            for ix in self.graph.neighbors_directed(from, Incoming) {
                 if self.ins[ix.index()] == s {
                     self.ins[ix.index()] = 0;
                     self.ins_size -= 1;
@@ -175,26 +187,48 @@ impl Vf2State {
 ///
 /// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
 ///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
-pub fn is_isomorphic(dag0: &PyDiGraph, dag1: &PyDiGraph) -> PyResult<bool> {
-    let g0 = &dag0.graph;
-    let g1 = &dag1.graph;
+pub fn is_isomorphic<Ty>(
+    py: Python,
+    g0: &StableGraph<PyObject, PyObject, Ty>,
+    g1: &StableGraph<PyObject, PyObject, Ty>,
+) -> PyResult<bool>
+where
+    Ty: EdgeType,
+{
+    let inner_temp_g0: StableGraph<PyObject, PyObject, Ty>;
+    let inner_temp_g1: StableGraph<PyObject, PyObject, Ty>;
+    let g0_out = if g0.nodes_removed() {
+        inner_temp_g0 = reindex_graph(py, g0);
+        &inner_temp_g0
+    } else {
+        g0
+    };
+    let g1_out = if g1.nodes_removed() {
+        inner_temp_g1 = reindex_graph(py, g1);
+        &inner_temp_g1
+    } else {
+        g1
+    };
+    let g0 = &g0_out;
+    let g1 = &g1_out;
     if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
     {
         return Ok(false);
     }
 
-    let mut st = [Vf2State::new(dag0), Vf2State::new(dag1)];
-    let res = try_match(
-        &mut st,
-        dag0,
-        dag1,
-        &mut NoSemanticMatch,
-        &mut NoSemanticMatch,
-    )?;
+    let mut st = [Vf2State::new(g0), Vf2State::new(g1)];
+    let res =
+        try_match(&mut st, g0, g1, &mut NoSemanticMatch, &mut NoSemanticMatch)?;
     Ok(res.unwrap_or(false))
 }
 
-fn reindex_graph(py: Python, dag: &PyDiGraph) -> PyDiGraph {
+fn reindex_graph<Ty>(
+    py: Python,
+    graph: &StableGraph<PyObject, PyObject, Ty>,
+) -> StableGraph<PyObject, PyObject, Ty>
+where
+    Ty: EdgeType,
+{
     // NOTE: this is a hacky workaround to handle non-contiguous node ids in
     // VF2. The code which was forked from petgraph was written assuming the
     // Graph type and not StableGraph so it makes an implicit assumption on
@@ -202,27 +236,21 @@ fn reindex_graph(py: Python, dag: &PyDiGraph) -> PyDiGraph {
     // StableGraph. This compacts the node ids as a workaround until VF2State
     // and try_match can be rewitten to handle this (and likely contributed
     // upstream to petgraph too).
-    let mut new_graph = StableDiGraph::<PyObject, PyObject>::new();
+    let mut new_graph = StableGraph::<PyObject, PyObject, Ty>::default();
     let mut id_map: HashMap<NodeIndex, NodeIndex> = HashMap::new();
-    for node_index in dag.graph.node_indices() {
-        let node_data = dag.graph.node_weight(node_index).unwrap();
+    for node_index in graph.node_indices() {
+        let node_data = graph.node_weight(node_index).unwrap();
         let new_index = new_graph.add_node(node_data.clone_ref(py));
         id_map.insert(node_index, new_index);
     }
-    for edge in dag.graph.edge_references() {
+    for edge in graph.edge_references() {
         let edge_w = edge.weight();
         let p_index = id_map.get(&edge.source()).unwrap();
         let c_index = id_map.get(&edge.target()).unwrap();
         new_graph.add_edge(*p_index, *c_index, edge_w.clone_ref(py));
     }
 
-    PyDiGraph {
-        graph: new_graph,
-        cycle_state: algo::DfsSpace::default(),
-        check_cycle: dag.check_cycle,
-        node_removed: false,
-        multigraph: true,
-    }
+    new_graph
 }
 
 /// [Graph] Return `true` if the graphs `g0` and `g1` are isomorphic.
@@ -231,47 +259,41 @@ fn reindex_graph(py: Python, dag: &PyDiGraph) -> PyDiGraph {
 /// graph isomorphism (graph structure and matching node and edge weights).
 ///
 /// The graphs should not be multigraphs.
-pub fn is_isomorphic_matching<F, G>(
+pub fn is_isomorphic_matching<Ty, F, G>(
     py: Python,
-    dag0: &PyDiGraph,
-    dag1: &PyDiGraph,
+    g0: &StableGraph<PyObject, PyObject, Ty>,
+    g1: &StableGraph<PyObject, PyObject, Ty>,
     mut node_match: F,
     mut edge_match: G,
 ) -> PyResult<bool>
 where
+    Ty: EdgeType,
     F: FnMut(&PyObject, &PyObject) -> PyResult<bool>,
     G: FnMut(&PyObject, &PyObject) -> PyResult<bool>,
 {
-    let inner_temp_dag0: PyDiGraph;
-    let inner_temp_dag1: PyDiGraph;
-    let dag0_out = if dag0.node_removed {
-        inner_temp_dag0 = reindex_graph(py, dag0);
-        &inner_temp_dag0
+    let inner_temp_g0: StableGraph<PyObject, PyObject, Ty>;
+    let inner_temp_g1: StableGraph<PyObject, PyObject, Ty>;
+    let g0_out = if g0.nodes_removed() {
+        inner_temp_g0 = reindex_graph(py, g0);
+        &inner_temp_g0
     } else {
-        dag0
+        g0
     };
-    let dag1_out = if dag1.node_removed {
-        inner_temp_dag1 = reindex_graph(py, dag1);
-        &inner_temp_dag1
+    let g1_out = if g1.nodes_removed() {
+        inner_temp_g1 = reindex_graph(py, g1);
+        &inner_temp_g1
     } else {
-        dag1
+        g1
     };
-    let g0 = &dag0_out.graph;
-    let g1 = &dag1_out.graph;
-
+    let g0 = &g0_out;
+    let g1 = &g1_out;
     if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
     {
         return Ok(false);
     }
 
-    let mut st = [Vf2State::new(&dag0_out), Vf2State::new(&dag1_out)];
-    let res = try_match(
-        &mut st,
-        &dag0_out,
-        &dag1_out,
-        &mut node_match,
-        &mut edge_match,
-    )?;
+    let mut st = [Vf2State::new(g0), Vf2State::new(g1)];
+    let res = try_match(&mut st, g0, g1, &mut node_match, &mut edge_match)?;
     Ok(res.unwrap_or(false))
 }
 
@@ -309,23 +331,22 @@ where
 }
 
 /// Return Some(bool) if isomorphism is decided, else None.
-fn try_match<F, G>(
-    mut st: &mut [Vf2State; 2],
-    dag0: &PyDiGraph,
-    dag1: &PyDiGraph,
+fn try_match<Ty, F, G>(
+    mut st: &mut [Vf2State<Ty>; 2],
+    g0: &StableGraph<PyObject, PyObject, Ty>,
+    g1: &StableGraph<PyObject, PyObject, Ty>,
     node_match: &mut F,
     edge_match: &mut G,
 ) -> PyResult<Option<bool>>
 where
+    Ty: EdgeType,
     F: SemanticMatcher<PyObject>,
     G: SemanticMatcher<PyObject>,
 {
-    let g0 = &dag0.graph;
-    let g1 = &dag1.graph;
     if st[0].is_complete() {
         return Ok(Some(true));
     }
-    let dag = [dag0, dag1];
+
     let g = [g0, g1];
     let graph_indices = 0..2;
     let end = NodeIndex::end();
@@ -350,7 +371,7 @@ where
     }
 
     let next_candidate =
-        |st: &mut [Vf2State; 2]| -> Option<(NodeIndex, NodeIndex, OpenList)> {
+        |st: &mut [Vf2State<'_, Ty>; 2]| -> Option<(NodeIndex, NodeIndex, OpenList)> {
             let mut to_index;
             let mut from_index = None;
             let mut open_list = OpenList::Out;
@@ -386,7 +407,7 @@ where
                 _ => None,
             }
         };
-    let next_from_ix = |st: &mut [Vf2State; 2],
+    let next_from_ix = |st: &mut [Vf2State<'_, Ty>; 2],
                         nx: NodeIndex,
                         open_list: OpenList|
      -> Option<NodeIndex> {
@@ -407,21 +428,21 @@ where
         }
     };
     //fn pop_state(nodes: [NodeIndex<Ix>; 2]) {
-    let pop_state = |st: &mut [Vf2State; 2], nodes: [NodeIndex; 2]| {
+    let pop_state = |st: &mut [Vf2State<'_, Ty>; 2], nodes: [NodeIndex; 2]| {
         // Restore state.
         for j in graph_indices.clone() {
-            st[j].pop_mapping(nodes[j], dag[j]);
+            st[j].pop_mapping(nodes[j]);
         }
     };
     //fn push_state(nodes: [NodeIndex<Ix>; 2]) {
-    let push_state = |st: &mut [Vf2State; 2], nodes: [NodeIndex; 2]| {
+    let push_state = |st: &mut [Vf2State<'_, Ty>; 2], nodes: [NodeIndex; 2]| {
         // Add mapping nx <-> mx to the state
         for j in graph_indices.clone() {
-            st[j].push_mapping(nodes[j], nodes[1 - j], dag[j]);
+            st[j].push_mapping(nodes[j], nodes[1 - j]);
         }
     };
     //fn is_feasible(nodes: [NodeIndex<Ix>; 2]) -> bool {
-    let mut is_feasible = |st: &mut [Vf2State; 2],
+    let mut is_feasible = |st: &mut [Vf2State<'_, Ty>; 2],
                            nodes: [NodeIndex; 2]|
      -> PyResult<bool> {
         // Check syntactic feasibility of mapping by ensuring adjacencies

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -192,8 +192,8 @@ where
     }
     for edge in graph.edge_references() {
         let edge_w = edge.weight();
-        let p_index = id_map.get(&edge.source()).unwrap();
-        let c_index = id_map.get(&edge.target()).unwrap();
+        let p_index = id_map[&edge.source()];
+        let c_index = id_map[&edge.target()];
         new_graph.add_edge(*p_index, *c_index, edge_w.clone_ref(py));
     }
 

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -194,7 +194,7 @@ where
         let edge_w = edge.weight();
         let p_index = id_map[&edge.source()];
         let c_index = id_map[&edge.target()];
-        new_graph.add_edge(*p_index, *c_index, edge_w.clone_ref(py));
+        new_graph.add_edge(p_index, c_index, edge_w.clone_ref(py));
     }
 
     new_graph

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -169,52 +169,6 @@ where
     }
 }
 
-/// [Graph] Return `true` if the graphs `g0` and `g1` are isomorphic.
-///
-/// Using the VF2 algorithm, only matching graph syntactically (graph
-/// structure).
-///
-/// The graphs should not be multigraphs.
-///
-/// **Reference**
-///
-/// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
-///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
-pub fn is_isomorphic<Ty>(
-    py: Python,
-    g0: &StableGraph<PyObject, PyObject, Ty>,
-    g1: &StableGraph<PyObject, PyObject, Ty>,
-) -> PyResult<bool>
-where
-    Ty: EdgeType,
-{
-    let inner_temp_g0: StableGraph<PyObject, PyObject, Ty>;
-    let inner_temp_g1: StableGraph<PyObject, PyObject, Ty>;
-    let g0_out = if g0.nodes_removed() {
-        inner_temp_g0 = reindex_graph(py, g0);
-        &inner_temp_g0
-    } else {
-        g0
-    };
-    let g1_out = if g1.nodes_removed() {
-        inner_temp_g1 = reindex_graph(py, g1);
-        &inner_temp_g1
-    } else {
-        g1
-    };
-    let g0 = &g0_out;
-    let g1 = &g1_out;
-    if g0.node_count() != g1.node_count() || g0.edge_count() != g1.edge_count()
-    {
-        return Ok(false);
-    }
-
-    let mut st = [Vf2State::new(g0), Vf2State::new(g1)];
-    let res =
-        try_match(&mut st, g0, g1, &mut NoSemanticMatch, &mut NoSemanticMatch)?;
-    Ok(res.unwrap_or(false))
-}
-
 fn reindex_graph<Ty>(
     py: Python,
     graph: &StableGraph<PyObject, PyObject, Ty>,
@@ -252,7 +206,7 @@ where
 /// graph isomorphism (graph structure and matching node and edge weights).
 ///
 /// The graphs should not be multigraphs.
-pub fn is_isomorphic_matching<Ty, F, G>(
+pub fn is_isomorphic<Ty, F, G>(
     py: Python,
     g0: &StableGraph<PyObject, PyObject, Ty>,
     g1: &StableGraph<PyObject, PyObject, Ty>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,7 @@ fn digraph_is_isomorphic(
         }
     });
 
-    let res = isomorphism::is_isomorphic_matching(
+    let res = isomorphism::is_isomorphic(
         py,
         &first.graph,
         &second.graph,
@@ -390,7 +390,7 @@ fn graph_is_isomorphic(
         }
     });
 
-    let res = isomorphism::is_isomorphic_matching(
+    let res = isomorphism::is_isomorphic(
         py,
         &first.graph,
         &second.graph,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,10 +253,11 @@ fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
 #[pyfunction]
 #[text_signature = "(first, second, /)"]
 fn is_isomorphic(
+    py: Python,
     first: &digraph::PyDiGraph,
     second: &digraph::PyDiGraph,
 ) -> PyResult<bool> {
-    let res = dag_isomorphism::is_isomorphic(first, second)?;
+    let res = dag_isomorphism::is_isomorphic(py, &first.graph, &second.graph)?;
     Ok(res)
 }
 
@@ -344,8 +345,8 @@ fn is_isomorphic_node_match(
     }
     let res = dag_isomorphism::is_isomorphic_matching(
         py,
-        first,
-        second,
+        &first.graph,
+        &second.graph,
         compare_nodes,
         compare_edges,
     )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,12 @@
 // under the License.
 
 mod astar;
-mod dag_isomorphism;
 mod digraph;
 mod dijkstra;
 mod dot_utils;
 mod generators;
 mod graph;
+mod isomorphism;
 mod iterators;
 mod k_shortest_path;
 mod max_weight_matching;
@@ -239,50 +239,6 @@ fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
     }
 }
 
-/// Determine if 2 graphs are structurally isomorphic
-///
-/// This checks if 2 graphs are structurally isomorphic (it doesn't match
-/// the contents of the nodes or edges on the graphs).
-///
-/// :param PyDiGraph first: The first graph to compare
-/// :param PyDiGraph second: The second graph to compare
-///
-/// :returns: ``True`` if the 2 graphs are structurally isomorphic, ``False``
-///     if they are not
-/// :rtype: bool
-#[pyfunction]
-#[text_signature = "(first, second, /)"]
-fn digraph_is_isomorphic(
-    py: Python,
-    first: &digraph::PyDiGraph,
-    second: &digraph::PyDiGraph,
-) -> PyResult<bool> {
-    let res = dag_isomorphism::is_isomorphic(py, &first.graph, &second.graph)?;
-    Ok(res)
-}
-
-/// Determine if 2 graphs are structurally isomorphic
-///
-/// This checks if 2 graphs are structurally isomorphic (it doesn't match
-/// the contents of the nodes or edges on the graphs).
-///
-/// :param PyGraph first: The first graph to compare
-/// :param PyGraph second: The second graph to compare
-///
-/// :returns: ``True`` if the 2 graphs are structurally isomorphic, ``False``
-///     if they are not
-/// :rtype: bool
-#[pyfunction]
-#[text_signature = "(first, second, /)"]
-fn graph_is_isomorphic(
-    py: Python,
-    first: &graph::PyGraph,
-    second: &graph::PyGraph,
-) -> PyResult<bool> {
-    let res = dag_isomorphism::is_isomorphic(py, &first.graph, &second.graph)?;
-    Ok(res)
-}
-
 /// Return a new PyDiGraph by forming a union from two input PyDiGraph objects
 ///
 /// The algorithm in this function operates in three phases:
@@ -326,47 +282,56 @@ fn digraph_union(
     Ok(res)
 }
 
-/// Determine if 2 DAGs are isomorphic
+/// Determine if 2 directed graphs are isomorphic
 ///
 /// This checks if 2 graphs are isomorphic both structurally and also
-/// comparing the node data using the provided matcher function. The matcher
-/// function takes in 2 node data objects and will compare them. A simple
+/// comparing the node data and edge data using the provided matcher functions.
+/// The matcher function takes in 2 data objects and will compare them. A simple
 /// example that checks if they're just equal would be::
 ///
-///     graph_a = retworkx.PyDAG()
-///     graph_b = retworkx.PyDAG()
-///     retworkx.is_isomorphic_node_match(graph_a, graph_b,
-///                                       lambda x, y: x == y)
+///     graph_a = retworkx.PyDiGraph()
+///     graph_b = retworkx.PyDiGraph()
+///     retworkx.is_isomorphic(graph_a, graph_b,
+///                            lambda x, y: x == y)
 ///
 /// :param PyDiGraph first: The first graph to compare
 /// :param PyDiGraph second: The second graph to compare
-/// :param callable matcher: A python callable object that takes 2 positional
+/// :param callable node_matcher: A python callable object that takes 2 positional
 ///     one for each node data object. If the return of this
-///     function evaluates to True then the nodes passed to it are vieded as
-///     matching.
+///     function evaluates to True then the nodes passed to it are vieded
+///     as matching.
+/// :param callable edge_matcher: A python callable object that takes 2 positional
+///     one for each edge data object. If the return of this
+///     function evaluates to True then the edges passed to it are vieded
+///     as matching.
 ///
 /// :returns: ``True`` if the 2 graphs are isomorphic ``False`` if they are
 ///     not.
 /// :rtype: bool
 #[pyfunction]
-#[text_signature = "(first, second, node_matcher, edge_matcher /)"]
-fn digraph_is_isomorphic_node_match(
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, /)"]
+fn digraph_is_isomorphic(
     py: Python,
     first: &digraph::PyDiGraph,
     second: &digraph::PyDiGraph,
-    node_matcher: PyObject,
-    edge_matcher: PyObject,
+    node_matcher: Option<PyObject>,
+    edge_matcher: Option<PyObject>,
 ) -> PyResult<bool> {
-    let compare_nodes = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = node_matcher.call1(py, (a, b))?;
-        Ok(res.is_true(py).unwrap())
-    };
+    let compare_nodes = node_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
 
-    let compare_edges = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = edge_matcher.call1(py, (a, b))?;
-        Ok(res.is_true(py).unwrap())
-    };
-    let res = dag_isomorphism::is_isomorphic_matching(
+    let compare_edges = edge_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let res = isomorphism::is_isomorphic_matching(
         py,
         &first.graph,
         &second.graph,
@@ -376,47 +341,56 @@ fn digraph_is_isomorphic_node_match(
     Ok(res)
 }
 
-/// Determine if 2 graphs are isomorphic
+/// Determine if 2 undirected graphs are isomorphic
 ///
 /// This checks if 2 graphs are isomorphic both structurally and also
-/// comparing the node data using the provided matcher function. The matcher
-/// function takes in 2 node data objects and will compare them. A simple
+/// comparing the node data and edge data using the provided matcher functions.
+/// The matcher function takes in 2 data objects and will compare them. A simple
 /// example that checks if they're just equal would be::
 ///
 ///     graph_a = retworkx.PyGraph()
 ///     graph_b = retworkx.PyGraph()
-///     retworkx.is_isomorphic_node_match(graph_a, graph_b,
-///                                       lambda x, y: x == y)
+///     retworkx.is_isomorphic(graph_a, graph_b,
+///                            lambda x, y: x == y)
 ///
 /// :param PyGraph first: The first graph to compare
 /// :param PyGraph second: The second graph to compare
-/// :param callable matcher: A python callable object that takes 2 positional
+/// :param callable node_matcher: A python callable object that takes 2 positional
 ///     one for each node data object. If the return of this
-///     function evaluates to True then the nodes passed to it are vieded as
-///     matching.
+///     function evaluates to True then the nodes passed to it are vieded
+///     as matching.
+/// :param callable edge_matcher: A python callable object that takes 2 positional
+///     one for each edge data object. If the return of this
+///     function evaluates to True then the edges passed to it are vieded
+///     as matching.
 ///
 /// :returns: ``True`` if the 2 graphs are isomorphic ``False`` if they are
 ///     not.
 /// :rtype: bool
 #[pyfunction]
-#[text_signature = "(first, second, node_matcher, edge_matcher /)"]
-fn graph_is_isomorphic_node_match(
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, /)"]
+fn graph_is_isomorphic(
     py: Python,
     first: &graph::PyGraph,
     second: &graph::PyGraph,
-    node_matcher: PyObject,
-    edge_matcher: PyObject,
+    node_matcher: Option<PyObject>,
+    edge_matcher: Option<PyObject>,
 ) -> PyResult<bool> {
-    let compare_nodes = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = node_matcher.call1(py, (a, b))?;
-        Ok(res.is_true(py).unwrap())
-    };
+    let compare_nodes = node_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
 
-    let compare_edges = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = edge_matcher.call1(py, (a, b))?;
-        Ok(res.is_true(py).unwrap())
-    };
-    let res = dag_isomorphism::is_isomorphic_matching(
+    let compare_edges = edge_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let res = isomorphism::is_isomorphic_matching(
         py,
         &first.graph,
         &second.graph,
@@ -2838,8 +2812,6 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_is_isomorphic))?;
     m.add_wrapped(wrap_pyfunction!(graph_is_isomorphic))?;
     m.add_wrapped(wrap_pyfunction!(digraph_union))?;
-    m.add_wrapped(wrap_pyfunction!(digraph_is_isomorphic_node_match))?;
-    m.add_wrapped(wrap_pyfunction!(graph_is_isomorphic_node_match))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(descendants))?;
     m.add_wrapped(wrap_pyfunction!(ancestors))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,22 +349,23 @@ fn digraph_union(
 ///     not.
 /// :rtype: bool
 #[pyfunction]
-#[text_signature = "(first, second, matcher, /)"]
+#[text_signature = "(first, second, node_matcher, edge_matcher /)"]
 fn digraph_is_isomorphic_node_match(
     py: Python,
     first: &digraph::PyDiGraph,
     second: &digraph::PyDiGraph,
-    matcher: PyObject,
+    node_matcher: PyObject,
+    edge_matcher: PyObject,
 ) -> PyResult<bool> {
     let compare_nodes = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = matcher.call1(py, (a, b))?;
+        let res = node_matcher.call1(py, (a, b))?;
         Ok(res.is_true(py).unwrap())
     };
 
-    #[allow(clippy::unnecessary_wraps)]
-    fn compare_edges(_a: &PyObject, _b: &PyObject) -> PyResult<bool> {
-        Ok(true)
-    }
+    let compare_edges = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+        let res = edge_matcher.call1(py, (a, b))?;
+        Ok(res.is_true(py).unwrap())
+    };
     let res = dag_isomorphism::is_isomorphic_matching(
         py,
         &first.graph,
@@ -398,22 +399,23 @@ fn digraph_is_isomorphic_node_match(
 ///     not.
 /// :rtype: bool
 #[pyfunction]
-#[text_signature = "(first, second, matcher, /)"]
+#[text_signature = "(first, second, node_matcher, edge_matcher /)"]
 fn graph_is_isomorphic_node_match(
     py: Python,
     first: &graph::PyGraph,
     second: &graph::PyGraph,
-    matcher: PyObject,
+    node_matcher: PyObject,
+    edge_matcher: PyObject,
 ) -> PyResult<bool> {
     let compare_nodes = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        let res = matcher.call1(py, (a, b))?;
+        let res = node_matcher.call1(py, (a, b))?;
         Ok(res.is_true(py).unwrap())
     };
 
-    #[allow(clippy::unnecessary_wraps)]
-    fn compare_edges(_a: &PyObject, _b: &PyObject) -> PyResult<bool> {
-        Ok(true)
-    }
+    let compare_edges = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+        let res = edge_matcher.call1(py, (a, b))?;
+        Ok(res.is_true(py).unwrap())
+    };
     let res = dag_isomorphism::is_isomorphic_matching(
         py,
         &first.graph,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -73,6 +73,13 @@ class TestDispatchPyGraph(unittest.TestCase):
         res = retworkx.dfs_edges(self.graph, 0)
         self.assertIsInstance(list(res), list)
 
+    def test_is_isomorphic_nodes_incompatible_raises(self):
+        with self.assertRaises(TypeError):
+            if self.class_type == "PyGraph":
+                retworkx.is_isomorphic(self.graph, retworkx.PyDiGraph())
+            else:
+                retworkx.is_isomorphic(self.graph, retworkx.PyGraph())
+
 
 class TestDispatchPyDiGraph(TestDispatchPyGraph):
 

--- a/tests/test_isomorphic.py
+++ b/tests/test_isomorphic.py
@@ -277,3 +277,57 @@ class TestIsomorphic(unittest.TestCase):
         self.assertTrue(
             retworkx.is_isomorphic(
                 g_a, g_b, lambda x, y: x == y))
+
+    def test_isomorphic_compare_edges_identical_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                g_a, g_b, edge_matcher=lambda x, y: x == y))
+
+    def test_isomorphic_removed_nodes_in_second_graph(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['a_0', 'a_2', 'a_1', 'a_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'e_01'), (nodes[0], nodes[3], 'e_03'),
+            (nodes[2], nodes[1], 'a_1'), (nodes[1], nodes[3], 'a_2')
+        ])
+        g_b.remove_node(nodes[0])
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                g_a, g_b, lambda x, y: x == y))
+
+    def test_isomorphic_node_count_not_equal(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1')
+        ])
+
+        nodes = g_b.add_nodes_from(['a_0', 'a_1'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'a_1')
+        ])
+        g_b.remove_node(nodes[0])
+        self.assertFalse(
+            retworkx.is_isomorphic(
+                g_a, g_b))

--- a/tests/test_isomorphic.py
+++ b/tests/test_isomorphic.py
@@ -56,7 +56,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, 'b_2', 'b_1')
         dag_b.add_child(node_b, 'b_3', 'b_2')
         self.assertFalse(
-            retworkx.is_isomorphic_node_match(
+            retworkx.is_isomorphic(
                 dag_a, dag_b, lambda x, y: x == y))
 
     def test_is_isomorphic_nodes_compare_raises(self):
@@ -76,7 +76,7 @@ class TestIsomorphic(unittest.TestCase):
 
         self.assertRaises(
             TypeError,
-            retworkx.is_isomorphic_node_match,
+            retworkx.is_isomorphic,
             (dag_a, dag_b, compare_nodes))
 
     def test_isomorphic_compare_nodes_identical(self):
@@ -91,8 +91,23 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, 'a_2', 'a_1')
         dag_b.add_child(node_b, 'a_3', 'a_2')
         self.assertTrue(
-            retworkx.is_isomorphic_node_match(
+            retworkx.is_isomorphic(
                 dag_a, dag_b, lambda x, y: x == y))
+
+    def test_isomorphic_compare_edges_identical(self):
+        dag_a = retworkx.PyDAG()
+        dag_b = retworkx.PyDAG()
+
+        node_a = dag_a.add_node('a_1')
+        dag_a.add_child(node_a, 'a_2', 'a_1')
+        dag_a.add_child(node_a, 'a_3', 'a_2')
+
+        node_b = dag_b.add_node('a_1')
+        dag_b.add_child(node_b, 'a_2', 'a_1')
+        dag_b.add_child(node_b, 'a_3', 'a_2')
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                dag_a, dag_b, edge_matcher=lambda x, y: x == y))
 
     def test_isomorphic_compare_nodes_with_removals(self):
         dag_a = retworkx.PyDAG()
@@ -132,7 +147,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_edge(measure_0, qr_0_out, 'qr[0]')
 
         self.assertTrue(
-            retworkx.is_isomorphic_node_match(
+            retworkx.is_isomorphic(
                 dag_a, dag_b, lambda x, y: x == y))
 
     def test_isomorphic_compare_nodes_with_removals_deepcopy(self):
@@ -173,6 +188,92 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_edge(measure_0, qr_0_out, 'qr[0]')
 
         self.assertTrue(
-            retworkx.is_isomorphic_node_match(
+            retworkx.is_isomorphic(
                 copy.deepcopy(dag_a), copy.deepcopy(dag_b),
                 lambda x, y: x == y))
+
+    def test_isomorphic_identical_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+        self.assertTrue(retworkx.is_isomorphic(g_a, g_b))
+
+    def test_isomorphic_mismatch_node_data_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
+        ])
+        self.assertTrue(retworkx.is_isomorphic(g_a, g_b))
+
+    def test_isomorphic_compare_nodes_mismatch_node_data_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
+        ])
+        self.assertFalse(
+            retworkx.is_isomorphic(
+                g_a, g_b, lambda x, y: x == y))
+
+    def test_is_isomorphic_nodes_compare_raises_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
+        ])
+
+        def compare_nodes(a, b):
+            raise TypeError("Failure")
+
+        self.assertRaises(
+            TypeError,
+            retworkx.is_isomorphic,
+            (g_a, g_b, compare_nodes))
+
+    def test_isomorphic_compare_nodes_identical_undirected(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_a.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+
+        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
+        g_b.add_edges_from([
+            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
+        ])
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                g_a, g_b, lambda x, y: x == y))


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Resolves #268.
Introduced changes:
- Vf2 implementation in `dag_isomorphism.rs` now works with `StableGraph` so we can pass the graph that `PyGraph` and `PyDiGraph` store.
- Optional `edge_matcher` argument to compare edge data.
- Unified api in a single `is_isomorphic` call.
- Retain `retworkx.is_isomorphic_node_matching` for backwards compatibility.