### PR TITLE
add core_number functions

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -93,6 +93,8 @@ Specific Graph Type Methods
    retworkx.is_matching
    retworkx.is_maximal_matching
    retworkx.max_weight_matching
+   retworkx.graph_core_number
+   retworkx.diWgraph_core_number
 
 .. _universal-functions:
 
@@ -116,6 +118,7 @@ type functions in the algorithms API but can be run with a
    retworkx.dijkstra_shortest_path_lengths
    retworkx.k_shortest_path_lengths
    retworkx.dfs_edges
+   retworkx.core_number
 
 Exceptions
 ----------

--- a/releasenotes/notes/add-core_number-b1d3b2fb7ebd276f.yaml
+++ b/releasenotes/notes/add-core_number-b1d3b2fb7ebd276f.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add a new function, :func:`~retworkx.core_number` for computing the core
+    number of each node in a :class:`~retworkx.PyGraph` or a 
+    :class:`~retworkx.PyDiGraph`, where for directed graphs the degrees are
+    calculated as in_degree + out_degree.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -437,3 +437,29 @@ def _digraph_dfs_edges(graph, source):
 @dfs_edges.register(PyGraph)
 def _graph_dfs_edges(graph, source):
     return graph_dfs_edges(graph, source)
+
+
+@functools.singledispatch
+def core_number(graph):
+    """Return the core number for each node
+
+    A k-core is a maximal subgraph that contains nodes of degree k or more.
+
+    :param graph: The graph to get core numbers. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`
+
+    :returns: A dictionary keyed by node index to the core number
+    :rtype: dict
+        raise TypeError("Invalid Input Type %s for graph" % type(graph))
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(graph))
+
+
+@core_number.register(PyGraph)
+def _graph_core_number(graph):
+    return graph_core_number(graph)
+
+
+@core_number.register(PyDiGraph)
+def _digraph_core_number(graph):
+    return digraph_core_number(graph)

--- a/tests/test_core_number.py
+++ b/tests/test_core_number.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestCoreNumber(unittest.TestCase):
+    def test_undirected_graph(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node(2)
+        node_d = graph.add_node(3)
+        graph.add_node(4)
+        graph.add_edge(node_a, node_b, 'ab')
+        graph.add_edge(node_b, node_c, 'bc')
+        graph.add_edge(node_a, node_c, 'ac')
+        graph.add_edge(node_c, node_d, 'cd')
+        res = retworkx.core_number(graph)
+        self.assertIsInstance(res, dict)
+        self.assertTrue({0: 2, 1: 2, 2: 2, 3: 1, 4: 0} == res)
+
+    def test_directed_graph(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node(2)
+        node_d = graph.add_node(3)
+        node_e = graph.add_node(4)
+        graph.add_edge(node_a, node_b, 'ab')
+        graph.add_edge(node_b, node_d, 'bd')
+        graph.add_edge(node_a, node_c, 'ac')
+        graph.add_edge(node_c, node_d, 'cd')
+        graph.add_edge(node_d, node_e, 'de')
+        res = retworkx.core_number(graph)
+        self.assertIsInstance(res, dict)
+        self.assertTrue({0: 2, 1: 2, 2: 2, 3: 2, 4: 1} == res)


### PR DESCRIPTION
Resolves #193; adds core_number functions for both PyGraph and PyDiGraph. The algorithm takes from [[1](https://arxiv.org/pdf/cs/0310049.pdf)].

Currently, it doesn't support graphs with self-loops or parallel edges. Let me know if it should support these two cases or raise an error.