### PR TITLE
Add random_layout function and Pos2DMapping

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,11 +1,11 @@
 .. _retworkx:
 
-======================
+######################
 Retworkx API Reference
-======================
+######################
 
 Graph Classes
--------------
+=============
 
 .. autosummary::
    :toctree: stubs
@@ -15,7 +15,7 @@ Graph Classes
     retworkx.PyDAG
 
 Generators
-----------
+==========
 
 .. autosummary::
    :toctree: stubs
@@ -32,7 +32,7 @@ Generators
     retworkx.generators.directed_grid_graph
 
 Random Circuit Functions
-------------------------
+========================
 
 .. autosummary::
    :toctree: stubs
@@ -43,10 +43,10 @@ Random Circuit Functions
     retworkx.undirected_gnm_random_graph
 
 Algorithm Functions
--------------------
+===================
 
 Specific Graph Type Methods
-'''''''''''''''''''''''''''
+---------------------------
 
 .. autosummary::
    :toctree: stubs
@@ -101,13 +101,11 @@ Specific Graph Type Methods
    retworkx.digraph_core_number
    retworkx.graph_complement
    retworkx.digraph_complement
-   retworkx.graph_random_layout
-   retworkx.digraph_random_layout
 
 .. _universal-functions:
 
 Universal Functions
-'''''''''''''''''''
+-------------------
 
 These functions are algorithm functions that wrap per graph object
 type functions in the algorithms API but can be run with a
@@ -133,8 +131,18 @@ type functions in the algorithms API but can be run with a
    retworkx.core_number
    retworkx.random_layout
 
+Layout Functions
+================
+
+.. autosummary::
+   :toctree: stubs
+
+   retworkx.random_layout
+   retworkx.graph_random_layout
+   retworkx.digraph_random_layout
+
 Exceptions
-----------
+==========
 
 .. autosummary::
    :toctree: stubs
@@ -147,8 +155,8 @@ Exceptions
    retworkx.NoPathFound
    retworkx.NullGraph
 
-Return Iterator Types
----------------------
+Custom Return Types
+===================
 
 .. autosummary::
    :toctree: stubs
@@ -157,3 +165,4 @@ Return Iterator Types
    retworkx.NodeIndices
    retworkx.EdgeList
    retworkx.WeightedEdgeList
+   retworkx.Pos2DMapping

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -101,6 +101,8 @@ Specific Graph Type Methods
    retworkx.digraph_core_number
    retworkx.graph_complement
    retworkx.digraph_complement
+   retworkx.graph_random_layout
+   retworkx.digraph_random_layout
 
 .. _universal-functions:
 
@@ -129,6 +131,7 @@ type functions in the algorithms API but can be run with a
    retworkx.is_isomorphic_node_match
    retworkx.transitivity
    retworkx.core_number
+   retworkx.random_layout
 
 Exceptions
 ----------

--- a/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
+++ b/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added a new layou function, :func:`retworkx.random_layout` (and it's
+    Added a new layout function, :func:`retworkx.random_layout` (and it's
     equivalent per type variants :func:`retworkx.graph_random_layout` and
     :func:`retworkx.diraph_random_layout`) to generate a random layout which
     can be used for visualizations.

--- a/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
+++ b/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Added a new layou function, :func:`retworkx.random_layout` (and it's
+    equivalent per type variants :func:`retworkx.graph_random_layout` and
+    :func:`retworkx.diraph_random_layout`) to generate a random layout which
+    can be used for visualizations.
+  - |
+    Add a new custom return class, :class:`retworkx.Pos2DMapping`, has been
+    added. This function will be returned by layout functions and is a drop
+    in replacement for an immutable read-only dictionary of the form::
+
+      {1: [0.1, 0.5]}
+
+    where the keys are node indices and the values are a 2 element sequence
+    that represents the position for the node.

--- a/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
+++ b/releasenotes/notes/add-random-layout-c1c2751be971e5d0.yaml
@@ -6,7 +6,7 @@ features:
     :func:`retworkx.diraph_random_layout`) to generate a random layout which
     can be used for visualizations.
   - |
-    Add a new custom return class, :class:`retworkx.Pos2DMapping`, has been
+    A new custom return class, :class:`retworkx.Pos2DMapping`, has been
     added. This function will be returned by layout functions and is a drop
     in replacement for an immutable read-only dictionary of the form::
 

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -635,7 +635,7 @@ def random_layout(graph, center=None, seed=None):
         ``float`` values for the center position
     :param int seed: An optional seed to set for the random number generator.
 
-    :returns: The complement of the graph.
+    :returns: The random layout of the graph.
     :rtype: Pos2DMapping
     """
     raise TypeError("Invalid Input Type %s for graph" % type(graph))

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -624,3 +624,28 @@ def _digraph_complement(graph):
 @complement.register(PyGraph)
 def _graph_complement(graph):
     return graph_complement(graph)
+
+
+@functools.singledispatch
+def random_layout(graph, center=None, seed=None):
+    """Generate a random layout
+
+    :param PyGraph graph: The graph to generate the layout for
+    :param tuple center: An optional center position. This is a 2 tuple of two
+        ``float`` values for the center position
+    :param int seed: An optional seed to set for the random number generator.
+
+    :returns: The complement of the graph.
+    :rtype: Pos2DMapping
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(graph))
+
+
+@random_layout.register(PyDiGraph)
+def _digraph_random_layout(graph, center=None, seed=None):
+    return digraph_random_layout(graph, center=center, seed=seed)
+
+
+@random_layout.register(PyGraph)
+def _graph_random_layout(graph, center=None, seed=None):
+    return graph_random_layout(graph, center=center, seed=seed)

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -16,8 +16,11 @@ use std::collections::hash_map::DefaultHasher;
 use std::convert::TryInto;
 use std::hash::Hasher;
 
-use pyo3::class::{PyObjectProtocol, PySequenceProtocol};
-use pyo3::exceptions::{PyIndexError, PyNotImplementedError};
+use hashbrown::HashMap;
+
+use pyo3::class::iter::{IterNextOutput, PyIterProtocol};
+use pyo3::class::{PyMappingProtocol, PyObjectProtocol, PySequenceProtocol};
+use pyo3::exceptions::{PyIndexError, PyKeyError, PyNotImplementedError};
 use pyo3::gc::{PyGCProtocol, PyVisit};
 use pyo3::prelude::*;
 use pyo3::types::PySequence;
@@ -550,5 +553,240 @@ impl PyGCProtocol for WeightedEdgeList {
 
     fn __clear__(&mut self) {
         self.edges = Vec::new();
+    }
+}
+
+/// A class representing a mapping of node indices to 2D positions
+///
+/// This class is equivalent to having a dict of the form::
+///
+///     {1: [0, 1], 3: [0.5, 1.2]}
+///
+/// It is used to efficiently represent a retworkx generated 2D layout for a
+/// graph. It behaves as a drop in replacement for a readonly ``dict``.
+#[pyclass(module = "retworkx", gc)]
+pub struct Pos2DMapping {
+    pub pos_map: HashMap<usize, [f64; 2]>,
+}
+
+#[pymethods]
+impl Pos2DMapping {
+    #[new]
+    fn new() -> Pos2DMapping {
+        Pos2DMapping {
+            pos_map: HashMap::new(),
+        }
+    }
+
+    fn __getstate__(&self) -> HashMap<usize, [f64; 2]> {
+        self.pos_map.clone()
+    }
+
+    fn __setstate__(&mut self, state: HashMap<usize, [f64; 2]>) {
+        self.pos_map = state;
+    }
+
+    fn keys(&self) -> Pos2DMappingKeys {
+        Pos2DMappingKeys {
+            pos_keys: self.pos_map.keys().copied().collect(),
+            iter_pos: 0,
+        }
+    }
+
+    fn values(&self) -> Pos2DMappingValues {
+        Pos2DMappingValues {
+            pos_values: self.pos_map.values().copied().collect(),
+            iter_pos: 0,
+        }
+    }
+
+    fn items(&self) -> Pos2DMappingItems {
+        let items: Vec<(usize, [f64; 2])> =
+            self.pos_map.iter().map(|(k, v)| (*k, *v)).collect();
+        Pos2DMappingItems {
+            pos_items: items,
+            iter_pos: 0,
+        }
+    }
+}
+
+#[pyproto]
+impl<'p> PyObjectProtocol<'p> for Pos2DMapping {
+    fn __richcmp__(
+        &self,
+        other: PyObject,
+        op: pyo3::basic::CompareOp,
+    ) -> PyResult<bool> {
+        let compare = |other: PyObject| -> PyResult<bool> {
+            let gil = Python::acquire_gil();
+            let py = gil.python();
+            let other_ref = other.as_ref(py);
+            if other_ref.len()? != self.pos_map.len() {
+                return Ok(false);
+            }
+            for (key, value) in &self.pos_map {
+                match other_ref.get_item(key) {
+                    Ok(other_raw) => {
+                        let other_value: [f64; 2] = other_raw.extract()?;
+                        if other_value != *value {
+                            return Ok(false);
+                        }
+                    }
+                    Err(ref err)
+                        if Python::with_gil(|py| {
+                            err.is_instance::<PyKeyError>(py)
+                        }) =>
+                    {
+                        return Ok(false);
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            Ok(true)
+        };
+        match op {
+            pyo3::basic::CompareOp::Eq => compare(other),
+            pyo3::basic::CompareOp::Ne => match compare(other) {
+                Ok(res) => Ok(!res),
+                Err(err) => Err(err),
+            },
+            _ => Err(PyNotImplementedError::new_err(
+                "Comparison not implemented",
+            )),
+        }
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        let mut str_vec: Vec<String> = Vec::with_capacity(self.pos_map.len());
+        for path in &self.pos_map {
+            str_vec.push(format!("{}: ({}, {})", path.0, path.1[0], path.1[1]));
+        }
+        Ok(format!("Pos2DMapping{{{}}}", str_vec.join(", ")))
+    }
+
+    fn __hash__(&self) -> PyResult<u64> {
+        let mut hasher = DefaultHasher::new();
+        for index in &self.pos_map {
+            hasher.write_usize(*index.0);
+            hasher.write(&index.1[0].to_be_bytes());
+            hasher.write(&index.1[1].to_be_bytes());
+        }
+        Ok(hasher.finish())
+    }
+}
+
+#[pyproto]
+impl PySequenceProtocol for Pos2DMapping {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.pos_map.len())
+    }
+
+    fn __contains__(&self, index: usize) -> PyResult<bool> {
+        Ok(self.pos_map.contains_key(&index))
+    }
+}
+
+#[pyproto]
+impl PyMappingProtocol for Pos2DMapping {
+    /// Return the number of nodes in the graph
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.pos_map.len())
+    }
+    fn __getitem__(&'p self, idx: usize) -> PyResult<[f64; 2]> {
+        match self.pos_map.get(&idx) {
+            Some(data) => Ok(*data),
+            None => Err(PyIndexError::new_err("No node found for index")),
+        }
+    }
+}
+
+#[pyproto]
+impl PyIterProtocol for Pos2DMapping {
+    fn __iter__(slf: PyRef<Self>) -> Pos2DMappingKeys {
+        Pos2DMappingKeys {
+            pos_keys: slf.pos_map.keys().copied().collect(),
+            iter_pos: 0,
+        }
+    }
+}
+
+#[pyproto]
+impl PyGCProtocol for Pos2DMapping {
+    fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {}
+}
+
+#[pyclass(module = "retworkx")]
+pub struct Pos2DMappingKeys {
+    pub pos_keys: Vec<usize>,
+    iter_pos: usize,
+}
+
+#[pyproto]
+impl PyIterProtocol for Pos2DMappingKeys {
+    fn __iter__(slf: PyRef<Self>) -> Py<Pos2DMappingKeys> {
+        slf.into()
+    }
+    fn __next__(
+        mut slf: PyRefMut<Self>,
+    ) -> IterNextOutput<usize, &'static str> {
+        if slf.iter_pos < slf.pos_keys.len() {
+            let res = IterNextOutput::Yield(slf.pos_keys[slf.iter_pos]);
+            slf.iter_pos += 1;
+            res
+        } else {
+            IterNextOutput::Return("Ended")
+        }
+    }
+}
+
+#[pyclass(module = "retworkx")]
+pub struct Pos2DMappingValues {
+    pub pos_values: Vec<[f64; 2]>,
+    iter_pos: usize,
+}
+
+#[pyproto]
+impl PyIterProtocol for Pos2DMappingValues {
+    fn __iter__(slf: PyRef<Self>) -> Py<Pos2DMappingValues> {
+        slf.into()
+    }
+    fn __next__(
+        mut slf: PyRefMut<Self>,
+    ) -> IterNextOutput<[f64; 2], &'static str> {
+        if slf.iter_pos < slf.pos_values.len() {
+            let res = IterNextOutput::Yield(slf.pos_values[slf.iter_pos]);
+            slf.iter_pos += 1;
+            res
+        } else {
+            IterNextOutput::Return("Ended")
+        }
+    }
+}
+
+#[pyclass(module = "retworkx")]
+pub struct Pos2DMappingItems {
+    pub pos_items: Vec<(usize, [f64; 2])>,
+    iter_pos: usize,
+}
+
+#[pyproto]
+impl PyIterProtocol for Pos2DMappingItems {
+    fn __iter__(slf: PyRef<Self>) -> Py<Pos2DMappingItems> {
+        slf.into()
+    }
+    fn __next__(
+        mut slf: PyRefMut<Self>,
+    ) -> IterNextOutput<(usize, [f64; 2]), &'static str> {
+        if slf.iter_pos < slf.pos_items.len() {
+            let res = IterNextOutput::Yield(slf.pos_items[slf.iter_pos]);
+            slf.iter_pos += 1;
+            res
+        } else {
+            IterNextOutput::Return("Ended")
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3267,7 +3267,7 @@ fn digraph_complement(
 
 fn _random_layout<Ty: EdgeType>(
     graph: &StableGraph<PyObject, PyObject, Ty>,
-    center: Option<(f64, f64)>,
+    center: Option<[f64; 2]>,
     seed: Option<u64>,
 ) -> Pos2DMapping {
     let mut rng: Pcg64 = match seed {
@@ -3283,8 +3283,8 @@ fn _random_layout<Ty: EdgeType>(
                     Some(center) => (
                         n.index(),
                         [
-                            random_tuple[0] + center.0,
-                            random_tuple[1] + center.1,
+                            random_tuple[0] + center[0],
+                            random_tuple[1] + center[1],
                         ],
                     ),
                     None => (n.index(), random_tuple),
@@ -3307,7 +3307,7 @@ fn _random_layout<Ty: EdgeType>(
 #[text_signature = "(graph, / center=None, seed=None)"]
 pub fn graph_random_layout(
     graph: &graph::PyGraph,
-    center: Option<(f64, f64)>,
+    center: Option<[f64; 2]>,
     seed: Option<u64>,
 ) -> Pos2DMapping {
     _random_layout(&graph.graph, center, seed)
@@ -3326,7 +3326,7 @@ pub fn graph_random_layout(
 #[text_signature = "(graph, / center=None, seed=None)"]
 pub fn digraph_random_layout(
     graph: &digraph::PyDiGraph,
-    center: Option<(f64, f64)>,
+    center: Option<[f64; 2]>,
     seed: Option<u64>,
 ) -> Pos2DMapping {
     _random_layout(&graph.graph, center, seed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![allow(clippy::float_cmp)]
+
 mod astar;
 mod digraph;
 mod dijkstra;
@@ -55,7 +57,7 @@ use rand_pcg::Pcg64;
 use rayon::prelude::*;
 
 use crate::generators::PyInit_generators;
-use crate::iterators::{EdgeList, NodeIndices, WeightedEdgeList};
+use crate::iterators::{EdgeList, NodeIndices, Pos2DMapping, WeightedEdgeList};
 
 trait NodesRemoved {
     fn nodes_removed(&self) -> bool;
@@ -3263,6 +3265,73 @@ fn digraph_complement(
     Ok(complement_graph)
 }
 
+fn _random_layout<Ty: EdgeType>(
+    graph: &StableGraph<PyObject, PyObject, Ty>,
+    center: Option<(f64, f64)>,
+    seed: Option<u64>,
+) -> Pos2DMapping {
+    let mut rng: Pcg64 = match seed {
+        Some(seed) => Pcg64::seed_from_u64(seed),
+        None => Pcg64::from_entropy(),
+    };
+    Pos2DMapping {
+        pos_map: graph
+            .node_indices()
+            .map(|n| {
+                let random_tuple: [f64; 2] = rng.gen();
+                match center {
+                    Some(center) => (
+                        n.index(),
+                        [
+                            random_tuple[0] + center.0,
+                            random_tuple[1] + center.1,
+                        ],
+                    ),
+                    None => (n.index(), random_tuple),
+                }
+            })
+            .collect(),
+    }
+}
+
+/// Generate a random layout
+///
+/// :param PyGraph graph: The graph to generate the layout for
+/// :param tuple center: An optional center position. This is a 2 tuple of two
+///     ``float`` values for the center position
+/// :param int seed: An optional seed to set for the random number generator.
+///
+/// :returns: The complement of the graph.
+/// :rtype: Pos2DMapping
+#[pyfunction]
+#[text_signature = "(graph, / center=None, seed=None)"]
+pub fn graph_random_layout(
+    graph: &graph::PyGraph,
+    center: Option<(f64, f64)>,
+    seed: Option<u64>,
+) -> Pos2DMapping {
+    _random_layout(&graph.graph, center, seed)
+}
+
+/// Generate a random layout
+///
+/// :param PyDiGraph graph: The graph to generate the layout for
+/// :param tuple center: An optional center position. This is a 2 tuple of two
+///     ``float`` values for the center position
+/// :param int seed: An optional seed to set for the random number generator.
+///
+/// :returns: The complement of the graph.
+/// :rtype: Pos2DMapping
+#[pyfunction]
+#[text_signature = "(graph, / center=None, seed=None)"]
+pub fn digraph_random_layout(
+    graph: &digraph::PyDiGraph,
+    center: Option<(f64, f64)>,
+    seed: Option<u64>,
+) -> Pos2DMapping {
+    _random_layout(&graph.graph, center, seed)
+}
+
 // The provided node is invalid.
 create_exception!(retworkx, InvalidNode, PyException);
 // Performing this operation would result in trying to add a cycle to a DAG.
@@ -3342,12 +3411,15 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_core_number))?;
     m.add_wrapped(wrap_pyfunction!(graph_complement))?;
     m.add_wrapped(wrap_pyfunction!(digraph_complement))?;
+    m.add_wrapped(wrap_pyfunction!(graph_random_layout))?;
+    m.add_wrapped(wrap_pyfunction!(digraph_random_layout))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
     m.add_class::<iterators::BFSSuccessors>()?;
     m.add_class::<iterators::NodeIndices>()?;
     m.add_class::<iterators::EdgeList>()?;
     m.add_class::<iterators::WeightedEdgeList>()?;
+    m.add_class::<iterators::Pos2DMapping>()?;
     m.add_wrapped(wrap_pymodule!(generators))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3301,7 +3301,7 @@ fn _random_layout<Ty: EdgeType>(
 ///     ``float`` values for the center position
 /// :param int seed: An optional seed to set for the random number generator.
 ///
-/// :returns: The complement of the graph.
+/// :returns: The random layout of the graph.
 /// :rtype: Pos2DMapping
 #[pyfunction]
 #[text_signature = "(graph, / center=None, seed=None)"]
@@ -3320,7 +3320,7 @@ pub fn graph_random_layout(
 ///     ``float`` values for the center position
 /// :param int seed: An optional seed to set for the random number generator.
 ///
-/// :returns: The complement of the graph.
+/// :returns: The random layout of the graph.
 /// :rtype: Pos2DMapping
 #[pyfunction]
 #[text_signature = "(graph, / center=None, seed=None)"]

--- a/tests/digraph/test_layout.py
+++ b/tests/digraph/test_layout.py
@@ -1,0 +1,62 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestRandomLayout(unittest.TestCase):
+
+    def setUp(self):
+        self.graph = retworkx.generators.directed_path_graph(10)
+
+    def test_random_layout(self):
+        res = retworkx.digraph_random_layout(self.graph, seed=42)
+        expected = {
+            0: (0.2265125179283135, 0.23910669031859955),
+            4: (0.8025885957751138, 0.37085692752109345),
+            5: (0.23635127852185123, 0.9286365888207462),
+            1: (0.760833410686741, 0.5278396573581516),
+            3: (0.1879083014236631, 0.524657662927804),
+            2: (0.9704763177409157, 0.37546268141451944),
+            6: (0.462700947802672, 0.44025745918644743),
+            7: (0.3125895420208278, 0.0893209773065271),
+            8: (0.5567725240957387, 0.21079648777222115),
+            9: (0.7586719404939911, 0.43090704138697045)
+        }
+        self.assertEqual(expected, res)
+
+    def test_random_layout_center(self):
+        res = retworkx.digraph_random_layout(self.graph, center=(0.5, 0.5),
+                                             seed=42)
+        expected = {
+            1: [1.260833410686741, 1.0278396573581516],
+            5: [0.7363512785218512, 1.4286365888207462],
+            7: [0.8125895420208278, 0.5893209773065271],
+            4: [1.3025885957751138, 0.8708569275210934],
+            8: [1.0567725240957389, 0.7107964877722212],
+            9: [1.2586719404939912, 0.9309070413869704],
+            0: [0.7265125179283135, 0.7391066903185995],
+            2: [1.4704763177409157, 0.8754626814145194],
+            6: [0.962700947802672, 0.9402574591864474],
+            3: [0.6879083014236631, 1.0246576629278041]
+        }
+        self.assertEqual(expected, res)
+
+    def test_random_layout_no_seed(self):
+        res = retworkx.digraph_random_layout(self.graph)
+        # Random output, just assert  structurally correct
+        self.assertIsInstance(res, retworkx.Pos2DMapping)
+        self.assertEqual(len(res), 10)
+        self.assertEqual(len(res[0]), 2)
+        self.assertIsInstance(res[0][0], float)

--- a/tests/graph/test_layout.py
+++ b/tests/graph/test_layout.py
@@ -1,0 +1,62 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestRandomLayout(unittest.TestCase):
+
+    def setUp(self):
+        self.graph = retworkx.generators.path_graph(10)
+
+    def test_random_layout(self):
+        res = retworkx.graph_random_layout(self.graph, seed=42)
+        expected = {
+            0: (0.2265125179283135, 0.23910669031859955),
+            4: (0.8025885957751138, 0.37085692752109345),
+            5: (0.23635127852185123, 0.9286365888207462),
+            1: (0.760833410686741, 0.5278396573581516),
+            3: (0.1879083014236631, 0.524657662927804),
+            2: (0.9704763177409157, 0.37546268141451944),
+            6: (0.462700947802672, 0.44025745918644743),
+            7: (0.3125895420208278, 0.0893209773065271),
+            8: (0.5567725240957387, 0.21079648777222115),
+            9: (0.7586719404939911, 0.43090704138697045)
+        }
+        self.assertEqual(expected, res)
+
+    def test_random_layout_center(self):
+        res = retworkx.graph_random_layout(self.graph, center=(0.5, 0.5),
+                                           seed=42)
+        expected = {
+            1: [1.260833410686741, 1.0278396573581516],
+            5: [0.7363512785218512, 1.4286365888207462],
+            7: [0.8125895420208278, 0.5893209773065271],
+            4: [1.3025885957751138, 0.8708569275210934],
+            8: [1.0567725240957389, 0.7107964877722212],
+            9: [1.2586719404939912, 0.9309070413869704],
+            0: [0.7265125179283135, 0.7391066903185995],
+            2: [1.4704763177409157, 0.8754626814145194],
+            6: [0.962700947802672, 0.9402574591864474],
+            3: [0.6879083014236631, 1.0246576629278041]
+        }
+        self.assertEqual(expected, res)
+
+    def test_random_layout_no_seed(self):
+        res = retworkx.graph_random_layout(self.graph)
+        # Random output, just assert  structurally correct
+        self.assertIsInstance(res, retworkx.Pos2DMapping)
+        self.assertEqual(len(res), 10)
+        self.assertEqual(len(res[0]), 2)
+        self.assertIsInstance(res[0][0], float)

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -276,3 +276,116 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         res = self.dag.weighted_edge_list()
         with self.assertRaises(TypeError):
             hash(res)
+
+
+class TestPos2DMapping(unittest.TestCase):
+
+    def setUp(self):
+        self.dag = retworkx.PyDiGraph()
+        self.dag.add_node('a')
+
+    def test__eq__match(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertTrue(res == {0: (0.4883489113112722, 0.6545867364101975)})
+
+    def test__eq__not_match_keys(self):
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0})
+
+    def test__eq__not_match_values(self):
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0})
+
+    def test__eq__different_length(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertFalse(res == {1: 1.0, 2: 2.0})
+
+    def test_eq__same_type(self):
+        self.assertEqual(
+            retworkx.random_layout(self.dag, seed=10244242),
+            retworkx.random_layout(self.dag, seed=10244242))
+
+    def test__eq__invalid_type(self):
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {'a': None})
+
+    def test__ne__match(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertFalse(res != {0: (0.4883489113112722, 0.6545867364101975)})
+
+    def test__ne__not_match(self):
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0})
+
+    def test__ne__not_match_values(self):
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0})
+
+    def test__ne__different_length(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+
+        self.assertTrue(res != {1: 1.0, 2: 2.0})
+
+    def test__ne__invalid_type(self):
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != ['a', None])
+
+    def test__gt__not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            retworkx.random_layout(self.dag, seed=10244242) > {1: 1.0}
+
+    def test_deepcopy(self):
+        positions = retworkx.random_layout(self.dag)
+        positions_copy = copy.deepcopy(positions)
+        self.assertEqual(positions_copy, positions)
+
+    def test_pickle(self):
+        pos = retworkx.random_layout(self.dag)
+        pos_pickle = pickle.dumps(pos)
+        pos_copy = pickle.loads(pos_pickle)
+        self.assertEqual(pos, pos_copy)
+
+    def test_str(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertEqual(
+            "Pos2DMapping{0: (0.4883489113112722, 0.6545867364101975)}",
+            str(res))
+
+    def test_hash(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        hash_res = hash(res)
+        self.assertIsInstance(hash_res, int)
+        # Assert hash is stable
+        self.assertEqual(hash_res, hash(res))
+
+    def test_index_error(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        with self.assertRaises(IndexError):
+            res[42]
+
+    def test_keys(self):
+        keys = retworkx.random_layout(self.dag, seed=10244242).keys()
+        self.assertEqual([0], list(keys))
+
+    def test_values(self):
+        values = retworkx.random_layout(self.dag, seed=10244242).values()
+        expected = [[0.4883489113112722, 0.6545867364101975]]
+        self.assertEqual(expected, list(values))
+
+    def test_items(self):
+        items = retworkx.random_layout(self.dag, seed=10244242).items()
+        self.assertEqual([(0, [0.4883489113112722, 0.6545867364101975])],
+                         list(items))
+
+    def test_iter(self):
+        mapping_iter = iter(retworkx.random_layout(self.dag, seed=10244242))
+        output = list(mapping_iter)
+        self.assertEqual(output, [0])
+
+    def test_contains(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertIn(0, res)
+
+    def test_not_contains(self):
+        res = retworkx.random_layout(self.dag, seed=10244242)
+        self.assertNotIn(1, res)


### PR DESCRIPTION
This commit adds a new function `random_layout()` which is used to
generate a random layout for a graph that can be used in visualization.
This is necessary for building a matplotlib drawer (issue #298 and a
first draft of the implementation #304). To make the function more
efficient it also adds a new custom return type `Pos2DMapping` which is
used to build an immutable readonly dict compatible result container for
the output type from this function.

Related to #280

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
