### PR TITLE
Skip rustup installation for ppc64le CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - export PATH=~/.cargo/bin:$PATH
   - which python
   - pip install -U pip virtualenv tox
+before_cache:
+  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
 script:
   - tox -epy
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       arch: ppc64le
       before_install:
         - which python
+        - sudo chown travis -R $TRAVIS_HOME/.cargo
         - pip install -U pip virtualenv tox
     - name: Python 3.7 Tests s390x Linux
       stage: Linux non-x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ jobs:
       stage: Linux non-x86_64
       python: 3.7
       arch: ppc64le
+      before_install:
+        - which python
+        - pip install -U pip virtualenv tox
     - name: Python 3.7 Tests s390x Linux
       stage: Linux non-x86_64
       python: 3.7


### PR DESCRIPTION
The ppc64le CI job has started to fail recently when installing rustup
to bootstrap a rust environmnet in the CI node. The error states that
there is already a system rust installation and that it will conflict
with rustup's version of rust. Since apparently rust is preinstalled on
the travis ppc64le CI nodes now this commit attempts to fix the error
by skipping the rustup step and using the preinstalled rust compiler.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
