### PR TITLE
Fix mutability of self on successor/predecessor indices methods

### DIFF
--- a/releasenotes/notes/fixed-mutability-0ab3030db0d77239.yaml
+++ b/releasenotes/notes/fixed-mutability-0ab3030db0d77239.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue where calling :meth:`retworkx.PyDiGraph.successor_indices`
+    or :meth:`retworkx.PyDiGraph.predecessor_indices` would raise a
+    ``RuntimeError`` exception if they were called in a context where retworkx
+    is already working with a reference to a :class:`~retworkx.PyDiGraph`
+    (primarily if it were called in a callback function for another
+    :class:`~retworkx.PyDiGraph` method).

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1450,7 +1450,7 @@ impl PyDiGraph {
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
     #[text_signature = "(self, node, /)"]
-    pub fn successor_indices(&mut self, node: usize) -> NodeIndices {
+    pub fn successor_indices(&self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
                 .graph
@@ -1473,7 +1473,7 @@ impl PyDiGraph {
     /// :returns: A list of the neighbor node indicies
     /// :rtype: NodeIndices
     #[text_signature = "(self, node, /)"]
-    pub fn predecessor_indices(&mut self, node: usize) -> NodeIndices {
+    pub fn predecessor_indices(&self, node: usize) -> NodeIndices {
         NodeIndices {
             nodes: self
                 .graph


### PR DESCRIPTION
This commit fixes a small overight in the predecessor_indices() and
successor_indices() methods for PyDiGraph. These functions were
previously set so they get a mutable borrow of self, but did not mutate
the contents of the graph object. This caused potential issues if/when
these methods were used in a context where there was another reference
to the graph object (like if they were used in the callback nethod for
a graph method) that would raise an error when the method was called.
This commit corrects this oversight by correctly setting the reference
to self to be immutable.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
