### PR TITLE
Simplify bidirectional logic in directed_path_graph()

### DIFF
--- a/src/generators.rs
+++ b/src/generators.rs
@@ -284,11 +284,9 @@ pub fn directed_path_graph(
     for (node_a, node_b) in pairwise(nodes) {
         match node_a {
             Some(node_a) => {
+                graph.add_edge(node_a, node_b, py.None());
                 if bidirectional {
-                    graph.add_edge(node_a, node_b, py.None());
                     graph.add_edge(node_b, node_a, py.None());
-                } else {
-                    graph.add_edge(node_a, node_b, py.None());
                 }
             }
             None => continue,


### PR DESCRIPTION
The logic around adding edges in directed_path_graph() was a bit more
complex then necessary. Regardless of whether bidirectional is set or
not we're always adding an edge, bidirectional only should control
adding the reverse edge. This commit simplifies the logic to remove the
unecessary else.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
