### PR TITLE
Format code with black

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: pip install -U flake8
+      - run: pip install -U flake8 black==21.5b0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -26,6 +26,8 @@ jobs:
         run: cargo fmt -- --check
       - name: Clippy
         run: cargo clippy -- -D warnings
+      - name: Black Codestyle Format
+        run: black --check --diff retworkx tests
       - name: Python Lint
         run: flake8 setup.py tests
   tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,8 @@ cargo clippy
 
 Python is used primarily for tests and some small pieces of packaging
 and namespace configuration code in the actual library.
-[flake8](https://flake8.pycqa.org/en/latest/) is used to enforce consistent
-style in the python code in the repository. You can run it via tox using:
+[black](https://github.com/psf/black) and [flake8](https://flake8.pycqa.org/en/latest/) are used to enforce consistent
+style in the python code in the repository. You can run them via tox using:
 
 ```bash
 tox -elint
@@ -115,6 +115,9 @@ tox -elint
 
 This will also run `cargo fmt` in check mode to ensure that you ran `cargo fmt`
 and will fail if the Rust code doesn't conform to the style rules.
+
+If black returns a code formatting error you can run `tox -eblack` to automatically
+update the code formatting to conform to the style.
 
 ### Building documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "setuptools-rust"]
+
+[tool.black]
+line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [tool.black]
-line-length = 100
+line-length = 80
 target-version = ['py36', 'py37', 'py38', 'py39']

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -116,9 +116,13 @@ def distance_matrix(graph, parallel_threshold=300):
 
 
 @distance_matrix.register(PyDiGraph)
-def _digraph_distance_matrix(graph, parallel_threshold=300, as_undirected=False):
+def _digraph_distance_matrix(
+    graph, parallel_threshold=300, as_undirected=False
+):
     return digraph_distance_matrix(
-        graph, parallel_threshold=parallel_threshold, as_undirected=as_undirected
+        graph,
+        parallel_threshold=parallel_threshold,
+        as_undirected=as_undirected,
     )
 
 
@@ -161,12 +165,16 @@ def adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
 
 @adjacency_matrix.register(PyDiGraph)
 def _digraph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
-    return digraph_adjacency_matrix(graph, weight_fn=weight_fn, default_weight=default_weight)
+    return digraph_adjacency_matrix(
+        graph, weight_fn=weight_fn, default_weight=default_weight
+    )
 
 
 @adjacency_matrix.register(PyGraph)
 def _graph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
-    return graph_adjacency_matrix(graph, weight_fn=weight_fn, default_weight=default_weight)
+    return graph_adjacency_matrix(
+        graph, weight_fn=weight_fn, default_weight=default_weight
+    )
 
 
 @functools.singledispatch
@@ -194,12 +202,16 @@ def all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
 
 @all_simple_paths.register(PyDiGraph)
 def _digraph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return digraph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
+    return digraph_all_simple_paths(
+        graph, from_, to, min_depth=min_depth, cutoff=cutoff
+    )
 
 
 @all_simple_paths.register(PyGraph)
 def _graph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return graph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
+    return graph_all_simple_paths(
+        graph, from_, to, min_depth=min_depth, cutoff=cutoff
+    )
 
 
 @functools.singledispatch
@@ -264,7 +276,9 @@ def _digraph_floyd_warshall_numpy(
 
 
 @floyd_warshall_numpy.register(PyGraph)
-def _graph_floyd_warshall_numpy(graph, weight_fn=None, default_weight=1.0, parallel_threshold=300):
+def _graph_floyd_warshall_numpy(
+    graph, weight_fn=None, default_weight=1.0, parallel_threshold=300
+):
     return graph_floyd_warshall_numpy(
         graph,
         weight_fn=weight_fn,
@@ -301,18 +315,31 @@ def astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
 
 
 @astar_shortest_path.register(PyDiGraph)
-def _digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
-    return digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
+def _digraph_astar_shortest_path(
+    graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
+):
+    return digraph_astar_shortest_path(
+        graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
+    )
 
 
 @astar_shortest_path.register(PyGraph)
-def _graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
-    return graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
+def _graph_astar_shortest_path(
+    graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
+):
+    return graph_astar_shortest_path(
+        graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
+    )
 
 
 @functools.singledispatch
 def dijkstra_shortest_paths(
-    graph, source, target=None, weight_fn=None, default_weight=1.0, as_undirected=False
+    graph,
+    source,
+    target=None,
+    weight_fn=None,
+    default_weight=1.0,
+    as_undirected=False,
 ):
     """Find the shortest path from a node
 
@@ -341,7 +368,12 @@ def dijkstra_shortest_paths(
 
 @dijkstra_shortest_paths.register(PyDiGraph)
 def _digraph_dijkstra_shortest_path(
-    graph, source, target=None, weight_fn=None, default_weight=1.0, as_undirected=False
+    graph,
+    source,
+    target=None,
+    weight_fn=None,
+    default_weight=1.0,
+    as_undirected=False,
 ):
     return digraph_dijkstra_shortest_paths(
         graph,
@@ -354,9 +386,15 @@ def _digraph_dijkstra_shortest_path(
 
 
 @dijkstra_shortest_paths.register(PyGraph)
-def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None, default_weight=1.0):
+def _graph_dijkstra_shortest_path(
+    graph, source, target=None, weight_fn=None, default_weight=1.0
+):
     return graph_dijkstra_shortest_paths(
-        graph, source, target=target, weight_fn=weight_fn, default_weight=default_weight
+        graph,
+        source,
+        target=target,
+        weight_fn=weight_fn,
+        default_weight=default_weight,
     )
 
 
@@ -386,13 +424,19 @@ def dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
 
 
 @dijkstra_shortest_path_lengths.register(PyDiGraph)
-def _digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
-    return digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
+def _digraph_dijkstra_shortest_path_lengths(
+    graph, node, edge_cost_fn, goal=None
+):
+    return digraph_dijkstra_shortest_path_lengths(
+        graph, node, edge_cost_fn, goal=goal
+    )
 
 
 @dijkstra_shortest_path_lengths.register(PyGraph)
 def _graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
-    return graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
+    return graph_dijkstra_shortest_path_lengths(
+        graph, node, edge_cost_fn, goal=goal
+    )
 
 
 @functools.singledispatch
@@ -422,7 +466,9 @@ def k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
 
 @k_shortest_path_lengths.register(PyDiGraph)
 def _digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
-    return digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=goal)
+    return digraph_k_shortest_path_lengths(
+        graph, start, k, edge_cost, goal=goal
+    )
 
 
 @k_shortest_path_lengths.register(PyGraph)
@@ -460,7 +506,9 @@ def _graph_dfs_edges(graph, source):
 
 
 @functools.singledispatch
-def is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
+def is_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
     """Determine if 2 graphs are isomorphic
 
     This checks if 2 graphs are isomorphic both structurally and also
@@ -506,13 +554,21 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=
 
 
 @is_isomorphic.register(PyDiGraph)
-def _digraph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
-    return digraph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order)
+def _digraph_is_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
+    return digraph_is_isomorphic(
+        first, second, node_matcher, edge_matcher, id_order
+    )
 
 
 @is_isomorphic.register(PyGraph)
-def _graph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
-    return graph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order)
+def _graph_is_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
+    return graph_is_isomorphic(
+        first, second, node_matcher, edge_matcher, id_order
+    )
 
 
 @functools.singledispatch
@@ -708,6 +764,9 @@ def networkx_converter(graph):
     nodes = list(graph.nodes)
     node_indices = dict(zip(nodes, new_graph.add_nodes_from(nodes)))
     new_graph.add_edges_from(
-        [(node_indices[x[0]], node_indices[x[1]], x[2]) for x in graph.edges(data=True)]
+        [
+            (node_indices[x[0]], node_indices[x[1]], x[2])
+            for x in graph.edges(data=True)
+        ]
     )
     return new_graph

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -11,7 +11,8 @@ import sys
 import functools
 
 from .retworkx import *
-sys.modules['retworkx.generators'] = generators
+
+sys.modules["retworkx.generators"] = generators
 
 
 class PyDAG(PyDiGraph):
@@ -82,6 +83,7 @@ class PyDAG(PyDiGraph):
     the same time, leveraging :meth:`PyDAG.add_child` or
     :meth:`PyDAG.add_parent` will avoid this overhead.
     """
+
     pass
 
 
@@ -114,11 +116,10 @@ def distance_matrix(graph, parallel_threshold=300):
 
 
 @distance_matrix.register(PyDiGraph)
-def _digraph_distance_matrix(graph, parallel_threshold=300,
-                             as_undirected=False):
-    return digraph_distance_matrix(graph,
-                                   parallel_threshold=parallel_threshold,
-                                   as_undirected=as_undirected)
+def _digraph_distance_matrix(graph, parallel_threshold=300, as_undirected=False):
+    return digraph_distance_matrix(
+        graph, parallel_threshold=parallel_threshold, as_undirected=as_undirected
+    )
 
 
 @distance_matrix.register(PyGraph)
@@ -160,14 +161,12 @@ def adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
 
 @adjacency_matrix.register(PyDiGraph)
 def _digraph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
-    return digraph_adjacency_matrix(graph, weight_fn=weight_fn,
-                                    default_weight=default_weight)
+    return digraph_adjacency_matrix(graph, weight_fn=weight_fn, default_weight=default_weight)
 
 
 @adjacency_matrix.register(PyGraph)
 def _graph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0):
-    return graph_adjacency_matrix(graph, weight_fn=weight_fn,
-                                  default_weight=default_weight)
+    return graph_adjacency_matrix(graph, weight_fn=weight_fn, default_weight=default_weight)
 
 
 @functools.singledispatch
@@ -195,19 +194,20 @@ def all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
 
 @all_simple_paths.register(PyDiGraph)
 def _digraph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return digraph_all_simple_paths(graph, from_, to, min_depth=min_depth,
-                                    cutoff=cutoff)
+    return digraph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
 
 
 @all_simple_paths.register(PyGraph)
 def _graph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return graph_all_simple_paths(graph, from_, to, min_depth=min_depth,
-                                  cutoff=cutoff)
+    return graph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
 
 
 @functools.singledispatch
 def floyd_warshall_numpy(
-    graph, weight_fn=None, default_weight=1.0, parallel_threshold=300,
+    graph,
+    weight_fn=None,
+    default_weight=1.0,
+    parallel_threshold=300,
 ):
     """Find all-pairs shortest path lengths using Floyd's algorithm
 
@@ -264,9 +264,7 @@ def _digraph_floyd_warshall_numpy(
 
 
 @floyd_warshall_numpy.register(PyGraph)
-def _graph_floyd_warshall_numpy(
-    graph, weight_fn=None, default_weight=1.0, parallel_threshold=300
-):
+def _graph_floyd_warshall_numpy(graph, weight_fn=None, default_weight=1.0, parallel_threshold=300):
     return graph_floyd_warshall_numpy(
         graph,
         weight_fn=weight_fn,
@@ -303,22 +301,19 @@ def astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
 
 
 @astar_shortest_path.register(PyDiGraph)
-def _digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn,
-                                 estimate_cost_fn):
-    return digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn,
-                                       estimate_cost_fn)
+def _digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+    return digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
 
 
 @astar_shortest_path.register(PyGraph)
-def _graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn,
-                               estimate_cost_fn):
-    return graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn,
-                                     estimate_cost_fn)
+def _graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+    return graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
 
 
 @functools.singledispatch
-def dijkstra_shortest_paths(graph, source, target=None, weight_fn=None,
-                            default_weight=1.0, as_undirected=False):
+def dijkstra_shortest_paths(
+    graph, source, target=None, weight_fn=None, default_weight=1.0, as_undirected=False
+):
     """Find the shortest path from a node
 
     This function will generate the shortest path from a source node using
@@ -345,20 +340,24 @@ def dijkstra_shortest_paths(graph, source, target=None, weight_fn=None,
 
 
 @dijkstra_shortest_paths.register(PyDiGraph)
-def _digraph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None,
-                                    default_weight=1.0, as_undirected=False):
-    return digraph_dijkstra_shortest_paths(graph, source, target=target,
-                                           weight_fn=weight_fn,
-                                           default_weight=default_weight,
-                                           as_undirected=as_undirected)
+def _digraph_dijkstra_shortest_path(
+    graph, source, target=None, weight_fn=None, default_weight=1.0, as_undirected=False
+):
+    return digraph_dijkstra_shortest_paths(
+        graph,
+        source,
+        target=target,
+        weight_fn=weight_fn,
+        default_weight=default_weight,
+        as_undirected=as_undirected,
+    )
 
 
 @dijkstra_shortest_paths.register(PyGraph)
-def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None,
-                                  default_weight=1.0):
-    return graph_dijkstra_shortest_paths(graph, source, target=target,
-                                         weight_fn=weight_fn,
-                                         default_weight=default_weight)
+def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None, default_weight=1.0):
+    return graph_dijkstra_shortest_paths(
+        graph, source, target=target, weight_fn=weight_fn, default_weight=default_weight
+    )
 
 
 @functools.singledispatch
@@ -387,17 +386,13 @@ def dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
 
 
 @dijkstra_shortest_path_lengths.register(PyDiGraph)
-def _digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn,
-                                            goal=None):
-    return digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn,
-                                                  goal=goal)
+def _digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
+    return digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
 
 
 @dijkstra_shortest_path_lengths.register(PyGraph)
-def _graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn,
-                                          goal=None):
-    return graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn,
-                                                goal=goal)
+def _graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
+    return graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
 
 
 @functools.singledispatch
@@ -427,14 +422,12 @@ def k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
 
 @k_shortest_path_lengths.register(PyDiGraph)
 def _digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
-    return digraph_k_shortest_path_lengths(graph, start, k, edge_cost,
-                                           goal=goal)
+    return digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=goal)
 
 
 @k_shortest_path_lengths.register(PyGraph)
 def _graph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
-    return graph_k_shortest_path_lengths(graph, start, k, edge_cost,
-                                         goal=goal)
+    return graph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=goal)
 
 
 @functools.singledispatch
@@ -467,8 +460,7 @@ def _graph_dfs_edges(graph, source):
 
 
 @functools.singledispatch
-def is_isomorphic(first, second, node_matcher=None, edge_matcher=None,
-                  id_order=True):
+def is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
     """Determine if 2 graphs are isomorphic
 
     This checks if 2 graphs are isomorphic both structurally and also
@@ -514,17 +506,13 @@ def is_isomorphic(first, second, node_matcher=None, edge_matcher=None,
 
 
 @is_isomorphic.register(PyDiGraph)
-def _digraph_is_isomorphic(first, second, node_matcher=None,
-                           edge_matcher=None, id_order=True):
-    return digraph_is_isomorphic(first, second, node_matcher,
-                                 edge_matcher, id_order)
+def _digraph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
+    return digraph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order)
 
 
 @is_isomorphic.register(PyGraph)
-def _graph_is_isomorphic(first, second, node_matcher=None,
-                         edge_matcher=None, id_order=True):
-    return graph_is_isomorphic(first, second, node_matcher,
-                               edge_matcher, id_order)
+def _graph_is_isomorphic(first, second, node_matcher=None, edge_matcher=None, id_order=True):
+    return graph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order)
 
 
 @functools.singledispatch
@@ -720,7 +708,6 @@ def networkx_converter(graph):
     nodes = list(graph.nodes)
     node_indices = dict(zip(nodes, new_graph.add_nodes_from(nodes)))
     new_graph.add_edges_from(
-        [(node_indices[x[0]],
-          node_indices[x[1]],
-          x[2]) for x in graph.edges(data=True)])
+        [(node_indices[x[0]], node_indices[x[1]], x[2]) for x in graph.edges(data=True)]
+    )
     return new_graph

--- a/tests/digraph/test_adj.py
+++ b/tests/digraph/test_adj.py
@@ -50,7 +50,9 @@ class TestAdj(unittest.TestCase):
         node_b = dag.add_child(node_a, "b", {"a": 1})
         node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.out_edges(node_a)
-        self.assertEqual([(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res)
+        self.assertEqual(
+            [(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res
+        )
 
     def test_neighbor_dir_surrounded_in_out_edges(self):
         dag = retworkx.PyDAG()

--- a/tests/digraph/test_adj.py
+++ b/tests/digraph/test_adj.py
@@ -18,80 +18,79 @@ import retworkx
 class TestAdj(unittest.TestCase):
     def test_single_neighbor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.adj(node_a)
-        self.assertEqual({node_b: {'a': 1}, node_c: {'a': 2}}, res)
+        self.assertEqual({node_b: {"a": 1}, node_c: {"a": 2}}, res)
 
     def test_single_neighbor_dir(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.adj_direction(node_a, False)
-        self.assertEqual({node_b: {'a': 1}, node_c: {'a': 2}}, res)
+        self.assertEqual({node_b: {"a": 1}, node_c: {"a": 2}}, res)
         res = dag.adj_direction(node_a, True)
         self.assertEqual({}, res)
 
     def test_neighbor_dir_surrounded(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         res = dag.adj_direction(node_b, False)
-        self.assertEqual({node_c: {'a': 2}}, res)
+        self.assertEqual({node_c: {"a": 2}}, res)
         res = dag.adj_direction(node_b, True)
-        self.assertEqual({node_a: {'a': 1}}, res)
+        self.assertEqual({node_a: {"a": 1}}, res)
 
     def test_single_neighbor_dir_out_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.out_edges(node_a)
-        self.assertEqual([(node_a, node_c, {'a': 2}),
-                          (node_a, node_b, {'a': 1})], res)
+        self.assertEqual([(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res)
 
     def test_neighbor_dir_surrounded_in_out_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         res = dag.out_edges(node_b)
-        self.assertEqual([(node_b, node_c, {'a': 2})], res)
+        self.assertEqual([(node_b, node_c, {"a": 2})], res)
         res = dag.in_edges(node_b)
-        self.assertEqual([(node_a, node_b, {'a': 1})], res)
+        self.assertEqual([(node_a, node_b, {"a": 1})], res)
 
     def test_no_neighbor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         self.assertEqual({}, dag.adj(node_a))
 
     def test_in_direction(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_parent(node_a, i, None)
         self.assertEqual(5, dag.in_degree(node_a))
 
     def test_in_direction_none(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_child(node_a, i, None)
         self.assertEqual(0, dag.in_degree(node_a))
 
     def test_out_direction(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_parent(node_a, i, None)
         self.assertEqual(0, dag.out_degree(node_a))
 
     def test_out_direction_none(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_child(node_a, i, None)
         self.assertEqual(5, dag.out_degree(node_a))

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -26,7 +26,11 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -39,7 +43,11 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -52,7 +60,11 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 4.0, 4.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 4.0, 4.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -96,7 +108,8 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
 
     def test_from_adjacency_matrix(self):
         input_array = np.array(
-            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
+            dtype=np.float64,
         )
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_array)
         out_array = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
@@ -110,12 +123,16 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
+        )
         with self.assertRaises(TypeError):
             retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
+        )
         graph = retworkx.PyDiGraph.from_adjacency_matrix(
             input_matrix.astype(np.float64, copy=False)
         )

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -19,61 +19,59 @@ import numpy as np
 class TestDAGAdjacencyMatrix(unittest.TestCase):
     def test_single_neighbor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
-        dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
+        dag.add_child(node_a, "c", {"a": 2})
         res = retworkx.digraph_adjacency_matrix(dag, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_no_weight_fn(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
-        dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
+        dag.add_child(node_a, "c", {"a": 2})
         res = retworkx.digraph_adjacency_matrix(dag)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_default_weight(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
-        dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
+        dag.add_child(node_a, "c", {"a": 2})
         res = retworkx.digraph_adjacency_matrix(dag, default_weight=4)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 4.0, 4.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 4.0, 4.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_float_cast_weight_func(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', 7.0)
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", 7.0)
         res = retworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0.0, 7.0], [0.0, 0.0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0.0, 7.0], [0.0, 0.0]]), res))
 
     def test_multigraph_sum_cast_weight_func(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 7.0)
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", 7.0)
         dag.add_edge(node_a, node_b, 0.5)
         res = retworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0.0, 7.5], [0.0, 0.0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0.0, 7.5], [0.0, 0.0]]), res))
 
     def test_graph_to_digraph_adjacency_matrix(self):
         graph = retworkx.PyGraph()
@@ -88,51 +86,44 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
 
     def test_digraph_with_index_holes(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 1)
-        dag.add_child(node_a, 'c', 1)
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", 1)
+        dag.add_child(node_a, "c", 1)
         dag.remove_node(node_b)
         res = retworkx.digraph_adjacency_matrix(dag, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0, 1], [0, 0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0, 1], [0, 0]]), res))
 
     def test_from_adjacency_matrix(self):
         input_array = np.array(
-            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
-            dtype=np.float64)
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64
+        )
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_array)
         out_array = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(input_array, out_array))
 
     def test_random_graph_full_path(self):
-        graph = retworkx.directed_gnp_random_graph(100, .95, seed=42)
+        graph = retworkx.directed_gnp_random_graph(100, 0.95, seed=42)
         adjacency_matrix = retworkx.digraph_adjacency_matrix(graph)
         new_graph = retworkx.PyDiGraph.from_adjacency_matrix(adjacency_matrix)
         new_adjacency_matrix = retworkx.digraph_adjacency_matrix(new_graph)
-        self.assertTrue(np.array_equal(adjacency_matrix,
-                                       new_adjacency_matrix))
+        self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=np.int64)
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=np.int64)
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         graph = retworkx.PyDiGraph.from_adjacency_matrix(
-            input_matrix.astype(np.float64, copy=False))
+            input_matrix.astype(np.float64, copy=False)
+        )
         adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 
     def test_random_graph_float_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=float)
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=float)
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))

--- a/tests/digraph/test_all_simple_paths.py
+++ b/tests/digraph/test_all_simple_paths.py
@@ -82,8 +82,15 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
-        expected = [[0, 3, 2, 4, 5], [0, 2, 3, 4, 5], [0, 1, 3, 4, 5], [0, 1, 2, 4, 5]]
+        paths = retworkx.digraph_all_simple_paths(
+            dag, 0, 5, min_depth=5, cutoff=5
+        )
+        expected = [
+            [0, 3, 2, 4, 5],
+            [0, 2, 3, 4, 5],
+            [0, 1, 3, 4, 5],
+            [0, 1, 2, 4, 5],
+        ]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -105,4 +112,6 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(TypeError, retworkx.digraph_all_simple_paths, (dag, 0, 1))
+        self.assertRaises(
+            TypeError, retworkx.digraph_all_simple_paths, (dag, 0, 1)
+        )

--- a/tests/digraph/test_all_simple_paths.py
+++ b/tests/digraph/test_all_simple_paths.py
@@ -31,7 +31,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
             (4, 2),
             (4, 5),
             (5, 2),
-            (5, 3)]
+            (5, 3),
+        ]
 
     def test_all_simple_paths(self):
         dag = retworkx.PyDAG()
@@ -47,7 +48,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
             [0, 2, 3, 4, 5],
             [0, 2, 4, 5],
             [0, 3, 2, 4, 5],
-            [0, 3, 4, 5]]
+            [0, 3, 4, 5],
+        ]
         for i in expected:
             self.assertIn(i, paths)
 
@@ -70,9 +72,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
         paths = retworkx.digraph_all_simple_paths(dag, 0, 5, cutoff=4)
-        expected = [
-            [0, 2, 4, 5],
-            [0, 3, 4, 5]]
+        expected = [[0, 2, 4, 5], [0, 3, 4, 5]]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -82,14 +82,8 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=5,
-                                                  cutoff=5)
-        expected = [
-            [0, 3, 2, 4, 5],
-            [0, 2, 3, 4, 5],
-            [0, 1, 3, 4, 5],
-            [0, 1, 2, 4, 5]
-        ]
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
+        expected = [[0, 3, 2, 4, 5], [0, 2, 3, 4, 5], [0, 1, 3, 4, 5], [0, 1, 2, 4, 5]]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -111,5 +105,4 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(TypeError, retworkx.digraph_all_simple_paths,
-                          (dag, 0, 1))
+        self.assertRaises(TypeError, retworkx.digraph_all_simple_paths, (dag, 0, 1))

--- a/tests/digraph/test_ancestors_descendants.py
+++ b/tests/digraph/test_ancestors_descendants.py
@@ -18,24 +18,24 @@ import retworkx
 class TestAncestors(unittest.TestCase):
     def test_ancestors(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         res = retworkx.ancestors(dag, node_c)
         self.assertEqual({node_a, node_b}, res)
 
     def test_no_ancestors(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
         res = retworkx.ancestors(dag, node_a)
         self.assertEqual(set(), res)
 
     def test_ancestors_no_descendants(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        dag.add_child(node_b, 'c', {'b': 1})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        dag.add_child(node_b, "c", {"b": 1})
         res = retworkx.ancestors(dag, node_b)
         self.assertEqual({node_a}, res)
 
@@ -43,22 +43,22 @@ class TestAncestors(unittest.TestCase):
 class TestDescendants(unittest.TestCase):
     def test_descendants(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         res = retworkx.descendants(dag, node_a)
         self.assertEqual({node_b, node_c}, res)
 
     def test_no_descendants(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         res = retworkx.descendants(dag, node_a)
         self.assertEqual(set(), res)
 
     def test_descendants_no_ancestors(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'b': 1})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"b": 1})
         res = retworkx.descendants(dag, node_b)
         self.assertEqual({node_c}, res)

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -74,7 +74,11 @@ class TestAstarDigraph(unittest.TestCase):
 
         for index, end in enumerate([a, b, c, d, e, f]):
             path = retworkx.digraph_astar_shortest_path(
-                g, a, lambda finish: finish_func(end, finish), lambda x: float(x), heuristic_func
+                g,
+                a,
+                lambda finish: finish_func(end, finish),
+                lambda x: float(x),
+                heuristic_func,
             )
             self.assertEqual(expected[index], path)
 
@@ -91,4 +95,6 @@ class TestAstarDigraph(unittest.TestCase):
         g = retworkx.PyGraph()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.digraph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)
+            retworkx.digraph_astar_shortest_path(
+                g, 0, lambda x: x, lambda y: 1, lambda z: 0
+            )

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestAstarDigraph(unittest.TestCase):
-
     def test_astar_null_heuristic(self):
         g = retworkx.PyDAG()
         a = g.add_node("A")
@@ -34,29 +33,28 @@ class TestAstarDigraph(unittest.TestCase):
         g.add_edge(b, f, 15)
         g.add_edge(c, f, 11)
         g.add_edge(e, f, 6)
-        path = retworkx.digraph_astar_shortest_path(g, a,
-                                                    lambda goal: goal == "E",
-                                                    lambda x: float(x),
-                                                    lambda y: 0)
+        path = retworkx.digraph_astar_shortest_path(
+            g, a, lambda goal: goal == "E", lambda x: float(x), lambda y: 0
+        )
         expected = [a, d, e]
         self.assertEqual(expected, path)
 
     def test_astar_manhattan_heuristic(self):
         g = retworkx.PyDAG()
-        a = g.add_node((0., 0.))
-        b = g.add_node((2., 0.))
-        c = g.add_node((1., 1.))
-        d = g.add_node((0., 2.))
-        e = g.add_node((3., 3.))
-        f = g.add_node((4., 2.))
-        no_path = g.add_node((5., 5.))  # no path to node
-        g.add_edge(a, b, 2.)
-        g.add_edge(a, d, 4.)
-        g.add_edge(b, c, 1.)
-        g.add_edge(b, f, 7.)
-        g.add_edge(c, e, 5.)
-        g.add_edge(e, f, 1.)
-        g.add_edge(d, e, 1.)
+        a = g.add_node((0.0, 0.0))
+        b = g.add_node((2.0, 0.0))
+        c = g.add_node((1.0, 1.0))
+        d = g.add_node((0.0, 2.0))
+        e = g.add_node((3.0, 3.0))
+        f = g.add_node((4.0, 2.0))
+        no_path = g.add_node((5.0, 5.0))  # no path to node
+        g.add_edge(a, b, 2.0)
+        g.add_edge(a, d, 4.0)
+        g.add_edge(b, c, 1.0)
+        g.add_edge(b, f, 7.0)
+        g.add_edge(c, e, 5.0)
+        g.add_edge(e, f, 1.0)
+        g.add_edge(d, e, 1.0)
 
         def heuristic_func(f):
             x1, x2 = f
@@ -76,18 +74,21 @@ class TestAstarDigraph(unittest.TestCase):
 
         for index, end in enumerate([a, b, c, d, e, f]):
             path = retworkx.digraph_astar_shortest_path(
-                g, a, lambda finish: finish_func(end, finish),
-                lambda x: float(x), heuristic_func)
+                g, a, lambda finish: finish_func(end, finish), lambda x: float(x), heuristic_func
+            )
             self.assertEqual(expected[index], path)
 
         with self.assertRaises(retworkx.NoPathFound):
             retworkx.digraph_astar_shortest_path(
-                g, a, lambda finish: finish_func(no_path, finish),
-                lambda x: float(x), heuristic_func)
+                g,
+                a,
+                lambda finish: finish_func(no_path, finish),
+                lambda x: float(x),
+                heuristic_func,
+            )
 
     def test_astar_digraph_with_graph_input(self):
         g = retworkx.PyGraph()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.digraph_astar_shortest_path(g, 0, lambda x: x,
-                                                 lambda y: 1, lambda z: 0)
+            retworkx.digraph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)

--- a/tests/digraph/test_collect_runs.py
+++ b/tests/digraph/test_collect_runs.py
@@ -49,27 +49,27 @@ class TestCollectRuns(unittest.TestCase):
         dag.add_edge(measure_qr_1_out, cr_1_out, "cr[1]")
 
         def filter_function(node):
-            return node in ['h', 'x']
+            return node in ["h", "x"]
 
         res = retworkx.collect_runs(dag, filter_function)
-        expected = [['h', 'x'], ['x']]
+        expected = [["h", "x"], ["x"]]
         self.assertEqual(expected, res)
 
     def test_multiple_successor_edges(self):
         dag = retworkx.PyDiGraph()
-        q0, q1 = dag.add_nodes_from(['q0', 'q1'])
-        cx_1 = dag.add_child(q0, 'cx', 'q0')
-        dag.add_edge(q1, cx_1, 'q1')
-        cx_2 = dag.add_child(cx_1, 'cx', 'q0')
-        dag.add_edge(q1, cx_2, 'q1')
-        cx_3 = dag.add_child(cx_2, 'cx', 'q0')
-        dag.add_edge(q1, cx_3, 'q1')
+        q0, q1 = dag.add_nodes_from(["q0", "q1"])
+        cx_1 = dag.add_child(q0, "cx", "q0")
+        dag.add_edge(q1, cx_1, "q1")
+        cx_2 = dag.add_child(cx_1, "cx", "q0")
+        dag.add_edge(q1, cx_2, "q1")
+        cx_3 = dag.add_child(cx_2, "cx", "q0")
+        dag.add_edge(q1, cx_3, "q1")
 
         def filter_function(node):
-            return node == 'cx'
+            return node == "cx"
 
         res = retworkx.collect_runs(dag, filter_function)
-        self.assertEqual([['cx', 'cx', 'cx']], res)
+        self.assertEqual([["cx", "cx", "cx"]], res)
 
     def test_cycle(self):
         dag = retworkx.PyDiGraph()
@@ -79,8 +79,8 @@ class TestCollectRuns(unittest.TestCase):
 
     def test_filter_function_inner_exception(self):
         dag = retworkx.PyDiGraph()
-        dag.add_node('a')
-        dag.add_child(0, 'b', None)
+        dag.add_node("a")
+        dag.add_child(0, "b", None)
 
         def filter_function(node):
             raise IndexError("Things fail from time to time")
@@ -94,45 +94,45 @@ class TestCollectRuns(unittest.TestCase):
 
     def test_h_h_cx(self):
         dag = retworkx.PyDiGraph()
-        q0, q1 = dag.add_nodes_from(['q0', 'q1'])
-        h_1 = dag.add_child(q0, 'h', 'q0')
-        h_2 = dag.add_child(q1, 'h', 'q1')
-        cx_2 = dag.add_child(h_1, 'cx', 'q0')
-        dag.add_edge(h_2, cx_2, 'q1')
+        q0, q1 = dag.add_nodes_from(["q0", "q1"])
+        h_1 = dag.add_child(q0, "h", "q0")
+        h_2 = dag.add_child(q1, "h", "q1")
+        cx_2 = dag.add_child(h_1, "cx", "q0")
+        dag.add_edge(h_2, cx_2, "q1")
 
         def filter_function(node):
-            return node in ['cx', 'h']
+            return node in ["cx", "h"]
 
         res = retworkx.collect_runs(dag, filter_function)
-        self.assertEqual([['h', 'cx'], ['h']], res)
+        self.assertEqual([["h", "cx"], ["h"]], res)
 
     def test_cx_h_h_cx(self):
         dag = retworkx.PyDiGraph()
-        q0, q1 = dag.add_nodes_from(['q0', 'q1'])
-        cx_1 = dag.add_child(q0, 'cx', 'q0')
-        dag.add_edge(q1, cx_1, 'q1')
-        h_1 = dag.add_child(cx_1, 'h', 'q0')
-        h_2 = dag.add_child(cx_1, 'h', 'q1')
-        cx_2 = dag.add_child(h_1, 'cx', 'q0')
-        dag.add_edge(h_2, cx_2, 'q1')
+        q0, q1 = dag.add_nodes_from(["q0", "q1"])
+        cx_1 = dag.add_child(q0, "cx", "q0")
+        dag.add_edge(q1, cx_1, "q1")
+        h_1 = dag.add_child(cx_1, "h", "q0")
+        h_2 = dag.add_child(cx_1, "h", "q1")
+        cx_2 = dag.add_child(h_1, "cx", "q0")
+        dag.add_edge(h_2, cx_2, "q1")
 
         def filter_function(node):
-            return node in ['cx', 'h']
+            return node in ["cx", "h"]
 
         res = retworkx.collect_runs(dag, filter_function)
-        self.assertEqual([['cx'], ['h', 'cx'], ['h']], res)
+        self.assertEqual([["cx"], ["h", "cx"], ["h"]], res)
 
     def test_cx_h_cx(self):
         dag = retworkx.PyDiGraph()
-        q0, q1 = dag.add_nodes_from(['q0', 'q1'])
-        cx_1 = dag.add_child(q0, 'cx', 'q0')
-        dag.add_edge(q1, cx_1, 'q1')
-        h_1 = dag.add_child(cx_1, 'h', 'q0')
-        cx_2 = dag.add_child(h_1, 'cx', 'q0')
-        dag.add_edge(cx_1, cx_2, 'q1')
+        q0, q1 = dag.add_nodes_from(["q0", "q1"])
+        cx_1 = dag.add_child(q0, "cx", "q0")
+        dag.add_edge(q1, cx_1, "q1")
+        h_1 = dag.add_child(cx_1, "h", "q0")
+        cx_2 = dag.add_child(h_1, "cx", "q0")
+        dag.add_edge(cx_1, cx_2, "q1")
 
         def filter_function(node):
-            return node in ['cx', 'h']
+            return node in ["cx", "h"]
 
         res = retworkx.collect_runs(dag, filter_function)
-        self.assertEqual([['cx'], ['h', 'cx']], res)
+        self.assertEqual([["cx"], ["h", "cx"]], res)

--- a/tests/digraph/test_complement.py
+++ b/tests/digraph/test_complement.py
@@ -25,7 +25,9 @@ class TestComplement(unittest.TestCase):
     def test_clique_directed(self):
         N = 5
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
+        graph.extend_from_edge_list(
+            [(i, j) for i in range(N) for j in range(N) if i != j]
+        )
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -37,7 +39,9 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyDiGraph()
-        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
+        expected_graph.extend_from_edge_list(
+            [(i, j) for i in range(N) for j in range(N) if i != j]
+        )
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -51,12 +55,22 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 == 0]
+            [
+                (i, j)
+                for i in range(N)
+                for j in range(N)
+                if i != j and (i + j) % 3 == 0
+            ]
         )
 
         expected_graph = retworkx.PyDiGraph()
         expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 != 0]
+            [
+                (i, j)
+                for i in range(N)
+                for j in range(N)
+                if i != j and (i + j) % 3 != 0
+            ]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/digraph/test_complement.py
+++ b/tests/digraph/test_complement.py
@@ -25,9 +25,7 @@ class TestComplement(unittest.TestCase):
     def test_clique_directed(self):
         N = 5
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j]
-        )
+        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -39,9 +37,7 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyDiGraph()
-        expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j]
-        )
+        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -55,22 +51,12 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i != j and (i + j) % 3 == 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 == 0]
         )
 
         expected_graph = retworkx.PyDiGraph()
         expected_graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i != j and (i + j) % 3 != 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 != 0]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/digraph/test_compose.py
+++ b/tests/digraph/test_compose.py
@@ -19,13 +19,13 @@ class TestCompose(unittest.TestCase):
     def test_simple_dag_composition(self):
         dag = retworkx.PyDAG()
         dag.check_cycle = True
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         dag_other = retworkx.PyDAG()
-        node_d = dag_other.add_node('d')
-        dag_other.add_child(node_d, 'e', {'a': 3})
-        res = dag.compose(dag_other, {node_c: (node_d, {'b': 1})})
+        node_d = dag_other.add_node("d")
+        dag_other.add_child(node_d, "e", {"a": 3})
+        res = dag.compose(dag_other, {node_c: (node_d, {"b": 1})})
         self.assertEqual({0: 3, 1: 4}, res)
         self.assertEqual([0, 1, 2, 3, 4], retworkx.topological_sort(dag))
 
@@ -37,53 +37,56 @@ class TestCompose(unittest.TestCase):
 
     def test_edge_map_and_node_map_funcs_digraph_compose(self):
         digraph = retworkx.PyDiGraph()
-        original_input_nodes = digraph.add_nodes_from(['qr[0]', 'qr[1]'])
-        original_op_nodes = digraph.add_nodes_from(['h'])
-        output_nodes = digraph.add_nodes_from(['qr[0]', 'qr[1]'])
-        digraph.add_edge(original_input_nodes[0], original_op_nodes[0],
-                         'qr[0]')
-        digraph.add_edge(original_op_nodes[0], output_nodes[0], 'qr[0]')
+        original_input_nodes = digraph.add_nodes_from(["qr[0]", "qr[1]"])
+        original_op_nodes = digraph.add_nodes_from(["h"])
+        output_nodes = digraph.add_nodes_from(["qr[0]", "qr[1]"])
+        digraph.add_edge(original_input_nodes[0], original_op_nodes[0], "qr[0]")
+        digraph.add_edge(original_op_nodes[0], output_nodes[0], "qr[0]")
         # Setup other graph
         other_digraph = retworkx.PyDiGraph()
-        input_nodes = other_digraph.add_nodes_from(['qr[2]', 'qr[3]'])
-        op_nodes = other_digraph.add_nodes_from(['cx'])
-        other_output_nodes = other_digraph.add_nodes_from(['qr[2]', 'qr[3]'])
-        other_digraph.add_edges_from([(input_nodes[0], op_nodes[0], 'qr[2]'),
-                                      (input_nodes[1], op_nodes[0], 'qr[3]')])
-        other_digraph.add_edges_from([
-            (op_nodes[0], other_output_nodes[0], 'qr[2]'),
-            (op_nodes[0], other_output_nodes[1], 'qr[3]')])
+        input_nodes = other_digraph.add_nodes_from(["qr[2]", "qr[3]"])
+        op_nodes = other_digraph.add_nodes_from(["cx"])
+        other_output_nodes = other_digraph.add_nodes_from(["qr[2]", "qr[3]"])
+        other_digraph.add_edges_from(
+            [(input_nodes[0], op_nodes[0], "qr[2]"), (input_nodes[1], op_nodes[0], "qr[3]")]
+        )
+        other_digraph.add_edges_from(
+            [
+                (op_nodes[0], other_output_nodes[0], "qr[2]"),
+                (op_nodes[0], other_output_nodes[1], "qr[3]"),
+            ]
+        )
 
         def map_fn(weight):
-            if weight == 'qr[2]':
-                return 'qr[0]'
-            elif weight == 'qr[3]':
-                return 'qr[1]'
+            if weight == "qr[2]":
+                return "qr[0]"
+            elif weight == "qr[3]":
+                return "qr[1]"
             else:
                 return weight
 
         digraph.remove_nodes_from(output_nodes)
         other_digraph.remove_nodes_from(input_nodes)
-        node_map = {original_op_nodes[0]: (op_nodes[0], 'qr[0]'),
-                    original_input_nodes[1]: (op_nodes[0], 'qr[1]')}
-        res = digraph.compose(other_digraph, node_map,
-                              node_map_func=map_fn,
-                              edge_map_func=map_fn)
+        node_map = {
+            original_op_nodes[0]: (op_nodes[0], "qr[0]"),
+            original_input_nodes[1]: (op_nodes[0], "qr[1]"),
+        }
+        res = digraph.compose(other_digraph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
-        self.assertEqual(digraph[res[other_output_nodes[0]]], 'qr[0]')
-        self.assertEqual(digraph[res[other_output_nodes[1]]], 'qr[1]')
+        self.assertEqual(digraph[res[other_output_nodes[0]]], "qr[0]")
+        self.assertEqual(digraph[res[other_output_nodes[1]]], "qr[1]")
         # qr[0] -> h
         self.assertTrue(digraph.has_edge(0, 2))
-        self.assertTrue(digraph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(digraph.get_all_edge_data(0, 2), ["qr[0]"])
         # qr[1] -> cx
         self.assertTrue(digraph.has_edge(1, 4))
-        self.assertTrue(digraph.get_all_edge_data(1, 4), ['qr[1]'])
+        self.assertTrue(digraph.get_all_edge_data(1, 4), ["qr[1]"])
         # h -> cx
         self.assertTrue(digraph.has_edge(2, 4))
-        self.assertTrue(digraph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(digraph.get_all_edge_data(0, 2), ["qr[0]"])
         # cx -> qr[2]
         self.assertTrue(digraph.has_edge(4, 3))
-        self.assertTrue(digraph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(digraph.get_all_edge_data(0, 2), ["qr[0]"])
         # cx -> qr[3]
         self.assertTrue(digraph.has_edge(4, 5))
-        self.assertTrue(digraph.get_all_edge_data(0, 2), ['qr[1]'])
+        self.assertTrue(digraph.get_all_edge_data(0, 2), ["qr[1]"])

--- a/tests/digraph/test_compose.py
+++ b/tests/digraph/test_compose.py
@@ -48,7 +48,10 @@ class TestCompose(unittest.TestCase):
         op_nodes = other_digraph.add_nodes_from(["cx"])
         other_output_nodes = other_digraph.add_nodes_from(["qr[2]", "qr[3]"])
         other_digraph.add_edges_from(
-            [(input_nodes[0], op_nodes[0], "qr[2]"), (input_nodes[1], op_nodes[0], "qr[3]")]
+            [
+                (input_nodes[0], op_nodes[0], "qr[2]"),
+                (input_nodes[1], op_nodes[0], "qr[3]"),
+            ]
         )
         other_digraph.add_edges_from(
             [
@@ -71,7 +74,9 @@ class TestCompose(unittest.TestCase):
             original_op_nodes[0]: (op_nodes[0], "qr[0]"),
             original_input_nodes[1]: (op_nodes[0], "qr[1]"),
         }
-        res = digraph.compose(other_digraph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
+        res = digraph.compose(
+            other_digraph, node_map, node_map_func=map_fn, edge_map_func=map_fn
+        )
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
         self.assertEqual(digraph[res[other_output_nodes[0]]], "qr[0]")
         self.assertEqual(digraph[res[other_output_nodes[1]]], "qr[1]")

--- a/tests/digraph/test_core_number.py
+++ b/tests/digraph/test_core_number.py
@@ -82,7 +82,9 @@ class TestCoreNumber(unittest.TestCase):
     def test_directed_all_3(self):
         digraph = retworkx.PyDiGraph()
         digraph.add_nodes_from(list(range(4)))
-        digraph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
+        digraph.add_edges_from_no_data(
+            [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+        )
         res = retworkx.core_number(digraph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/digraph/test_core_number.py
+++ b/tests/digraph/test_core_number.py
@@ -53,7 +53,7 @@ class TestCoreNumber(unittest.TestCase):
             (8, 19),
             (11, 16),
             (11, 17),
-            (12, 18)
+            (12, 18),
         ]
 
         example_core = {}
@@ -82,9 +82,7 @@ class TestCoreNumber(unittest.TestCase):
     def test_directed_all_3(self):
         digraph = retworkx.PyDiGraph()
         digraph.add_nodes_from(list(range(4)))
-        digraph.add_edges_from_no_data([
-            (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)
-        ])
+        digraph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
         res = retworkx.core_number(digraph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/digraph/test_deepcopy.py
+++ b/tests/digraph/test_deepcopy.py
@@ -23,7 +23,9 @@ class TestDeepcopy(unittest.TestCase):
         dag_a.add_child(node_a, "a_2", "a_1")
         dag_a.add_child(node_a, "a_3", "a_2")
         dag_b = copy.deepcopy(dag_a)
-        self.assertTrue(retworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y))
+        self.assertTrue(
+            retworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y)
+        )
 
     def test_deepcopy_with_holes(self):
         dag_a = retworkx.PyDAG()

--- a/tests/digraph/test_deepcopy.py
+++ b/tests/digraph/test_deepcopy.py
@@ -17,24 +17,21 @@ import retworkx
 
 
 class TestDeepcopy(unittest.TestCase):
-
     def test_isomorphic_compare_nodes_identical(self):
         dag_a = retworkx.PyDAG()
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
         dag_b = copy.deepcopy(dag_a)
-        self.assertTrue(
-            retworkx.is_isomorphic_node_match(
-                dag_a, dag_b, lambda x, y: x == y))
+        self.assertTrue(retworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y))
 
     def test_deepcopy_with_holes(self):
         dag_a = retworkx.PyDAG()
-        node_a = dag_a.add_node('a_1')
-        node_b = dag_a.add_node('a_2')
-        dag_a.add_edge(node_a, node_b, 'edge_1')
-        node_c = dag_a.add_node('a_3')
-        dag_a.add_edge(node_b, node_c, 'edge_2')
+        node_a = dag_a.add_node("a_1")
+        node_b = dag_a.add_node("a_2")
+        dag_a.add_edge(node_a, node_b, "edge_1")
+        node_c = dag_a.add_node("a_3")
+        dag_a.add_edge(node_b, node_c, "edge_2")
         dag_a.remove_node(node_b)
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyDAG)

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -38,7 +38,10 @@ class TestLongestPath(unittest.TestCase):
         node_f = dag.add_child(node_e, "f", {})
         dag.add_child(node_c, "g", {})
         self.assertEqual(4, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([node_a, node_b, node_c, node_e, node_f], retworkx.dag_longest_path(dag))
+        self.assertEqual(
+            [node_a, node_b, node_c, node_e, node_f],
+            retworkx.dag_longest_path(dag),
+        )
 
     def test_less_linear(self):
         dag = retworkx.PyDAG()
@@ -51,7 +54,10 @@ class TestLongestPath(unittest.TestCase):
         dag.add_edge(node_a, node_e, {})
         dag.add_edge(node_c, node_e, {})
         self.assertEqual(4, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([node_a, node_b, node_c, node_d, node_e], retworkx.dag_longest_path(dag))
+        self.assertEqual(
+            [node_a, node_b, node_c, node_d, node_e],
+            retworkx.dag_longest_path(dag),
+        )
 
     def test_degenerate_graph(self):
         dag = retworkx.PyDAG()

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -30,40 +30,36 @@ class TestLongestPath(unittest.TestCase):
         f g
         """
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
-        dag.add_child(node_b, 'd', {})
-        node_e = dag.add_child(node_c, 'e', {})
-        node_f = dag.add_child(node_e, 'f', {})
-        dag.add_child(node_c, 'g', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
+        dag.add_child(node_b, "d", {})
+        node_e = dag.add_child(node_c, "e", {})
+        node_f = dag.add_child(node_e, "f", {})
+        dag.add_child(node_c, "g", {})
         self.assertEqual(4, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([node_a, node_b, node_c, node_e, node_f],
-                         retworkx.dag_longest_path(dag))
+        self.assertEqual([node_a, node_b, node_c, node_e, node_f], retworkx.dag_longest_path(dag))
 
     def test_less_linear(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
-        node_d = dag.add_child(node_c, 'd', {})
-        node_e = dag.add_child(node_d, 'e', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
+        node_d = dag.add_child(node_c, "d", {})
+        node_e = dag.add_child(node_d, "e", {})
         dag.add_edge(node_a, node_c, {})
         dag.add_edge(node_a, node_e, {})
         dag.add_edge(node_c, node_e, {})
         self.assertEqual(4, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([node_a, node_b, node_c, node_d, node_e],
-                         retworkx.dag_longest_path(dag))
+        self.assertEqual([node_a, node_b, node_c, node_d, node_e], retworkx.dag_longest_path(dag))
 
     def test_degenerate_graph(self):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         self.assertEqual(0, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([0],
-                         retworkx.dag_longest_path(dag))
+        self.assertEqual([0], retworkx.dag_longest_path(dag))
 
     def test_empty_graph(self):
         dag = retworkx.PyDAG()
         self.assertEqual(0, retworkx.dag_longest_path_length(dag))
-        self.assertEqual([],
-                         retworkx.dag_longest_path(dag))
+        self.assertEqual([], retworkx.dag_longest_path(dag))

--- a/tests/digraph/test_dfs_edges.py
+++ b/tests/digraph/test_dfs_edges.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestDfsEdges(unittest.TestCase):
-
     def test_digraph_disconnected_dfs_edges(self):
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list([(0, 1), (2, 3)])

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -61,7 +61,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_weight_fn(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, weight_fn=lambda x: x
+        )
         expected = {
             1: [0, 1],
             2: [0, 1, 2],
@@ -72,7 +74,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_target(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, target=self.e)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, target=self.e
+        )
         expected = {
             4: [0, 3, 4],
         }
@@ -88,7 +92,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, as_undirected=True)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, as_undirected=True
+        )
         expected = {
             1: [0, 1],
             2: [0, 2],
@@ -122,7 +128,11 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_path_undirected_with_weight_fn_and_target(self):
         paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, target=self.e, weight_fn=lambda x: x, as_undirected=True
+            self.graph,
+            self.a,
+            target=self.e,
+            weight_fn=lambda x: x,
+            as_undirected=True,
         )
         expected = {
             4: [0, 3, 4],
@@ -130,7 +140,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(
+            self.graph, self.a, lambda x: 1
+        )
         expected = {1: 1.0, 2: 2.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
@@ -138,7 +150,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         g = retworkx.PyDiGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(
+            g, a, lambda x: float(x)
+        )
         expected = {}
         self.assertEqual(expected, path)
 
@@ -156,7 +170,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         b = g.add_child(a, "B", 1.2)
         g.add_node("C")
         g.add_parent(b, "D", 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: x)
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(
+            g, a, lambda x: x
+        )
         expected = {1: 1.2}
         self.assertEqual(expected, path)
 

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -39,7 +39,8 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra(self):
         path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), self.e)
+            self.graph, self.a, lambda x: float(x), self.e
+        )
         expected = {4: 23.0}
         self.assertEqual(expected, path)
 
@@ -60,8 +61,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_weight_fn(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: x)
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)
         expected = {
             1: [0, 1],
             2: [0, 1, 2],
@@ -72,8 +72,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_target(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a,
-                                                         target=self.e)
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, target=self.e)
         expected = {
             4: [0, 3, 4],
         }
@@ -81,15 +80,15 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_path_with_weight_fn_and_target(self):
         paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, target=self.e, weight_fn=lambda x: x)
+            self.graph, self.a, target=self.e, weight_fn=lambda x: x
+        )
         expected = {
             4: [0, 3, 4],
         }
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a,
-                                                         as_undirected=True)
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, as_undirected=True)
         expected = {
             1: [0, 1],
             2: [0, 2],
@@ -100,9 +99,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected_with_weight_fn(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a,
-                                                         weight_fn=lambda x: x,
-                                                         as_undirected=True)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, weight_fn=lambda x: x, as_undirected=True
+        )
         expected = {
             1: [0, 1],
             2: [0, 2],
@@ -113,56 +112,51 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected_with_target(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a,
-                                                         target=self.e,
-                                                         as_undirected=True)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, target=self.e, as_undirected=True
+        )
         expected = {
             4: [0, 3, 4],
         }
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected_with_weight_fn_and_target(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a,
-                                                         target=self.e,
-                                                         weight_fn=lambda x: x,
-                                                         as_undirected=True)
+        paths = retworkx.digraph_dijkstra_shortest_paths(
+            self.graph, self.a, target=self.e, weight_fn=lambda x: x, as_undirected=True
+        )
         expected = {
             4: [0, 3, 4],
         }
         self.assertEqual(expected, paths)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: 1)
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
         expected = {1: 1.0, 2: 2.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_no_path(self):
         g = retworkx.PyDiGraph()
-        a = g.add_node('A')
-        g.add_node('B')
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: float(x))
+        a = g.add_node("A")
+        g.add_node("B")
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
     def test_dijkstra_path_with_no_path(self):
         g = retworkx.PyDiGraph()
-        a = g.add_node('A')
-        g.add_node('B')
-        path = retworkx.digraph_dijkstra_shortest_paths(
-            g, a)
+        a = g.add_node("A")
+        g.add_node("B")
+        path = retworkx.digraph_dijkstra_shortest_paths(g, a)
         expected = {}
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_disconnected_nodes(self):
         g = retworkx.PyDiGraph()
-        a = g.add_node('A')
-        b = g.add_child(a, 'B', 1.2)
-        g.add_node('C')
-        g.add_parent(b, 'D', 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: x)
+        a = g.add_node("A")
+        b = g.add_child(a, "B", 1.2)
+        g.add_node("C")
+        g.add_parent(b, "D", 2.4)
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: x)
         expected = {1: 1.2}
         self.assertEqual(expected, path)
 

--- a/tests/digraph/test_dist_matrix.py
+++ b/tests/digraph/test_dist_matrix.py
@@ -18,64 +18,74 @@ import retworkx
 
 
 class TestDistanceMatrix(unittest.TestCase):
-
     def test_digraph_distance_matrix(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph)
-        expected = numpy.array([[0., 1., 2., 3., 4., 5., 1.],
-                                [0., 0., 1., 2., 3., 4., 5.],
-                                [0., 0., 0., 1., 2., 3., 4.],
-                                [0., 0., 0., 0., 1., 2., 3.],
-                                [0., 0., 0., 0., 0., 1., 2.],
-                                [0., 0., 0., 0., 0., 0., 1.],
-                                [0., 0., 0., 0., 0., 0., 0.]])
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))
 
     def test_digraph_distance_matrix_parallel(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5)
-        expected = numpy.array([[0., 1., 2., 3., 4., 5., 1.],
-                                [0., 0., 1., 2., 3., 4., 5.],
-                                [0., 0., 0., 1., 2., 3., 4.],
-                                [0., 0., 0., 0., 1., 2., 3.],
-                                [0., 0., 0., 0., 0., 1., 2.],
-                                [0., 0., 0., 0., 0., 0., 1.],
-                                [0., 0., 0., 0., 0., 0., 0.]])
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))
 
     def test_digraph_distance_matrix_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph, as_undirected=True)
-        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
-                                [1., 0., 1., 2., 3., 3., 2.],
-                                [2., 1., 0., 1., 2., 3., 3.],
-                                [3., 2., 1., 0., 1., 2., 3.],
-                                [3., 3., 2., 1., 0., 1., 2.],
-                                [2., 3., 3., 2., 1., 0., 1.],
-                                [1., 2., 3., 3., 2., 1., 0.]])
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [3.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [2.0, 3.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))
 
     def test_digraph_distance_matrix_parallel_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5,
-                                                as_undirected=True)
-        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
-                                [1., 0., 1., 2., 3., 3., 2.],
-                                [2., 1., 0., 1., 2., 3., 3.],
-                                [3., 2., 1., 0., 1., 2., 3.],
-                                [3., 3., 2., 1., 0., 1., 2.],
-                                [2., 3., 3., 2., 1., 0., 1.],
-                                [1., 2., 3., 3., 2., 1., 0.]])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5, as_undirected=True)
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [3.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [2.0, 3.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))

--- a/tests/digraph/test_dist_matrix.py
+++ b/tests/digraph/test_dist_matrix.py
@@ -21,7 +21,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.digraph_distance_matrix(graph)
         expected = numpy.array(
             [
@@ -39,7 +41,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_parallel(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5)
         expected = numpy.array(
             [
@@ -57,7 +61,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.digraph_distance_matrix(graph, as_undirected=True)
         expected = numpy.array(
             [
@@ -75,8 +81,12 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_parallel_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5, as_undirected=True)
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
+        dist = retworkx.digraph_distance_matrix(
+            graph, parallel_threshold=5, as_undirected=True
+        )
         expected = numpy.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],

--- a/tests/digraph/test_dot.py
+++ b/tests/digraph/test_dot.py
@@ -25,37 +25,34 @@ class TestDot(unittest.TestCase):
 
     def test_digraph_to_dot_to_file(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({'color': 'black', 'fillcolor': 'green',
-                        'label': "a", 'style': 'filled'})
-        graph.add_node({'color': 'black', 'fillcolor': 'red',
-                        'label': "a", 'style': 'filled'})
-        graph.add_edge(0, 1, dict(label='1', name='1'))
+        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
+        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'digraph {\n0 [color=black, fillcolor=green, label="a", '
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
-            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n')
-        res = graph.to_dot(lambda node: node, lambda edge: edge,
-                           filename=self.path)
+            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n'
+        )
+        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
-        with open(self.path, 'r') as fd:
+        with open(self.path, "r") as fd:
             res = fd.read()
         self.assertEqual(expected, res)
 
     def test_digraph_empty_dicts(self):
-        graph = retworkx.directed_gnp_random_graph(3, .9, seed=42)
+        graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {})
-        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n",
-                         dot_str)
+        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)
 
     def test_digraph_graph_attrs(self):
-        graph = retworkx.directed_gnp_random_graph(3, .9, seed=42)
-        dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {'bgcolor': 'red'})
-        self.assertEqual("digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n"
-                         "0 -> 2 ;\n}\n", dot_str)
+        graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
+        dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
+        self.assertEqual(
+            "digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n" "0 -> 2 ;\n}\n", dot_str
+        )
 
     def test_digraph_no_args(self):
-        graph = retworkx.directed_gnp_random_graph(3, .95, seed=24)
+        graph = retworkx.directed_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n",
-                         dot_str)
+        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)

--- a/tests/digraph/test_dot.py
+++ b/tests/digraph/test_dot.py
@@ -25,15 +25,31 @@ class TestDot(unittest.TestCase):
 
     def test_digraph_to_dot_to_file(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
-        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "green",
+                "label": "a",
+                "style": "filled",
+            }
+        )
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "red",
+                "label": "a",
+                "style": "filled",
+            }
+        )
         graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'digraph {\n0 [color=black, fillcolor=green, label="a", '
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
             'style=filled];\n0 -> 1 [label="1", name=1];\n}\n'
         )
-        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
+        res = graph.to_dot(
+            lambda node: node, lambda edge: edge, filename=self.path
+        )
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
         with open(self.path, "r") as fd:
@@ -43,16 +59,22 @@ class TestDot(unittest.TestCase):
     def test_digraph_empty_dicts(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {})
-        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)
+        self.assertEqual(
+            "digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str
+        )
 
     def test_digraph_graph_attrs(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
         self.assertEqual(
-            "digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n" "0 -> 2 ;\n}\n", dot_str
+            "digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n"
+            "0 -> 2 ;\n}\n",
+            dot_str,
         )
 
     def test_digraph_no_args(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)
+        self.assertEqual(
+            "digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str
+        )

--- a/tests/digraph/test_edgelist.py
+++ b/tests/digraph/test_edgelist.py
@@ -104,7 +104,9 @@ class TestEdgeList(unittest.TestCase):
             fd.write("1|2|1\n")
             fd.write("//2|3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//", deliminator="|")
+            graph = retworkx.PyDiGraph.read_edge_list(
+                fd.name, comment="//", deliminator="|"
+            )
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))

--- a/tests/digraph/test_edgelist.py
+++ b/tests/digraph/test_edgelist.py
@@ -18,21 +18,20 @@ import retworkx
 
 
 class TestEdgeList(unittest.TestCase):
-
     def test_empty_edge_list_digraph(self):
         with tempfile.NamedTemporaryFile() as fd:
             graph = retworkx.PyDiGraph.read_edge_list(fd.name)
         self.assertEqual(graph.nodes(), [])
 
     def test_invalid_path_digraph(self):
-        path = os.path.join(tempfile.gettempdir(), 'fake_file_name.txt')
+        path = os.path.join(tempfile.gettempdir(), "fake_file_name.txt")
         with self.assertRaises(FileNotFoundError):
             retworkx.PyDiGraph.read_edge_list(path)
 
     def test_simple_example_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('1 2\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("1 2\n")
             fd.flush()
             graph = retworkx.PyDiGraph.read_edge_list(fd.name)
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
@@ -43,10 +42,10 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_blank_line_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('\n')
-            fd.write('1 2\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("\n")
+            fd.write("1 2\n")
             fd.flush()
             graph = retworkx.PyDiGraph.read_edge_list(fd.name)
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
@@ -57,12 +56,12 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_comment_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1 // test a comment\n')
-            fd.write('1 2\n')
-            fd.write('//2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1 // test a comment\n")
+            fd.write("1 2\n")
+            fd.write("//2 3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment='//')
+            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
@@ -71,12 +70,12 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_comment_leading_space_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1 // test a comment\n')
-            fd.write('1 2\n')
-            fd.write('  //2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1 // test a comment\n")
+            fd.write("1 2\n")
+            fd.write("  //2 3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment='//')
+            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
@@ -85,32 +84,31 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_weight_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1 0// test a comment\n')
-            fd.write('1 2 1\n')
-            fd.write('//2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1 0// test a comment\n")
+            fd.write("1 2 1\n")
+            fd.write("//2 3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment='//')
+            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
         self.assertFalse(graph.has_edge(1, 0))
         self.assertFalse(graph.has_edge(2, 1))
         self.assertFalse(graph.has_edge(0, 2))
-        self.assertEqual(graph.edges(), ['0', '1'])
+        self.assertEqual(graph.edges(), ["0", "1"])
 
     def test_delim_digraph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0|1|0// test a comment\n')
-            fd.write('1|2|1\n')
-            fd.write('//2|3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0|1|0// test a comment\n")
+            fd.write("1|2|1\n")
+            fd.write("//2|3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment='//',
-                                                      deliminator='|')
+            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//", deliminator="|")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
         self.assertFalse(graph.has_edge(1, 0))
         self.assertFalse(graph.has_edge(2, 1))
         self.assertFalse(graph.has_edge(0, 2))
-        self.assertEqual(graph.edges(), ['0', '1'])
+        self.assertEqual(graph.edges(), ["0", "1"])

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -16,204 +16,198 @@ import retworkx
 
 
 class TestEdges(unittest.TestCase):
-
     def test_get_edge_data(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
         res = dag.get_edge_data(node_a, node_b)
         self.assertEqual("Edgy", res)
 
     def test_get_all_edge_data(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag.add_edge(node_a, node_b, 'b')
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag.add_edge(node_a, node_b, "b")
         res = dag.get_all_edge_data(node_a, node_b)
-        self.assertIn('b', res)
-        self.assertIn('Edgy', res)
+        self.assertIn("b", res)
+        self.assertIn("Edgy", res)
 
     def test_no_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.get_edge_data,
-                          node_a, node_b)
+        node_a = dag.add_node("a")
+        node_b = dag.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b)
 
     def test_update_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 'not edgy')
-        dag.update_edge(node_a, node_b, 'Edgy')
-        self.assertEqual([(0, 1, 'Edgy')], dag.weighted_edge_list())
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "not edgy")
+        dag.update_edge(node_a, node_b, "Edgy")
+        self.assertEqual([(0, 1, "Edgy")], dag.weighted_edge_list())
 
     def test_update_edge_no_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.update_edge,
-                          node_a, node_b, None)
+        node_a = dag.add_node("a")
+        node_b = dag.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.update_edge, node_a, node_b, None)
 
     def test_update_edge_by_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', 'not edgy')
-        dag.update_edge_by_index(0, 'Edgy')
-        self.assertEqual([(0, 1, 'Edgy')], dag.weighted_edge_list())
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "not edgy")
+        dag.update_edge_by_index(0, "Edgy")
+        self.assertEqual([(0, 1, "Edgy")], dag.weighted_edge_list())
 
     def test_update_edge_invalid_index(self):
         dag = retworkx.PyDAG()
-        dag.add_node('a')
-        dag.add_node('b')
+        dag.add_node("a")
+        dag.add_node("b")
         self.assertRaises(IndexError, dag.update_edge_by_index, 0, None)
 
     def test_update_edge_parallel_edges(self):
         graph = retworkx.PyDiGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'not edgy')
-        edge_index = graph.add_edge(node_a, node_b, 'not edgy')
-        graph.update_edge_by_index(edge_index, 'Edgy')
-        self.assertEqual([(0, 1, 'not edgy'), (0, 1, 'Edgy')],
-                         list(graph.weighted_edge_list()))
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "not edgy")
+        edge_index = graph.add_edge(node_a, node_b, "not edgy")
+        graph.update_edge_by_index(edge_index, "Edgy")
+        self.assertEqual([(0, 1, "not edgy"), (0, 1, "Edgy")], list(graph.weighted_edge_list()))
 
     def test_has_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
         self.assertTrue(dag.has_edge(node_a, node_b))
 
     def test_has_edge_no_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_node('b')
+        node_a = dag.add_node("a")
+        node_b = dag.add_node("b")
         self.assertFalse(dag.has_edge(node_a, node_b))
 
     def test_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag.add_child(node_b, 'c', "Super edgy")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag.add_child(node_b, "c", "Super edgy")
         self.assertEqual(["Edgy", "Super edgy"], dag.edges())
 
     def test_edges_empty(self):
         dag = retworkx.PyDAG()
-        dag.add_node('a')
+        dag.add_node("a")
         self.assertEqual([], dag.edges())
 
     def test_add_duplicates(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'a', 'a')
-        dag.add_edge(node_a, node_b, 'b')
-        self.assertEqual(['a', 'b'], dag.edges())
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "a", "a")
+        dag.add_edge(node_a, node_b, "b")
+        self.assertEqual(["a", "b"], dag.edges())
 
     def test_remove_no_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.remove_edge,
-                          node_a, node_b)
+        node_a = dag.add_node("a")
+        node_b = dag.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 'edgy')
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "edgy")
         dag.remove_edge(node_a, node_b)
         self.assertEqual([], dag.edges())
 
     def test_remove_multiple(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', 'edgy')
-        dag.add_edge(node_a, node_b, 'super_edgy')
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "edgy")
+        dag.add_edge(node_a, node_b, "super_edgy")
         dag.remove_edge_from_index(0)
-        self.assertEqual(['super_edgy'], dag.edges())
+        self.assertEqual(["super_edgy"], dag.edges())
 
     def test_remove_edges_from(self):
         graph = retworkx.PyDiGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_c, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_c, "super_edgy")
         graph.remove_edges_from([(node_a, node_b), (node_a, node_c)])
         self.assertEqual([], graph.edges())
 
     def test_remove_edges_from_invalid(self):
         graph = retworkx.PyDiGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_c, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_c, "super_edgy")
         with self.assertRaises(retworkx.NoEdgeBetweenNodes):
             graph.remove_edges_from([(node_b, node_c), (node_a, node_c)])
 
     def test_remove_edge_from_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', 'edgy')
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "edgy")
         dag.remove_edge_from_index(0)
         self.assertEqual([], dag.edges())
 
     def test_remove_edge_no_edge(self):
         dag = retworkx.PyDAG()
-        dag.add_node('a')
+        dag.add_node("a")
         dag.remove_edge_from_index(0)
         self.assertEqual([], dag.edges())
 
     def test_add_cycle(self):
         dag = retworkx.PyDAG()
         dag.check_cycle = True
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        self.assertRaises(retworkx.DAGWouldCycle, dag.add_edge, node_b,
-                          node_a, {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        self.assertRaises(retworkx.DAGWouldCycle, dag.add_edge, node_b, node_a, {})
 
     def test_add_edge_with_cycle_check_enabled(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_c = dag.add_node('c')
-        node_b = dag.add_child(node_a, 'b', {})
+        node_a = dag.add_node("a")
+        node_c = dag.add_node("c")
+        node_b = dag.add_child(node_a, "b", {})
         dag.add_edge(node_c, node_b, {})
         self.assertTrue(dag.has_edge(node_c, node_b))
 
     def test_enable_cycle_checking_after_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
         dag.add_edge(node_b, node_a, {})
         with self.assertRaises(retworkx.DAGHasCycle):
             dag.check_cycle = True
 
     def test_cycle_checking_at_init(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edge(node_b, node_a, {})
 
     def test_find_adjacent_node_by_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'weights': [1, 2]})
-        dag.add_child(node_a, 'c', {'weights': [3, 4]})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"weights": [1, 2]})
+        dag.add_child(node_a, "c", {"weights": [3, 4]})
 
         def compare_edges(edge):
-            return 4 in edge['weights']
+            return 4 in edge["weights"]
 
         res = dag.find_adjacent_node_by_edge(node_a, compare_edges)
-        self.assertEqual('c', res)
+        self.assertEqual("c", res)
 
     def test_find_adjacent_node_by_edge_no_match(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'weights': [1, 2]})
-        dag.add_child(node_a, 'c', {'weights': [3, 4]})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"weights": [1, 2]})
+        dag.add_child(node_a, "c", {"weights": [3, 4]})
 
         def compare_edges(edge):
-            return 5 in edge['weights']
+            return 5 in edge["weights"]
 
         with self.assertRaises(retworkx.NoSuitableNeighbors):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
@@ -222,11 +216,10 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         nodes = list(range(4))
         dag.add_nodes_from(nodes)
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         res = dag.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], dag.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
         self.assertEqual(3, dag.out_degree(0))
         self.assertEqual(0, dag.in_degree(0))
         self.assertEqual(1, dag.out_degree(1))
@@ -240,9 +233,9 @@ class TestEdges(unittest.TestCase):
 
     def test_cycle_checking_at_init_nodes_from(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edges_from([(node_a, node_c, {}), (node_c, node_b, {})])
 
@@ -259,8 +252,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         nodes = list(range(4))
         dag.add_nodes_from(nodes)
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         res = dag.add_edges_from_no_data(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual([None, None, None, None, None], dag.edges())
@@ -277,17 +269,16 @@ class TestEdges(unittest.TestCase):
 
     def test_cycle_checking_at_init_nodes_from_no_data(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
             dag.add_edges_from_no_data([(node_a, node_c), (node_c, node_b)])
 
     def test_edge_list(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         dag.add_edges_from(edge_list)
         self.assertEqual([(x[0], x[1]) for x in edge_list], dag.edge_list())
 
@@ -298,8 +289,7 @@ class TestEdges(unittest.TestCase):
     def test_weighted_edge_list(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         dag.add_edges_from(edge_list)
         self.assertEqual(edge_list, dag.weighted_edge_list())
 
@@ -309,8 +299,7 @@ class TestEdges(unittest.TestCase):
 
     def test_extend_from_edge_list(self):
         dag = retworkx.PyDAG()
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         dag.extend_from_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
         self.assertEqual([None] * 5, dag.edges())
@@ -327,18 +316,16 @@ class TestEdges(unittest.TestCase):
 
     def test_cycle_checking_at_init_extend_from_weighted_edge_list(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
-            dag.extend_from_weighted_edge_list([(node_a, node_c, {}),
-                                               (node_c, node_b, {})])
+            dag.extend_from_weighted_edge_list([(node_a, node_c, {}), (node_c, node_b, {})])
 
     def test_extend_from_edge_list_nodes_exist(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         dag.extend_from_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
         self.assertEqual([None] * 5, dag.edges())
@@ -350,11 +337,10 @@ class TestEdges(unittest.TestCase):
 
     def test_extend_from_weighted_edge_list(self):
         dag = retworkx.PyDAG()
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         dag.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], dag.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
         self.assertEqual(3, dag.out_degree(0))
         self.assertEqual(0, dag.in_degree(0))
         self.assertEqual(1, dag.out_degree(1))
@@ -368,20 +354,19 @@ class TestEdges(unittest.TestCase):
 
     def test_cycle_checking_at_init_nodes_extend_from_edge_list(self):
         dag = retworkx.PyDAG(True)
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
-        node_c = dag.add_child(node_b, 'c', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
+        node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
             dag.extend_from_edge_list([(node_a, node_c), (node_c, node_b)])
 
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         dag.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], dag.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
         self.assertEqual(3, dag.out_degree(0))
         self.assertEqual(0, dag.in_degree(0))
         self.assertEqual(1, dag.out_degree(1))
@@ -390,113 +375,130 @@ class TestEdges(unittest.TestCase):
 
     def test_insert_node_on_in_edges(self):
         graph = retworkx.PyDiGraph()
-        in_node = graph.add_node('qr[0]')
-        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
-        h_gate = graph.add_node('h')
+        in_node = graph.add_node("qr[0]")
+        out_node = graph.add_child(in_node, "qr[0]", "qr[0]")
+        h_gate = graph.add_node("h")
         graph.insert_node_on_in_edges(h_gate, out_node)
         self.assertEqual(
-            [(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')],
-            graph.weighted_edge_list())
+            [(in_node, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")], graph.weighted_edge_list()
+        )
 
     def test_insert_node_on_in_edges_multiple(self):
         graph = retworkx.PyDiGraph()
-        in_node_0 = graph.add_node('qr[0]')
-        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
-        in_node_1 = graph.add_node('qr[1]')
-        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
-        cx_gate = graph.add_node('cx')
-        graph.insert_node_on_in_edges_multiple(cx_gate,
-                                               [out_node_0, out_node_1])
+        in_node_0 = graph.add_node("qr[0]")
+        out_node_0 = graph.add_child(in_node_0, "qr[0]", "qr[0]")
+        in_node_1 = graph.add_node("qr[1]")
+        out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
+        cx_gate = graph.add_node("cx")
+        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
         self.assertEqual(
-            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
-             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
-            set(graph.weighted_edge_list()))
+            {
+                (in_node_0, cx_gate, "qr[0]"),
+                (cx_gate, out_node_0, "qr[0]"),
+                (in_node_1, cx_gate, "qr[1]"),
+                (cx_gate, out_node_1, "qr[1]"),
+            },
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_in_edges_double(self):
         graph = retworkx.PyDiGraph()
-        in_node = graph.add_node('qr[0]')
-        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
-        h_gate = graph.add_node('h')
-        z_gate = graph.add_node('z')
+        in_node = graph.add_node("qr[0]")
+        out_node = graph.add_child(in_node, "qr[0]", "qr[0]")
+        h_gate = graph.add_node("h")
+        z_gate = graph.add_node("z")
         graph.insert_node_on_in_edges(h_gate, out_node)
         graph.insert_node_on_in_edges(z_gate, out_node)
         self.assertEqual(
-            {(in_node, h_gate, 'qr[0]'), (h_gate, z_gate, 'qr[0]'),
-             (z_gate, out_node, 'qr[0]')},
-            set(graph.weighted_edge_list()))
+            {(in_node, h_gate, "qr[0]"), (h_gate, z_gate, "qr[0]"), (z_gate, out_node, "qr[0]")},
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_in_edges_multiple_double(self):
         graph = retworkx.PyDiGraph()
-        in_node_0 = graph.add_node('qr[0]')
-        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
-        in_node_1 = graph.add_node('qr[1]')
-        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
-        cx_gate = graph.add_node('cx')
-        cz_gate = graph.add_node('cz')
-        graph.insert_node_on_in_edges_multiple(cx_gate,
-                                               [out_node_0, out_node_1])
-        graph.insert_node_on_in_edges_multiple(cz_gate,
-                                               [out_node_0, out_node_1])
+        in_node_0 = graph.add_node("qr[0]")
+        out_node_0 = graph.add_child(in_node_0, "qr[0]", "qr[0]")
+        in_node_1 = graph.add_node("qr[1]")
+        out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
+        cx_gate = graph.add_node("cx")
+        cz_gate = graph.add_node("cz")
+        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(cz_gate, [out_node_0, out_node_1])
         self.assertEqual(
-            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, cz_gate, 'qr[0]'),
-             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, cz_gate, 'qr[1]'),
-             (cz_gate, out_node_0, 'qr[0]'), (cz_gate, out_node_1, 'qr[1]')},
-            set(graph.weighted_edge_list()))
+            {
+                (in_node_0, cx_gate, "qr[0]"),
+                (cx_gate, cz_gate, "qr[0]"),
+                (in_node_1, cx_gate, "qr[1]"),
+                (cx_gate, cz_gate, "qr[1]"),
+                (cz_gate, out_node_0, "qr[0]"),
+                (cz_gate, out_node_1, "qr[1]"),
+            },
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_out_edges(self):
         graph = retworkx.PyDiGraph()
-        in_node = graph.add_node('qr[0]')
-        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
-        h_gate = graph.add_node('h')
+        in_node = graph.add_node("qr[0]")
+        out_node = graph.add_child(in_node, "qr[0]", "qr[0]")
+        h_gate = graph.add_node("h")
         graph.insert_node_on_out_edges(h_gate, in_node)
         self.assertEqual(
-            {(in_node, h_gate, 'qr[0]'), (h_gate, out_node, 'qr[0]')},
-            set(graph.weighted_edge_list()))
+            {(in_node, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")},
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_out_edges_multiple(self):
         graph = retworkx.PyDiGraph()
-        in_node_0 = graph.add_node('qr[0]')
-        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
-        in_node_1 = graph.add_node('qr[1]')
-        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
-        cx_gate = graph.add_node('cx')
-        graph.insert_node_on_out_edges_multiple(cx_gate,
-                                                [in_node_0, in_node_1])
+        in_node_0 = graph.add_node("qr[0]")
+        out_node_0 = graph.add_child(in_node_0, "qr[0]", "qr[0]")
+        in_node_1 = graph.add_node("qr[1]")
+        out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
+        cx_gate = graph.add_node("cx")
+        graph.insert_node_on_out_edges_multiple(cx_gate, [in_node_0, in_node_1])
         self.assertEqual(
-            {(in_node_0, cx_gate, 'qr[0]'), (cx_gate, out_node_0, 'qr[0]'),
-             (in_node_1, cx_gate, 'qr[1]'), (cx_gate, out_node_1, 'qr[1]')},
-            set(graph.weighted_edge_list()))
+            {
+                (in_node_0, cx_gate, "qr[0]"),
+                (cx_gate, out_node_0, "qr[0]"),
+                (in_node_1, cx_gate, "qr[1]"),
+                (cx_gate, out_node_1, "qr[1]"),
+            },
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_out_edges_double(self):
         graph = retworkx.PyDiGraph()
-        in_node = graph.add_node('qr[0]')
-        out_node = graph.add_child(in_node, 'qr[0]', 'qr[0]')
-        h_gate = graph.add_node('h')
-        z_gate = graph.add_node('z')
+        in_node = graph.add_node("qr[0]")
+        out_node = graph.add_child(in_node, "qr[0]", "qr[0]")
+        h_gate = graph.add_node("h")
+        z_gate = graph.add_node("z")
         graph.insert_node_on_out_edges(h_gate, in_node)
         graph.insert_node_on_out_edges(z_gate, in_node)
         self.assertEqual(
-            {(in_node, z_gate, 'qr[0]'), (z_gate, h_gate, 'qr[0]'),
-             (h_gate, out_node, 'qr[0]')},
-            set(graph.weighted_edge_list()))
+            {(in_node, z_gate, "qr[0]"), (z_gate, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")},
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_out_edges_multiple_double(self):
         graph = retworkx.PyDiGraph()
-        in_node_0 = graph.add_node('qr[0]')
-        out_node_0 = graph.add_child(in_node_0, 'qr[0]', 'qr[0]')
-        in_node_1 = graph.add_node('qr[1]')
-        out_node_1 = graph.add_child(in_node_1, 'qr[1]', 'qr[1]')
-        cx_gate = graph.add_node('cx')
-        cz_gate = graph.add_node('cz')
-        graph.insert_node_on_out_edges_multiple(cx_gate,
-                                                [in_node_0, in_node_1])
-        graph.insert_node_on_out_edges_multiple(cz_gate,
-                                                [in_node_0, in_node_1])
+        in_node_0 = graph.add_node("qr[0]")
+        out_node_0 = graph.add_child(in_node_0, "qr[0]", "qr[0]")
+        in_node_1 = graph.add_node("qr[1]")
+        out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
+        cx_gate = graph.add_node("cx")
+        cz_gate = graph.add_node("cz")
+        graph.insert_node_on_out_edges_multiple(cx_gate, [in_node_0, in_node_1])
+        graph.insert_node_on_out_edges_multiple(cz_gate, [in_node_0, in_node_1])
         self.assertEqual(
-            {(in_node_0, cz_gate, 'qr[0]'), (cz_gate, cx_gate, 'qr[0]'),
-             (in_node_1, cz_gate, 'qr[1]'), (cz_gate, cx_gate, 'qr[1]'),
-             (cx_gate, out_node_0, 'qr[0]'), (cx_gate, out_node_1, 'qr[1]')},
-            set(graph.weighted_edge_list()))
+            {
+                (in_node_0, cz_gate, "qr[0]"),
+                (cz_gate, cx_gate, "qr[0]"),
+                (in_node_1, cz_gate, "qr[1]"),
+                (cz_gate, cx_gate, "qr[1]"),
+                (cx_gate, out_node_0, "qr[0]"),
+                (cx_gate, out_node_1, "qr[1]"),
+            },
+            set(graph.weighted_edge_list()),
+        )
 
     def test_insert_node_on_in_edges_no_edges(self):
         graph = retworkx.PyDiGraph()
@@ -528,113 +530,109 @@ class TestEdges(unittest.TestCase):
 
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
-
     def test_multigraph_attr(self):
         graph = retworkx.PyDiGraph(multigraph=False)
         self.assertFalse(graph.multigraph)
 
     def test_get_edge_data(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
         res = graph.get_edge_data(node_a, node_b)
         self.assertEqual("Edgy", res)
 
     def test_get_all_edge_data(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        graph.add_edge(node_a, node_b, 'b')
+        graph.add_edge(node_a, node_b, "b")
         res = graph.get_all_edge_data(node_a, node_b)
-        self.assertIn('b', res)
-        self.assertNotIn('Edgy', res)
+        self.assertIn("b", res)
+        self.assertNotIn("Edgy", res)
 
     def test_no_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, {})
         self.assertTrue(graph.has_edge(node_a, node_b))
 
     def test_has_edge_no_edge(self):
         graph = retworkx.PyDiGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         self.assertFalse(graph.has_edge(node_a, node_b))
 
     def test_edges(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(["Edgy", "Super edgy"], graph.edges())
 
     def test_edges_empty(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        graph.add_node('a')
+        graph.add_node("a")
         self.assertEqual([], graph.edges())
 
     def test_add_duplicates(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'a')
-        graph.add_edge(node_a, node_b, 'b')
-        self.assertEqual(['b'], graph.edges())
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "a")
+        graph.add_edge(node_a, node_b, "b")
+        self.assertEqual(["b"], graph.edges())
 
     def test_remove_no_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge(node_a, node_b)
         self.assertEqual([], graph.edges())
 
     def test_remove_multiple(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_b, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_b, "super_edgy")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edge_from_index(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edge_no_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        graph.add_node('a')
+        graph.add_node("a")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
@@ -670,25 +668,29 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
 
     def test_extend_from_weighted_edge_list_edges_exist(self):
         graph = retworkx.PyDiGraph(multigraph=False)
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e'), (0, 1, 'not_a')]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+            (0, 1, "not_a"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['not_a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["not_a", "b", "c", "d", "e"], graph.edges())
 
     def test_extend_from_edge_list(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
@@ -701,16 +703,14 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_edge_list_existing_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3), (0, 1)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3), (0, 1)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -36,7 +36,9 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b
+        )
 
     def test_update_edge(self):
         dag = retworkx.PyDAG()
@@ -49,7 +51,9 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.update_edge, node_a, node_b, None)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, dag.update_edge, node_a, node_b, None
+        )
 
     def test_update_edge_by_index(self):
         dag = retworkx.PyDAG()
@@ -71,7 +75,10 @@ class TestEdges(unittest.TestCase):
         graph.add_edge(node_a, node_b, "not edgy")
         edge_index = graph.add_edge(node_a, node_b, "not edgy")
         graph.update_edge_by_index(edge_index, "Edgy")
-        self.assertEqual([(0, 1, "not edgy"), (0, 1, "Edgy")], list(graph.weighted_edge_list()))
+        self.assertEqual(
+            [(0, 1, "not edgy"), (0, 1, "Edgy")],
+            list(graph.weighted_edge_list()),
+        )
 
     def test_has_edge(self):
         dag = retworkx.PyDAG()
@@ -108,7 +115,9 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.remove_edge, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, dag.remove_edge, node_a, node_b
+        )
 
     def test_remove_edge_single(self):
         dag = retworkx.PyDAG()
@@ -163,7 +172,9 @@ class TestEdges(unittest.TestCase):
         dag.check_cycle = True
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", {})
-        self.assertRaises(retworkx.DAGWouldCycle, dag.add_edge, node_b, node_a, {})
+        self.assertRaises(
+            retworkx.DAGWouldCycle, dag.add_edge, node_b, node_a, {}
+        )
 
     def test_add_edge_with_cycle_check_enabled(self):
         dag = retworkx.PyDAG(True)
@@ -216,7 +227,13 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         nodes = list(range(4))
         dag.add_nodes_from(nodes)
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         res = dag.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
@@ -278,7 +295,13 @@ class TestEdges(unittest.TestCase):
     def test_edge_list(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         dag.add_edges_from(edge_list)
         self.assertEqual([(x[0], x[1]) for x in edge_list], dag.edge_list())
 
@@ -289,7 +312,13 @@ class TestEdges(unittest.TestCase):
     def test_weighted_edge_list(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         dag.add_edges_from(edge_list)
         self.assertEqual(edge_list, dag.weighted_edge_list())
 
@@ -320,7 +349,9 @@ class TestEdges(unittest.TestCase):
         node_b = dag.add_child(node_a, "b", {})
         node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
-            dag.extend_from_weighted_edge_list([(node_a, node_c, {}), (node_c, node_b, {})])
+            dag.extend_from_weighted_edge_list(
+                [(node_a, node_c, {}), (node_c, node_b, {})]
+            )
 
     def test_extend_from_edge_list_nodes_exist(self):
         dag = retworkx.PyDiGraph()
@@ -337,7 +368,13 @@ class TestEdges(unittest.TestCase):
 
     def test_extend_from_weighted_edge_list(self):
         dag = retworkx.PyDAG()
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         dag.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
@@ -363,7 +400,13 @@ class TestEdges(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         dag = retworkx.PyDiGraph()
         dag.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         dag.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(dag), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], dag.edges())
@@ -380,7 +423,8 @@ class TestEdges(unittest.TestCase):
         h_gate = graph.add_node("h")
         graph.insert_node_on_in_edges(h_gate, out_node)
         self.assertEqual(
-            [(in_node, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")], graph.weighted_edge_list()
+            [(in_node, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")],
+            graph.weighted_edge_list(),
         )
 
     def test_insert_node_on_in_edges_multiple(self):
@@ -390,7 +434,9 @@ class TestEdges(unittest.TestCase):
         in_node_1 = graph.add_node("qr[1]")
         out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
         cx_gate = graph.add_node("cx")
-        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(
+            cx_gate, [out_node_0, out_node_1]
+        )
         self.assertEqual(
             {
                 (in_node_0, cx_gate, "qr[0]"),
@@ -410,7 +456,11 @@ class TestEdges(unittest.TestCase):
         graph.insert_node_on_in_edges(h_gate, out_node)
         graph.insert_node_on_in_edges(z_gate, out_node)
         self.assertEqual(
-            {(in_node, h_gate, "qr[0]"), (h_gate, z_gate, "qr[0]"), (z_gate, out_node, "qr[0]")},
+            {
+                (in_node, h_gate, "qr[0]"),
+                (h_gate, z_gate, "qr[0]"),
+                (z_gate, out_node, "qr[0]"),
+            },
             set(graph.weighted_edge_list()),
         )
 
@@ -422,8 +472,12 @@ class TestEdges(unittest.TestCase):
         out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
         cx_gate = graph.add_node("cx")
         cz_gate = graph.add_node("cz")
-        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
-        graph.insert_node_on_in_edges_multiple(cz_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(
+            cx_gate, [out_node_0, out_node_1]
+        )
+        graph.insert_node_on_in_edges_multiple(
+            cz_gate, [out_node_0, out_node_1]
+        )
         self.assertEqual(
             {
                 (in_node_0, cx_gate, "qr[0]"),
@@ -474,7 +528,11 @@ class TestEdges(unittest.TestCase):
         graph.insert_node_on_out_edges(h_gate, in_node)
         graph.insert_node_on_out_edges(z_gate, in_node)
         self.assertEqual(
-            {(in_node, z_gate, "qr[0]"), (z_gate, h_gate, "qr[0]"), (h_gate, out_node, "qr[0]")},
+            {
+                (in_node, z_gate, "qr[0]"),
+                (z_gate, h_gate, "qr[0]"),
+                (h_gate, out_node, "qr[0]"),
+            },
             set(graph.weighted_edge_list()),
         )
 
@@ -556,13 +614,17 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
+        )
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
+        )
 
     def test_has_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
@@ -603,7 +665,9 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
+        )
 
     def test_remove_edge_single(self):
         graph = retworkx.PyDiGraph(multigraph=False)
@@ -668,7 +732,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
@@ -710,7 +780,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyDiGraph(multigraph=False)
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())

--- a/tests/digraph/test_find_cycle.py
+++ b/tests/digraph/test_find_cycle.py
@@ -19,26 +19,29 @@ class TestFindCycle(unittest.TestCase):
     def setUp(self):
         self.graph = retworkx.PyDiGraph()
         self.graph.add_nodes_from(list(range(10)))
-        self.graph.add_edges_from_no_data([
-            (0, 1),
-            (3, 0),
-            (0, 5),
-            (8, 0),
-            (1, 2),
-            (1, 6),
-            (2, 3),
-            (3, 4),
-            (4, 5),
-            (6, 7),
-            (7, 8),
-            (8, 9)])
+        self.graph.add_edges_from_no_data(
+            [
+                (0, 1),
+                (3, 0),
+                (0, 5),
+                (8, 0),
+                (1, 2),
+                (1, 6),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (6, 7),
+                (7, 8),
+                (8, 9),
+            ]
+        )
 
     def test_find_cycle(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(6)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5), (4, 0)
-        ])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5), (4, 0)]
+        )
         res = retworkx.digraph_find_cycle(graph, 0)
         self.assertEqual([(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)], res)
 

--- a/tests/digraph/test_floyd_warshall.py
+++ b/tests/digraph/test_floyd_warshall.py
@@ -78,8 +78,12 @@ class TestFloydWarshall(unittest.TestCase):
     def test_directed_floyd_warshall_numpy_cycle_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: 1, as_undirected=True)
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
+        dist = retworkx.digraph_floyd_warshall_numpy(
+            graph, lambda x: 1, as_undirected=True
+        )
         expected = numpy.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
@@ -129,7 +133,9 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_digraph_cycle(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -164,7 +170,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -175,7 +183,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 4)
@@ -184,7 +194,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/digraph/test_floyd_warshall.py
+++ b/tests/digraph/test_floyd_warshall.py
@@ -24,36 +24,36 @@ class TestFloydWarshall(unittest.TestCase):
         """Test the algorithm on a 5q x 4 depth circuit."""
         dag = retworkx.PyDAG()
         # inputs
-        qr_0 = dag.add_node('qr[0]')
-        qr_1 = dag.add_node('qr[1]')
-        qr_2 = dag.add_node('qr[2]')
-        cr_0 = dag.add_node('cr[0]')
-        cr_1 = dag.add_node('cr[1]')
+        qr_0 = dag.add_node("qr[0]")
+        qr_1 = dag.add_node("qr[1]")
+        qr_2 = dag.add_node("qr[2]")
+        cr_0 = dag.add_node("cr[0]")
+        cr_1 = dag.add_node("cr[1]")
         # wires
-        cx_1 = dag.add_node('cx_1')
-        dag.add_edge(qr_0, cx_1, 'qr[0]')
-        dag.add_edge(qr_1, cx_1, 'qr[1]')
-        h_1 = dag.add_node('h_1')
-        dag.add_edge(cx_1, h_1, 'qr[0]')
-        cx_2 = dag.add_node('cx_2')
-        dag.add_edge(cx_1, cx_2, 'qr[1]')
-        dag.add_edge(qr_2, cx_2, 'qr[2]')
-        cx_3 = dag.add_node('cx_3')
-        dag.add_edge(h_1, cx_3, 'qr[0]')
-        dag.add_edge(cx_2, cx_3, 'qr[2]')
-        h_2 = dag.add_node('h_2')
-        dag.add_edge(cx_3, h_2, 'qr[2]')
+        cx_1 = dag.add_node("cx_1")
+        dag.add_edge(qr_0, cx_1, "qr[0]")
+        dag.add_edge(qr_1, cx_1, "qr[1]")
+        h_1 = dag.add_node("h_1")
+        dag.add_edge(cx_1, h_1, "qr[0]")
+        cx_2 = dag.add_node("cx_2")
+        dag.add_edge(cx_1, cx_2, "qr[1]")
+        dag.add_edge(qr_2, cx_2, "qr[2]")
+        cx_3 = dag.add_node("cx_3")
+        dag.add_edge(h_1, cx_3, "qr[0]")
+        dag.add_edge(cx_2, cx_3, "qr[2]")
+        h_2 = dag.add_node("h_2")
+        dag.add_edge(cx_3, h_2, "qr[2]")
         # # outputs
-        qr_0_out = dag.add_node('qr[0]_out')
-        dag.add_edge(cx_3, qr_0_out, 'qr[0]')
-        qr_1_out = dag.add_node('qr[1]_out')
-        dag.add_edge(cx_2, qr_1_out, 'qr[1]')
-        qr_2_out = dag.add_node('qr[2]_out')
-        dag.add_edge(h_2, qr_2_out, 'qr[2]')
-        cr_0_out = dag.add_node('cr[0]_out')
-        dag.add_edge(cr_0, cr_0_out, 'qr[2]')
-        cr_1_out = dag.add_node('cr[1]_out')
-        dag.add_edge(cr_1, cr_1_out, 'cr[1]')
+        qr_0_out = dag.add_node("qr[0]_out")
+        dag.add_edge(cx_3, qr_0_out, "qr[0]")
+        qr_1_out = dag.add_node("qr[1]_out")
+        dag.add_edge(cx_2, qr_1_out, "qr[1]")
+        qr_2_out = dag.add_node("qr[2]_out")
+        dag.add_edge(h_2, qr_2_out, "qr[2]")
+        cr_0_out = dag.add_node("cr[0]_out")
+        dag.add_edge(cr_0, cr_0_out, "qr[2]")
+        cr_1_out = dag.add_node("cr[1]_out")
+        dag.add_edge(cr_1, cr_1_out, "cr[1]")
 
         result = retworkx.floyd_warshall(dag)
         expected = {
@@ -78,17 +78,19 @@ class TestFloydWarshall(unittest.TestCase):
     def test_directed_floyd_warshall_numpy_cycle_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: 1,
-                                                     as_undirected=True)
-        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
-                                [1., 0., 1., 2., 3., 3., 2.],
-                                [2., 1., 0., 1., 2., 3., 3.],
-                                [3., 2., 1., 0., 1., 2., 3.],
-                                [3., 3., 2., 1., 0., 1., 2.],
-                                [2., 3., 3., 2., 1., 0., 1.],
-                                [1., 2., 3., 3., 2., 1., 0.]])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: 1, as_undirected=True)
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [3.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [2.0, 3.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))
 
     def test_floyd_warshall_numpy_digraph_three_edges(self):
@@ -106,16 +108,18 @@ class TestFloydWarshall(unittest.TestCase):
     def test_weighted_numpy_digraph_two_edges(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
-        graph.add_edges_from([
-            (0, 1, 2),
-            (1, 2, 2),
-            (2, 3, 1),
-            (3, 4, 1),
-            (4, 5, 1),
-            (5, 6, 1),
-            (6, 7, 1),
-            (7, 0, 1),
-        ])
+        graph.add_edges_from(
+            [
+                (0, 1, 2),
+                (1, 2, 2),
+                (2, 3, 1),
+                (3, 4, 1),
+                (4, 5, 1),
+                (5, 6, 1),
+                (6, 7, 1),
+                (7, 0, 1),
+            ]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: x, parallel_threshold=self.parallel_threshold
         )
@@ -125,8 +129,7 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_digraph_cycle(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -136,12 +139,14 @@ class TestFloydWarshall(unittest.TestCase):
     def test_weighted_numpy_directed_negative_cycle(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(4)))
-        graph.add_edges_from([
-            (0, 1, 1),
-            (1, 2, -1),
-            (2, 3, -1),
-            (3, 0, -1),
-        ])
+        graph.add_edges_from(
+            [
+                (0, 1, 1),
+                (1, 2, -1),
+                (2, 3, -1),
+                (3, 0, -1),
+            ]
+        )
         dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: x)
         self.assertTrue(numpy.all(numpy.diag(dist) < 0))
 
@@ -159,8 +164,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -171,8 +175,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 4)
@@ -181,8 +184,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -17,196 +17,193 @@ import retworkx
 
 
 class TestIsomorphic(unittest.TestCase):
-
     def test_isomorphic_identical(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('a_1')
-        dag_b.add_child(node_b, 'a_2', 'a_1')
-        dag_b.add_child(node_b, 'a_3', 'a_2')
+        node_b = dag_b.add_node("a_1")
+        dag_b.add_child(node_b, "a_2", "a_1")
+        dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, id_order=id_order))
+                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
 
     def test_isomorphic_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('b_1')
-        dag_b.add_child(node_b, 'b_2', 'b_1')
-        dag_b.add_child(node_b, 'b_3', 'b_2')
+        node_b = dag_b.add_node("b_1")
+        dag_b.add_child(node_b, "b_2", "b_1")
+        dag_b.add_child(node_b, "b_3", "b_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, id_order=id_order))
+                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('b_1')
-        dag_b.add_child(node_b, 'b_2', 'b_1')
-        dag_b.add_child(node_b, 'b_3', 'b_2')
+        node_b = dag_b.add_node("b_1")
+        dag_b.add_child(node_b, "b_2", "b_1")
+        dag_b.add_child(node_b, "b_3", "b_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_is_isomorphic_nodes_compare_raises(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('b_1')
-        dag_b.add_child(node_b, 'b_2', 'b_1')
-        dag_b.add_child(node_b, 'b_3', 'b_2')
+        node_b = dag_b.add_node("b_1")
+        dag_b.add_child(node_b, "b_2", "b_1")
+        dag_b.add_child(node_b, "b_3", "b_2")
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(
-            TypeError,
-            retworkx.is_isomorphic,
-            (dag_a, dag_b, compare_nodes))
+        self.assertRaises(TypeError, retworkx.is_isomorphic, (dag_a, dag_b, compare_nodes))
 
     def test_isomorphic_compare_nodes_identical(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('a_1')
-        dag_b.add_child(node_b, 'a_2', 'a_1')
-        dag_b.add_child(node_b, 'a_3', 'a_2')
+        node_b = dag_b.add_node("a_1")
+        dag_b.add_child(node_b, "a_2", "a_1")
+        dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_isomorphic_compare_edges_identical(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        node_a = dag_a.add_node('a_1')
-        dag_a.add_child(node_a, 'a_2', 'a_1')
-        dag_a.add_child(node_a, 'a_3', 'a_2')
+        node_a = dag_a.add_node("a_1")
+        dag_a.add_child(node_a, "a_2", "a_1")
+        dag_a.add_child(node_a, "a_3", "a_2")
 
-        node_b = dag_b.add_node('a_1')
-        dag_b.add_child(node_b, 'a_2', 'a_1')
-        dag_b.add_child(node_b, 'a_3', 'a_2')
+        node_b = dag_b.add_node("a_1")
+        dag_b.add_child(node_b, "a_2", "a_1")
+        dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
                     retworkx.is_isomorphic(
-                        dag_a, dag_b, edge_matcher=lambda x, y: x == y,
-                        id_order=id_order))
+                        dag_a, dag_b, edge_matcher=lambda x, y: x == y, id_order=id_order
+                    )
+                )
 
     def test_isomorphic_compare_nodes_with_removals(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        qr_0_in = dag_a.add_node('qr[0]')
-        qr_1_in = dag_a.add_node('qr[1]')
-        cr_0_in = dag_a.add_node('cr[0]')
-        qr_0_out = dag_a.add_node('qr[0]')
-        qr_1_out = dag_a.add_node('qr[1]')
-        cr_0_out = dag_a.add_node('qr[0]')
-        cu1 = dag_a.add_child(qr_0_in, 'cu1', 'qr[0]')
-        dag_a.add_edge(qr_1_in, cu1, 'qr[1]')
-        measure_0 = dag_a.add_child(cr_0_in, 'measure', 'cr[0]')
-        dag_a.add_edge(cu1, measure_0, 'qr[0]')
-        measure_1 = dag_a.add_child(cu1, 'measure', 'qr[1]')
-        dag_a.add_edge(measure_0, measure_1, 'cr[0]')
-        dag_a.add_edge(measure_1, qr_1_out, 'qr[1]')
-        dag_a.add_edge(measure_1, cr_0_out, 'cr[0]')
-        dag_a.add_edge(measure_0, qr_0_out, 'qr[0]')
+        qr_0_in = dag_a.add_node("qr[0]")
+        qr_1_in = dag_a.add_node("qr[1]")
+        cr_0_in = dag_a.add_node("cr[0]")
+        qr_0_out = dag_a.add_node("qr[0]")
+        qr_1_out = dag_a.add_node("qr[1]")
+        cr_0_out = dag_a.add_node("qr[0]")
+        cu1 = dag_a.add_child(qr_0_in, "cu1", "qr[0]")
+        dag_a.add_edge(qr_1_in, cu1, "qr[1]")
+        measure_0 = dag_a.add_child(cr_0_in, "measure", "cr[0]")
+        dag_a.add_edge(cu1, measure_0, "qr[0]")
+        measure_1 = dag_a.add_child(cu1, "measure", "qr[1]")
+        dag_a.add_edge(measure_0, measure_1, "cr[0]")
+        dag_a.add_edge(measure_1, qr_1_out, "qr[1]")
+        dag_a.add_edge(measure_1, cr_0_out, "cr[0]")
+        dag_a.add_edge(measure_0, qr_0_out, "qr[0]")
         dag_a.remove_node(cu1)
-        dag_a.add_edge(qr_0_in, measure_0, 'qr[0]')
-        dag_a.add_edge(qr_1_in, measure_1, 'qr[1]')
+        dag_a.add_edge(qr_0_in, measure_0, "qr[0]")
+        dag_a.add_edge(qr_1_in, measure_1, "qr[1]")
 
-        qr_0_in = dag_b.add_node('qr[0]')
-        qr_1_in = dag_b.add_node('qr[1]')
-        cr_0_in = dag_b.add_node('cr[0]')
-        qr_0_out = dag_b.add_node('qr[0]')
-        qr_1_out = dag_b.add_node('qr[1]')
-        cr_0_out = dag_b.add_node('qr[0]')
-        measure_0 = dag_b.add_child(cr_0_in, 'measure', 'cr[0]')
-        dag_b.add_edge(qr_0_in, measure_0, 'qr[0]')
-        measure_1 = dag_b.add_child(qr_1_in, 'measure', 'qr[1]')
-        dag_b.add_edge(measure_1, qr_1_out, 'qr[1]')
-        dag_b.add_edge(measure_1, cr_0_out, 'cr[0]')
-        dag_b.add_edge(measure_0, measure_1, 'cr[0]')
-        dag_b.add_edge(measure_0, qr_0_out, 'qr[0]')
+        qr_0_in = dag_b.add_node("qr[0]")
+        qr_1_in = dag_b.add_node("qr[1]")
+        cr_0_in = dag_b.add_node("cr[0]")
+        qr_0_out = dag_b.add_node("qr[0]")
+        qr_1_out = dag_b.add_node("qr[1]")
+        cr_0_out = dag_b.add_node("qr[0]")
+        measure_0 = dag_b.add_child(cr_0_in, "measure", "cr[0]")
+        dag_b.add_edge(qr_0_in, measure_0, "qr[0]")
+        measure_1 = dag_b.add_child(qr_1_in, "measure", "qr[1]")
+        dag_b.add_edge(measure_1, qr_1_out, "qr[1]")
+        dag_b.add_edge(measure_1, cr_0_out, "cr[0]")
+        dag_b.add_edge(measure_0, measure_1, "cr[0]")
+        dag_b.add_edge(measure_0, qr_0_out, "qr[0]")
 
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_isomorphic_compare_nodes_with_removals_deepcopy(self):
         dag_a = retworkx.PyDAG()
         dag_b = retworkx.PyDAG()
 
-        qr_0_in = dag_a.add_node('qr[0]')
-        qr_1_in = dag_a.add_node('qr[1]')
-        cr_0_in = dag_a.add_node('cr[0]')
-        qr_0_out = dag_a.add_node('qr[0]')
-        qr_1_out = dag_a.add_node('qr[1]')
-        cr_0_out = dag_a.add_node('qr[0]')
-        cu1 = dag_a.add_child(qr_0_in, 'cu1', 'qr[0]')
-        dag_a.add_edge(qr_1_in, cu1, 'qr[1]')
-        measure_0 = dag_a.add_child(cr_0_in, 'measure', 'cr[0]')
-        dag_a.add_edge(cu1, measure_0, 'qr[0]')
-        measure_1 = dag_a.add_child(cu1, 'measure', 'qr[1]')
-        dag_a.add_edge(measure_0, measure_1, 'cr[0]')
-        dag_a.add_edge(measure_1, qr_1_out, 'qr[1]')
-        dag_a.add_edge(measure_1, cr_0_out, 'cr[0]')
-        dag_a.add_edge(measure_0, qr_0_out, 'qr[0]')
+        qr_0_in = dag_a.add_node("qr[0]")
+        qr_1_in = dag_a.add_node("qr[1]")
+        cr_0_in = dag_a.add_node("cr[0]")
+        qr_0_out = dag_a.add_node("qr[0]")
+        qr_1_out = dag_a.add_node("qr[1]")
+        cr_0_out = dag_a.add_node("qr[0]")
+        cu1 = dag_a.add_child(qr_0_in, "cu1", "qr[0]")
+        dag_a.add_edge(qr_1_in, cu1, "qr[1]")
+        measure_0 = dag_a.add_child(cr_0_in, "measure", "cr[0]")
+        dag_a.add_edge(cu1, measure_0, "qr[0]")
+        measure_1 = dag_a.add_child(cu1, "measure", "qr[1]")
+        dag_a.add_edge(measure_0, measure_1, "cr[0]")
+        dag_a.add_edge(measure_1, qr_1_out, "qr[1]")
+        dag_a.add_edge(measure_1, cr_0_out, "cr[0]")
+        dag_a.add_edge(measure_0, qr_0_out, "qr[0]")
         dag_a.remove_node(cu1)
-        dag_a.add_edge(qr_0_in, measure_0, 'qr[0]')
-        dag_a.add_edge(qr_1_in, measure_1, 'qr[1]')
+        dag_a.add_edge(qr_0_in, measure_0, "qr[0]")
+        dag_a.add_edge(qr_1_in, measure_1, "qr[1]")
 
-        qr_0_in = dag_b.add_node('qr[0]')
-        qr_1_in = dag_b.add_node('qr[1]')
-        cr_0_in = dag_b.add_node('cr[0]')
-        qr_0_out = dag_b.add_node('qr[0]')
-        qr_1_out = dag_b.add_node('qr[1]')
-        cr_0_out = dag_b.add_node('qr[0]')
-        measure_0 = dag_b.add_child(cr_0_in, 'measure', 'cr[0]')
-        dag_b.add_edge(qr_0_in, measure_0, 'qr[0]')
-        measure_1 = dag_b.add_child(qr_1_in, 'measure', 'qr[1]')
-        dag_b.add_edge(measure_1, qr_1_out, 'qr[1]')
-        dag_b.add_edge(measure_1, cr_0_out, 'cr[0]')
-        dag_b.add_edge(measure_0, measure_1, 'cr[0]')
-        dag_b.add_edge(measure_0, qr_0_out, 'qr[0]')
+        qr_0_in = dag_b.add_node("qr[0]")
+        qr_1_in = dag_b.add_node("qr[1]")
+        cr_0_in = dag_b.add_node("cr[0]")
+        qr_0_out = dag_b.add_node("qr[0]")
+        qr_1_out = dag_b.add_node("qr[1]")
+        cr_0_out = dag_b.add_node("qr[0]")
+        measure_0 = dag_b.add_child(cr_0_in, "measure", "cr[0]")
+        dag_b.add_edge(qr_0_in, measure_0, "qr[0]")
+        measure_1 = dag_b.add_child(qr_1_in, "measure", "qr[1]")
+        dag_b.add_edge(measure_1, qr_1_out, "qr[1]")
+        dag_b.add_edge(measure_1, cr_0_out, "cr[0]")
+        dag_b.add_edge(measure_0, measure_1, "cr[0]")
+        dag_b.add_edge(measure_0, qr_0_out, "qr[0]")
 
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
                     retworkx.is_isomorphic(
-                        copy.deepcopy(dag_a), copy.deepcopy(dag_b),
-                        lambda x, y: x == y, id_order=id_order))
+                        copy.deepcopy(dag_a),
+                        copy.deepcopy(dag_b),
+                        lambda x, y: x == y,
+                        id_order=id_order,
+                    )
+                )

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -30,7 +30,9 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
+                self.assertTrue(
+                    retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order)
+                )
 
     def test_isomorphic_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
@@ -45,7 +47,9 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "b_3", "b_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
+                self.assertTrue(
+                    retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order)
+                )
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
@@ -61,7 +65,9 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_is_isomorphic_nodes_compare_raises(self):
@@ -79,7 +85,9 @@ class TestIsomorphic(unittest.TestCase):
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(TypeError, retworkx.is_isomorphic, (dag_a, dag_b, compare_nodes))
+        self.assertRaises(
+            TypeError, retworkx.is_isomorphic, (dag_a, dag_b, compare_nodes)
+        )
 
     def test_isomorphic_compare_nodes_identical(self):
         dag_a = retworkx.PyDAG()
@@ -95,7 +103,9 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_isomorphic_compare_edges_identical(self):
@@ -113,7 +123,10 @@ class TestIsomorphic(unittest.TestCase):
             with self.subTest(id_order=id_order):
                 self.assertTrue(
                     retworkx.is_isomorphic(
-                        dag_a, dag_b, edge_matcher=lambda x, y: x == y, id_order=id_order
+                        dag_a,
+                        dag_b,
+                        edge_matcher=lambda x, y: x == y,
+                        id_order=id_order,
                     )
                 )
 
@@ -157,7 +170,9 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_isomorphic_compare_nodes_with_removals_deepcopy(self):

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -20,17 +20,48 @@ class TestKShortestpath(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.add_edges_from_no_data(
-            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+            [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (4, 5),
+                (1, 4),
+                (5, 6),
+                (6, 7),
+                (7, 5),
+            ]
         )
         res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1)
-        expected = {0: 7.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 5.0, 5: 5.0, 6: 6.0, 7: 7.0}
+        expected = {
+            0: 7.0,
+            1: 4.0,
+            2: 5.0,
+            3: 6.0,
+            4: 5.0,
+            5: 5.0,
+            6: 6.0,
+            7: 7.0,
+        }
         self.assertEqual(res, expected)
 
     def test_digraph_k_shortest_path_lengths_with_goal(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.add_edges_from_no_data(
-            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+            [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (4, 5),
+                (1, 4),
+                (5, 6),
+                (6, 7),
+                (7, 5),
+            ]
         )
-        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1, 3)
+        res = retworkx.digraph_k_shortest_path_lengths(
+            graph, 1, 2, lambda _: 1, 3
+        )
         self.assertEqual(res, {3: 6})

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -19,37 +19,18 @@ class TestKShortestpath(unittest.TestCase):
     def test_digraph_k_shortest_path_lengths(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
-        graph.add_edges_from_no_data([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (4, 5),
-            (1, 4),
-            (5, 6),
-            (6, 7),
-            (7, 5)
-        ])
-        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2,
-                                                       lambda _: 1)
-        expected = {0: 7.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 5.0, 5: 5.0, 6: 6.0,
-                    7: 7.0}
+        graph.add_edges_from_no_data(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+        )
+        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1)
+        expected = {0: 7.0, 1: 4.0, 2: 5.0, 3: 6.0, 4: 5.0, 5: 5.0, 6: 6.0, 7: 7.0}
         self.assertEqual(res, expected)
 
     def test_digraph_k_shortest_path_lengths_with_goal(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
-        graph.add_edges_from_no_data([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (4, 5),
-            (1, 4),
-            (5, 6),
-            (6, 7),
-            (7, 5)
-        ])
-        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2,
-                                                       lambda _: 1, 3)
+        graph.add_edges_from_no_data(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+        )
+        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1, 3)
         self.assertEqual(res, {3: 6})

--- a/tests/digraph/test_layers.py
+++ b/tests/digraph/test_layers.py
@@ -49,13 +49,14 @@ class TestLayers(unittest.TestCase):
 
         res = retworkx.layers(dag, input_nodes)
         expected = [
-            ['qr[0]', 'qr[1]', 'cr[0]', 'cr[1]'],
-            ['h'],
-            ['cx'],
-            ['measure'],
-            ['x'],
-            ['measure', 'measure'],
-            ['cr[1]', 'qr[1]', 'cr[0]', 'qr[0]']]
+            ["qr[0]", "qr[1]", "cr[0]", "cr[1]"],
+            ["h"],
+            ["cx"],
+            ["measure"],
+            ["x"],
+            ["measure", "measure"],
+            ["cr[1]", "qr[1]", "cr[0]", "qr[0]"],
+        ]
         self.assertEqual(expected, res)
 
     def test_first_layer_invalid_node(self):

--- a/tests/digraph/test_layout.py
+++ b/tests/digraph/test_layout.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestRandomLayout(unittest.TestCase):
-
     def setUp(self):
         self.graph = retworkx.generators.directed_path_graph(10)
 
@@ -32,13 +31,12 @@ class TestRandomLayout(unittest.TestCase):
             6: (0.462700947802672, 0.44025745918644743),
             7: (0.3125895420208278, 0.0893209773065271),
             8: (0.5567725240957387, 0.21079648777222115),
-            9: (0.7586719404939911, 0.43090704138697045)
+            9: (0.7586719404939911, 0.43090704138697045),
         }
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.digraph_random_layout(self.graph, center=(0.5, 0.5),
-                                             seed=42)
+        res = retworkx.digraph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],
@@ -49,7 +47,7 @@ class TestRandomLayout(unittest.TestCase):
             0: [0.7265125179283135, 0.7391066903185995],
             2: [1.4704763177409157, 0.8754626814145194],
             6: [0.962700947802672, 0.9402574591864474],
-            3: [0.6879083014236631, 1.0246576629278041]
+            3: [0.6879083014236631, 1.0246576629278041],
         }
         self.assertEqual(expected, res)
 

--- a/tests/digraph/test_layout.py
+++ b/tests/digraph/test_layout.py
@@ -36,7 +36,9 @@ class TestRandomLayout(unittest.TestCase):
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.digraph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
+        res = retworkx.digraph_random_layout(
+            self.graph, center=(0.5, 0.5), seed=42
+        )
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],

--- a/tests/digraph/test_neighbors.py
+++ b/tests/digraph/test_neighbors.py
@@ -18,26 +18,26 @@ import retworkx
 class TestAdj(unittest.TestCase):
     def test_single_neighbor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.neighbors(node_a)
         self.assertCountEqual([node_c, node_b], res)
 
     def test_unique_neighbors_on_dags(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', ['edge a->b'])
-        node_c = dag.add_child(node_a, 'c', ['edge a->c'])
-        dag.add_edge(node_a, node_b, ['edge a->b bis'])
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", ["edge a->b"])
+        node_c = dag.add_child(node_a, "c", ["edge a->c"])
+        dag.add_edge(node_a, node_b, ["edge a->b bis"])
         res = dag.neighbors(node_a)
         self.assertCountEqual([node_c, node_b], res)
 
     def test_single_neighbor_dir(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.successor_indices(node_a)
         self.assertEqual([node_c, node_b], res)
         res = dag.predecessor_indices(node_a)
@@ -45,9 +45,9 @@ class TestAdj(unittest.TestCase):
 
     def test_neighbor_dir_surrounded(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
         res = dag.successor_indices(node_b)
         self.assertEqual([node_c], res)
         res = dag.predecessor_indices(node_b)
@@ -55,5 +55,5 @@ class TestAdj(unittest.TestCase):
 
     def test_no_neighbor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         self.assertEqual([], dag.neighbors(node_a))

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -16,13 +16,12 @@ import retworkx
 
 
 class TestNodes(unittest.TestCase):
-
     def test_nodes(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "Edgy")
         res = dag.nodes()
-        self.assertEqual(['a', 'b'], res)
+        self.assertEqual(["a", "b"], res)
         self.assertEqual([0, 1], dag.node_indexes())
 
     def test_no_nodes(self):
@@ -32,108 +31,108 @@ class TestNodes(unittest.TestCase):
 
     def test_remove_node(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node(node_b)
         res = dag.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], dag.node_indexes())
 
     def test_remove_node_invalid_index(self):
         graph = retworkx.PyDAG()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
         graph.remove_node(76)
         res = graph.nodes()
-        self.assertEqual(['a', 'b', 'c'], res)
+        self.assertEqual(["a", "b", "c"], res)
         self.assertEqual([0, 1, 2], graph.node_indexes())
 
     def test_remove_nodes_from(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_nodes_from([node_b, node_c])
         res = dag.nodes()
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
         self.assertEqual([0], dag.node_indexes())
 
     def test_remove_nodes_from_with_invalid_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_nodes_from([node_b, node_c, 76])
         res = dag.nodes()
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
         self.assertEqual([0], dag.node_indexes())
 
     def test_remove_nodes_retain_edges_single_edge(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(node_b)
         res = dag.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], dag.node_indexes())
         self.assertTrue(dag.has_edge(node_a, node_c))
-        self.assertEqual(dag.get_all_edge_data(node_a, node_c), ['Edgy'])
+        self.assertEqual(dag.get_all_edge_data(node_a, node_c), ["Edgy"])
 
     def test_remove_nodes_retain_edges_single_edge_outgoing_weight(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(node_b, use_outgoing=True)
         res = dag.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], dag.node_indexes())
         self.assertTrue(dag.has_edge(node_a, node_c))
-        self.assertEqual(dag.get_all_edge_data(node_a, node_c), ['Edgy_mk2'])
+        self.assertEqual(dag.get_all_edge_data(node_a, node_c), ["Edgy_mk2"])
 
     def test_remove_nodes_retain_edges_multiple_in_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_d = dag.add_node('d')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        node_d = dag.add_node("d")
+        node_b = dag.add_child(node_a, "b", "Edgy")
         dag.add_edge(node_d, node_b, "Multiple in edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(node_b)
         res = dag.nodes()
-        self.assertEqual(['a', 'd', 'c'], res)
+        self.assertEqual(["a", "d", "c"], res)
         self.assertEqual([0, 1, 3], dag.node_indexes())
         self.assertTrue(dag.has_edge(node_a, node_c))
         self.assertTrue(dag.has_edge(node_d, node_c))
 
     def test_remove_nodes_retain_edges_multiple_out_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_d = dag.add_node('d')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        node_d = dag.add_node("d")
+        node_b = dag.add_child(node_a, "b", "Edgy")
         dag.add_edge(node_b, node_d, "Multiple out edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(node_b)
         res = dag.nodes()
-        self.assertEqual(['a', 'd', 'c'], res)
+        self.assertEqual(["a", "d", "c"], res)
         self.assertEqual([0, 1, 3], dag.node_indexes())
         self.assertTrue(dag.has_edge(node_a, node_c))
         self.assertTrue(dag.has_edge(node_a, node_d))
 
     def test_remove_nodes_retain_edges_multiple_in_and_out_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_d = dag.add_node('d')
-        node_e = dag.add_node('e')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        node_d = dag.add_node("d")
+        node_e = dag.add_node("e")
+        node_b = dag.add_child(node_a, "b", "Edgy")
         dag.add_edge(node_b, node_d, "Multiple out edgy")
         dag.add_edge(node_e, node_b, "multiple in edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(node_b)
         res = dag.nodes()
-        self.assertEqual(['a', 'd', 'e', 'c'], res)
+        self.assertEqual(["a", "d", "e", "c"], res)
         self.assertEqual([0, 1, 2, 4], dag.node_indexes())
         self.assertTrue(dag.has_edge(node_a, node_c))
         self.assertTrue(dag.has_edge(node_a, node_d))
@@ -142,17 +141,16 @@ class TestNodes(unittest.TestCase):
 
     def test_remove_node_retain_edges_with_condition(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_d = dag.add_node('d')
-        node_e = dag.add_node('e')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        node_d = dag.add_node("d")
+        node_e = dag.add_node("e")
+        node_b = dag.add_child(node_a, "b", "Edgy")
         dag.add_edge(node_b, node_d, "Multiple out edgy")
         dag.add_edge(node_e, node_b, "multiple in edgy")
-        node_c = dag.add_child(node_b, 'c', "Edgy_mk2")
-        dag.remove_node_retain_edges(
-            node_b, condition=lambda a, b: a == 'multiple in edgy')
+        node_c = dag.add_child(node_b, "c", "Edgy_mk2")
+        dag.remove_node_retain_edges(node_b, condition=lambda a, b: a == "multiple in edgy")
         res = dag.nodes()
-        self.assertEqual(['a', 'd', 'e', 'c'], res)
+        self.assertEqual(["a", "d", "e", "c"], res)
         self.assertEqual([0, 1, 2, 4], dag.node_indexes())
         self.assertFalse(dag.has_edge(node_a, node_c))
         self.assertFalse(dag.has_edge(node_a, node_d))
@@ -161,12 +159,12 @@ class TestNodes(unittest.TestCase):
 
     def test_remove_nodes_retain_edges_with_invalid_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag.add_child(node_b, "c", "Edgy_mk2")
         dag.remove_node_retain_edges(76)
         res = dag.nodes()
-        self.assertEqual(['a', 'b', 'c'], res)
+        self.assertEqual(["a", "b", "c"], res)
         self.assertEqual([0, 1, 2], dag.node_indexes())
 
     def test_topo_sort_empty(self):
@@ -175,90 +173,103 @@ class TestNodes(unittest.TestCase):
 
     def test_topo_sort(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_child(node_a, i, None)
-        dag.add_parent(3, 'A parent', None)
+        dag.add_parent(3, "A parent", None)
         res = retworkx.topological_sort(dag)
         self.assertEqual([6, 0, 5, 4, 3, 2, 1], res)
 
     def test_topo_sort_with_cycle(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {})
         dag.add_edge(node_b, node_a, {})
         self.assertRaises(retworkx.DAGHasCycle, retworkx.topological_sort, dag)
 
     def test_lexicographical_topo_sort(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(5):
             dag.add_child(node_a, i, None)
-        dag.add_parent(3, 'A parent', None)
+        dag.add_parent(3, "A parent", None)
         res = retworkx.lexicographical_topological_sort(dag, lambda x: str(x))
         # Node values for nodes [6, 0, 5, 4, 3, 2, 1]
-        expected = ['A parent', 'a', 0, 1, 2, 3, 4]
+        expected = ["A parent", "a", 0, 1, 2, 3, 4]
         self.assertEqual(expected, res)
 
     def test_lexicographical_topo_sort_qiskit(self):
         dag = retworkx.PyDAG()
         # inputs
-        qr_0 = dag.add_node('qr[0]')
-        qr_1 = dag.add_node('qr[1]')
-        qr_2 = dag.add_node('qr[2]')
-        cr_0 = dag.add_node('cr[0]')
-        cr_1 = dag.add_node('cr[1]')
+        qr_0 = dag.add_node("qr[0]")
+        qr_1 = dag.add_node("qr[1]")
+        qr_2 = dag.add_node("qr[2]")
+        cr_0 = dag.add_node("cr[0]")
+        cr_1 = dag.add_node("cr[1]")
 
         # wires
-        cx_1 = dag.add_node('cx_1')
-        dag.add_edge(qr_0, cx_1, 'qr[0]')
-        dag.add_edge(qr_1, cx_1, 'qr[1]')
-        h_1 = dag.add_node('h_1')
-        dag.add_edge(cx_1, h_1, 'qr[0]')
-        cx_2 = dag.add_node('cx_2')
-        dag.add_edge(cx_1, cx_2, 'qr[1]')
-        dag.add_edge(qr_2, cx_2, 'qr[2]')
-        cx_3 = dag.add_node('cx_3')
-        dag.add_edge(h_1, cx_3, 'qr[0]')
-        dag.add_edge(cx_2, cx_3, 'qr[2]')
-        h_2 = dag.add_node('h_2')
-        dag.add_edge(cx_3, h_2, 'qr[2]')
+        cx_1 = dag.add_node("cx_1")
+        dag.add_edge(qr_0, cx_1, "qr[0]")
+        dag.add_edge(qr_1, cx_1, "qr[1]")
+        h_1 = dag.add_node("h_1")
+        dag.add_edge(cx_1, h_1, "qr[0]")
+        cx_2 = dag.add_node("cx_2")
+        dag.add_edge(cx_1, cx_2, "qr[1]")
+        dag.add_edge(qr_2, cx_2, "qr[2]")
+        cx_3 = dag.add_node("cx_3")
+        dag.add_edge(h_1, cx_3, "qr[0]")
+        dag.add_edge(cx_2, cx_3, "qr[2]")
+        h_2 = dag.add_node("h_2")
+        dag.add_edge(cx_3, h_2, "qr[2]")
 
         # outputs
-        qr_0_out = dag.add_node('qr[0]_out')
-        dag.add_edge(cx_3, qr_0_out, 'qr[0]')
-        qr_1_out = dag.add_node('qr[1]_out')
-        dag.add_edge(cx_2, qr_1_out, 'qr[1]')
-        qr_2_out = dag.add_node('qr[2]_out')
-        dag.add_edge(h_2, qr_2_out, 'qr[2]')
-        cr_0_out = dag.add_node('cr[0]_out')
-        dag.add_edge(cr_0, cr_0_out, 'qr[2]')
-        cr_1_out = dag.add_node('cr[1]_out')
-        dag.add_edge(cr_1, cr_1_out, 'cr[1]')
+        qr_0_out = dag.add_node("qr[0]_out")
+        dag.add_edge(cx_3, qr_0_out, "qr[0]")
+        qr_1_out = dag.add_node("qr[1]_out")
+        dag.add_edge(cx_2, qr_1_out, "qr[1]")
+        qr_2_out = dag.add_node("qr[2]_out")
+        dag.add_edge(h_2, qr_2_out, "qr[2]")
+        cr_0_out = dag.add_node("cr[0]_out")
+        dag.add_edge(cr_0, cr_0_out, "qr[2]")
+        cr_1_out = dag.add_node("cr[1]_out")
+        dag.add_edge(cr_1, cr_1_out, "cr[1]")
 
-        res = list(retworkx.lexicographical_topological_sort(dag,
-                                                             lambda x: str(x)))
-        expected = ['cr[0]', 'cr[0]_out', 'cr[1]', 'cr[1]_out', 'qr[0]',
-                    'qr[1]', 'cx_1', 'h_1', 'qr[2]', 'cx_2', 'cx_3', 'h_2',
-                    'qr[0]_out', 'qr[1]_out', 'qr[2]_out']
+        res = list(retworkx.lexicographical_topological_sort(dag, lambda x: str(x)))
+        expected = [
+            "cr[0]",
+            "cr[0]_out",
+            "cr[1]",
+            "cr[1]_out",
+            "qr[0]",
+            "qr[1]",
+            "cx_1",
+            "h_1",
+            "qr[2]",
+            "cx_2",
+            "cx_3",
+            "h_2",
+            "qr[0]_out",
+            "qr[1]_out",
+            "qr[2]_out",
+        ]
         self.assertEqual(expected, res)
 
     def test_get_node_data(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        self.assertEqual('b', dag.get_node_data(node_b))
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        self.assertEqual("b", dag.get_node_data(node_b))
 
     def test_get_node_data_bad_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "Edgy")
         self.assertRaises(IndexError, dag.get_node_data, 42)
 
     def test_pydag_length(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "Edgy")
         self.assertEqual(2, len(dag))
 
     def test_pydag_length_empty(self):
@@ -279,50 +290,50 @@ class TestNodes(unittest.TestCase):
 
     def test_get_node_data_getitem(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        self.assertEqual('b', dag[node_b])
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        self.assertEqual("b", dag[node_b])
 
     def test_get_node_data_getitem_bad_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "Edgy")
         with self.assertRaises(IndexError):
             dag[42]
 
     def test_set_node_data_setitem(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag[node_b] = 'Oh so cool'
-        self.assertEqual('Oh so cool', dag[node_b])
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag[node_b] = "Oh so cool"
+        self.assertEqual("Oh so cool", dag[node_b])
 
     def test_set_node_data_setitem_bad_index(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', "Edgy")
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", "Edgy")
         with self.assertRaises(IndexError):
-            dag[42] = 'Oh so cool'
+            dag[42] = "Oh so cool"
 
     def test_remove_node_delitem(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', "Edgy")
-        dag.add_child(node_b, 'c', "Edgy_mk2")
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "Edgy")
+        dag.add_child(node_b, "c", "Edgy_mk2")
         del dag[node_b]
         res = dag.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], dag.node_indexes())
 
     def test_remove_node_delitem_invalid_index(self):
         graph = retworkx.PyDAG()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
         with self.assertRaises(IndexError):
             del graph[76]
         res = graph.nodes()
-        self.assertEqual(['a', 'b', 'c'], res)
+        self.assertEqual(["a", "b", "c"], res)
         self.assertEqual([0, 1, 2], graph.node_indexes())
 
     def test_find_node_by_weight(self):
@@ -339,38 +350,36 @@ class TestNodes(unittest.TestCase):
 
     def test_find_node_by_weight_multiple_matches(self):
         graph = retworkx.PyDiGraph()
-        graph.add_nodes_from(['a', 'a'])
-        res = graph.find_node_by_weight('a')
+        graph.add_nodes_from(["a", "a"])
+        res = graph.find_node_by_weight("a")
         self.assertEqual(res, 0)
 
     def test_merge_nodes(self):
         graph = retworkx.PyDiGraph()
-        graph.add_nodes_from(['a', 'a', 'b', 'c'])
-        graph.add_edge(0, 2, 'edge0')
-        graph.add_edge(3, 0, 'edge1')
+        graph.add_nodes_from(["a", "a", "b", "c"])
+        graph.add_edge(0, 2, "edge0")
+        graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 1)
         self.assertEqual(graph.node_indexes(), [1, 2, 3])
-        self.assertEqual([(3, 1, 'edge1'), (1, 2, 'edge0')],
-                         graph.weighted_edge_list())
+        self.assertEqual([(3, 1, "edge1"), (1, 2, "edge0")], graph.weighted_edge_list())
 
     def test_merge_nodes_no_match(self):
         graph = retworkx.PyDiGraph()
-        graph.add_nodes_from(['a', 'a', 'b', 'c'])
-        graph.add_edge(0, 2, 'edge0')
-        graph.add_edge(3, 0, 'edge1')
+        graph.add_nodes_from(["a", "a", "b", "c"])
+        graph.add_edge(0, 2, "edge0")
+        graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 2)
         self.assertEqual(graph.node_indexes(), [0, 1, 2, 3])
-        self.assertEqual([(0, 2, 'edge0'), (3, 0, 'edge1')],
-                         graph.weighted_edge_list())
+        self.assertEqual([(0, 2, "edge0"), (3, 0, "edge1")], graph.weighted_edge_list())
 
     def test_merge_nodes_invalid_node_first_index(self):
         graph = retworkx.PyDiGraph()
-        graph.add_nodes_from(['a', 'b'])
+        graph.add_nodes_from(["a", "b"])
         with self.assertRaises(IndexError):
             graph.merge_nodes(2, 0)
 
     def test_merge_nodes_invalid_node_second_index(self):
         graph = retworkx.PyDiGraph()
-        graph.add_nodes_from(['a', 'b'])
+        graph.add_nodes_from(["a", "b"])
         with self.assertRaises(IndexError):
             graph.merge_nodes(0, 3)

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -148,7 +148,9 @@ class TestNodes(unittest.TestCase):
         dag.add_edge(node_b, node_d, "Multiple out edgy")
         dag.add_edge(node_e, node_b, "multiple in edgy")
         node_c = dag.add_child(node_b, "c", "Edgy_mk2")
-        dag.remove_node_retain_edges(node_b, condition=lambda a, b: a == "multiple in edgy")
+        dag.remove_node_retain_edges(
+            node_b, condition=lambda a, b: a == "multiple in edgy"
+        )
         res = dag.nodes()
         self.assertEqual(["a", "d", "e", "c"], res)
         self.assertEqual([0, 1, 2, 4], dag.node_indexes())
@@ -234,7 +236,9 @@ class TestNodes(unittest.TestCase):
         cr_1_out = dag.add_node("cr[1]_out")
         dag.add_edge(cr_1, cr_1_out, "cr[1]")
 
-        res = list(retworkx.lexicographical_topological_sort(dag, lambda x: str(x)))
+        res = list(
+            retworkx.lexicographical_topological_sort(dag, lambda x: str(x))
+        )
         expected = [
             "cr[0]",
             "cr[0]_out",
@@ -361,7 +365,9 @@ class TestNodes(unittest.TestCase):
         graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 1)
         self.assertEqual(graph.node_indexes(), [1, 2, 3])
-        self.assertEqual([(3, 1, "edge1"), (1, 2, "edge0")], graph.weighted_edge_list())
+        self.assertEqual(
+            [(3, 1, "edge1"), (1, 2, "edge0")], graph.weighted_edge_list()
+        )
 
     def test_merge_nodes_no_match(self):
         graph = retworkx.PyDiGraph()
@@ -370,7 +376,9 @@ class TestNodes(unittest.TestCase):
         graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 2)
         self.assertEqual(graph.node_indexes(), [0, 1, 2, 3])
-        self.assertEqual([(0, 2, "edge0"), (3, 0, "edge1")], graph.weighted_edge_list())
+        self.assertEqual(
+            [(0, 2, "edge0"), (3, 0, "edge1")], graph.weighted_edge_list()
+        )
 
     def test_merge_nodes_invalid_node_first_index(self):
         graph = retworkx.PyDiGraph()

--- a/tests/digraph/test_pred_succ.py
+++ b/tests/digraph/test_pred_succ.py
@@ -150,9 +150,21 @@ class TestBfsSuccessors(unittest.TestCase):
         node_j = dag.add_child(node_i, 9, {})
         dag.add_child(node_j, 10, {})
         res = {n: sorted(s) for n, s in retworkx.bfs_successors(dag, node_b)}
-        expected = {1: [2], 2: [3, 7], 3: [4], 4: [5], 5: [6], 7: [8], 8: [9], 9: [10]}
+        expected = {
+            1: [2],
+            2: [3, 7],
+            3: [4],
+            4: [5],
+            5: [6],
+            7: [8],
+            8: [9],
+            9: [10],
+        }
         self.assertEqual(expected, res)
-        self.assertEqual([(7, [8]), (8, [9]), (9, [10])], retworkx.bfs_successors(dag, node_h))
+        self.assertEqual(
+            [(7, [8]), (8, [9]), (9, [10])],
+            retworkx.bfs_successors(dag, node_h),
+        )
 
     def test_bfs_successors_sequence(self):
         dag = retworkx.PyDAG()

--- a/tests/digraph/test_pred_succ.py
+++ b/tests/digraph/test_pred_succ.py
@@ -18,85 +18,123 @@ import retworkx
 class TestPredecessors(unittest.TestCase):
     def test_single_predecessor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.predecessors(node_c)
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
 
     def test_single_predecessor_multiple_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_a, 'c', {'a': 2})
-        dag.add_edge(node_a, node_c, {'a': 3})
+        node_a = dag.add_node("a")
+        dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_a, "c", {"a": 2})
+        dag.add_edge(node_a, node_c, {"a": 3})
         res = dag.predecessors(node_c)
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
 
     def test_many_parents(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(10):
-            dag.add_parent(node_a, {'numeral': i}, {'edge': i})
+            dag.add_parent(node_a, {"numeral": i}, {"edge": i})
         res = dag.predecessors(node_a)
-        self.assertEqual([{'numeral': 9}, {'numeral': 8}, {'numeral': 7},
-                          {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
-                          {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
-                          {'numeral': 0}], res)
+        self.assertEqual(
+            [
+                {"numeral": 9},
+                {"numeral": 8},
+                {"numeral": 7},
+                {"numeral": 6},
+                {"numeral": 5},
+                {"numeral": 4},
+                {"numeral": 3},
+                {"numeral": 2},
+                {"numeral": 1},
+                {"numeral": 0},
+            ],
+            res,
+        )
 
 
 class TestSuccessors(unittest.TestCase):
     def test_single_successor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
-        dag.add_child(node_c, 'd', {'a': 1})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
+        dag.add_child(node_c, "d", {"a": 1})
         res = dag.successors(node_b)
-        self.assertEqual(['c'], res)
+        self.assertEqual(["c"], res)
 
     def test_single_successor_multiple_edges(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
-        dag.add_child(node_c, 'd', {'a': 1})
-        dag.add_edge(node_b, node_c, {'a': 3})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
+        dag.add_child(node_c, "d", {"a": 1})
+        dag.add_edge(node_b, node_c, {"a": 3})
         res = dag.successors(node_b)
-        self.assertEqual(['c'], res)
+        self.assertEqual(["c"], res)
 
     def test_many_children(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(10):
-            dag.add_child(node_a, {'numeral': i}, {'edge': i})
+            dag.add_child(node_a, {"numeral": i}, {"edge": i})
         res = dag.successors(node_a)
-        self.assertEqual([{'numeral': 9}, {'numeral': 8}, {'numeral': 7},
-                          {'numeral': 6}, {'numeral': 5}, {'numeral': 4},
-                          {'numeral': 3}, {'numeral': 2}, {'numeral': 1},
-                          {'numeral': 0}], res)
+        self.assertEqual(
+            [
+                {"numeral": 9},
+                {"numeral": 8},
+                {"numeral": 7},
+                {"numeral": 6},
+                {"numeral": 5},
+                {"numeral": 4},
+                {"numeral": 3},
+                {"numeral": 2},
+                {"numeral": 1},
+                {"numeral": 0},
+            ],
+            res,
+        )
 
 
 class TestBfsSuccessors(unittest.TestCase):
     def test_single_successor(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
-        node_b = dag.add_child(node_a, 'b', {'a': 1})
-        node_c = dag.add_child(node_b, 'c', {'a': 2})
-        dag.add_child(node_c, 'd', {'a': 1})
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", {"a": 1})
+        node_c = dag.add_child(node_b, "c", {"a": 2})
+        dag.add_child(node_c, "d", {"a": 1})
         res = retworkx.bfs_successors(dag, node_b)
-        self.assertEqual([('b', ['c']), ('c', ['d'])], res)
+        self.assertEqual([("b", ["c"]), ("c", ["d"])], res)
 
     def test_many_children(self):
         dag = retworkx.PyDAG()
-        node_a = dag.add_node('a')
+        node_a = dag.add_node("a")
         for i in range(10):
-            dag.add_child(node_a, {'numeral': i}, {'edge': i})
+            dag.add_child(node_a, {"numeral": i}, {"edge": i})
         res = retworkx.bfs_successors(dag, node_a)
-        self.assertEqual([('a', [{'numeral': 9}, {'numeral': 8},
-                          {'numeral': 7}, {'numeral': 6}, {'numeral': 5},
-                          {'numeral': 4}, {'numeral': 3}, {'numeral': 2},
-                          {'numeral': 1}, {'numeral': 0}])], res)
+        self.assertEqual(
+            [
+                (
+                    "a",
+                    [
+                        {"numeral": 9},
+                        {"numeral": 8},
+                        {"numeral": 7},
+                        {"numeral": 6},
+                        {"numeral": 5},
+                        {"numeral": 4},
+                        {"numeral": 3},
+                        {"numeral": 2},
+                        {"numeral": 1},
+                        {"numeral": 0},
+                    ],
+                )
+            ],
+            res,
+        )
 
     def test_bfs_succesors(self):
         dag = retworkx.PyDAG()
@@ -112,19 +150,9 @@ class TestBfsSuccessors(unittest.TestCase):
         node_j = dag.add_child(node_i, 9, {})
         dag.add_child(node_j, 10, {})
         res = {n: sorted(s) for n, s in retworkx.bfs_successors(dag, node_b)}
-        expected = {
-            1: [2],
-            2: [3, 7],
-            3: [4],
-            4: [5],
-            5: [6],
-            7: [8],
-            8: [9],
-            9: [10]
-        }
+        expected = {1: [2], 2: [3, 7], 3: [4], 4: [5], 5: [6], 7: [8], 8: [9], 9: [10]}
         self.assertEqual(expected, res)
-        self.assertEqual([(7, [8]), (8, [9]), (9, [10])],
-                         retworkx.bfs_successors(dag, node_h))
+        self.assertEqual([(7, [8]), (8, [9]), (9, [10])], retworkx.bfs_successors(dag, node_h))
 
     def test_bfs_successors_sequence(self):
         dag = retworkx.PyDAG()
@@ -148,11 +176,10 @@ class TestBfsSuccessors(unittest.TestCase):
             (8, [9]),
             (4, [5]),
             (9, [10]),
-            (5, [6])
+            (5, [6]),
         ]
         for index, expected_value in enumerate(expected):
-            self.assertEqual((res[index][0], res[index][1]),
-                             expected_value)
+            self.assertEqual((res[index][0], res[index][1]), expected_value)
 
     def test_bfs_successors_sequence_invalid_index(self):
         dag = retworkx.PyDAG()

--- a/tests/digraph/test_strongly_connected.py
+++ b/tests/digraph/test_strongly_connected.py
@@ -16,40 +16,39 @@ import retworkx
 
 
 class TestStronglyConnected(unittest.TestCase):
-
     def test_number_strongly_connected_all_strong(self):
         G = retworkx.PyDiGraph()
         node_a = G.add_node(1)
         node_b = G.add_child(node_a, 2, {})
         node_c = G.add_child(node_b, 3, {})
-        self.assertEqual(retworkx.strongly_connected_components(G),
-                         [[node_c], [node_b], [node_a]])
+        self.assertEqual(retworkx.strongly_connected_components(G), [[node_c], [node_b], [node_a]])
 
     def test_number_strongly_connected(self):
         G = retworkx.PyDiGraph()
         node_a = G.add_node(1)
         node_b = G.add_child(node_a, 2, {})
         node_c = G.add_node(3)
-        self.assertEqual(retworkx.strongly_connected_components(G),
-                         [[node_c], [node_b], [node_a]])
+        self.assertEqual(retworkx.strongly_connected_components(G), [[node_c], [node_b], [node_a]])
 
     def test_stongly_connected_no_linear(self):
         G = retworkx.PyDiGraph()
         G.add_nodes_from(list(range(8)))
-        G.add_edges_from_no_data([
-            (0, 1),
-            (1, 2),
-            (1, 7),
-            (2, 3),
-            (2, 6),
-            (3, 4),
-            (4, 2),
-            (4, 5),
-            (6, 3),
-            (6, 5),
-            (7, 0),
-            (7, 6),
-        ])
+        G.add_edges_from_no_data(
+            [
+                (0, 1),
+                (1, 2),
+                (1, 7),
+                (2, 3),
+                (2, 6),
+                (3, 4),
+                (4, 2),
+                (4, 5),
+                (6, 3),
+                (6, 5),
+                (7, 0),
+                (7, 6),
+            ]
+        )
         expected = [[5], [2, 3, 4, 6], [0, 1, 7]]
         components = retworkx.strongly_connected_components(G)
         self.assertEqual(components, expected)
@@ -59,5 +58,4 @@ class TestStronglyConnected(unittest.TestCase):
         for i in range(100000):
             node = G.add_node(i)
             G.add_child(node, str(i), {})
-        self.assertEqual(len(retworkx.strongly_connected_components(G)),
-                         200000)
+        self.assertEqual(len(retworkx.strongly_connected_components(G)), 200000)

--- a/tests/digraph/test_strongly_connected.py
+++ b/tests/digraph/test_strongly_connected.py
@@ -21,14 +21,20 @@ class TestStronglyConnected(unittest.TestCase):
         node_a = G.add_node(1)
         node_b = G.add_child(node_a, 2, {})
         node_c = G.add_child(node_b, 3, {})
-        self.assertEqual(retworkx.strongly_connected_components(G), [[node_c], [node_b], [node_a]])
+        self.assertEqual(
+            retworkx.strongly_connected_components(G),
+            [[node_c], [node_b], [node_a]],
+        )
 
     def test_number_strongly_connected(self):
         G = retworkx.PyDiGraph()
         node_a = G.add_node(1)
         node_b = G.add_child(node_a, 2, {})
         node_c = G.add_node(3)
-        self.assertEqual(retworkx.strongly_connected_components(G), [[node_c], [node_b], [node_a]])
+        self.assertEqual(
+            retworkx.strongly_connected_components(G),
+            [[node_c], [node_b], [node_a]],
+        )
 
     def test_stongly_connected_no_linear(self):
         G = retworkx.PyDiGraph()

--- a/tests/digraph/test_subgraph.py
+++ b/tests/digraph/test_subgraph.py
@@ -57,7 +57,9 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(
+            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
+        )
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0]["a"] = 4
         self.assertEqual(subgraph[0]["a"], 4)
@@ -70,7 +72,9 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(
+            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
+        )
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
         self.assertEqual(subgraph[0]["a"], 0)

--- a/tests/digraph/test_subgraph.py
+++ b/tests/digraph/test_subgraph.py
@@ -16,24 +16,23 @@ import retworkx
 
 
 class TestSubgraph(unittest.TestCase):
-
     def test_subgraph(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([1, 3])
         self.assertEqual([(0, 1, 4)], subgraph.weighted_edge_list())
-        self.assertEqual(['b', 'd'], subgraph.nodes())
+        self.assertEqual(["b", "d"], subgraph.nodes())
 
     def test_subgraph_empty_list(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([])
         self.assertEqual([], subgraph.weighted_edge_list())
@@ -41,10 +40,10 @@ class TestSubgraph(unittest.TestCase):
 
     def test_subgraph_invalid_entry(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([42])
         self.assertEqual([], subgraph.weighted_edge_list())
@@ -52,28 +51,26 @@ class TestSubgraph(unittest.TestCase):
 
     def test_subgraph_pass_by_reference(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({'a': 0})
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node({"a": 0})
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)],
-                         subgraph.weighted_edge_list())
-        self.assertEqual([{'a': 0}, 'b', 'd'], subgraph.nodes())
-        graph[0]['a'] = 4
-        self.assertEqual(subgraph[0]['a'], 4)
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
+        graph[0]["a"] = 4
+        self.assertEqual(subgraph[0]["a"], 4)
 
     def test_subgraph_replace_weight_no_reference(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({'a': 0})
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node({"a": 0})
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)],
-                         subgraph.weighted_edge_list())
-        self.assertEqual([{'a': 0}, 'b', 'd'], subgraph.nodes())
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
-        self.assertEqual(subgraph[0]['a'], 0)
+        self.assertEqual(subgraph[0]["a"], 0)

--- a/tests/digraph/test_symmetric.py
+++ b/tests/digraph/test_symmetric.py
@@ -25,6 +25,15 @@ class TestSymmetric(unittest.TestCase):
 
     def test_bidirectional_ring(self):
         digraph = retworkx.PyDiGraph()
-        edge_list = [(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2), (3, 0), (0, 3)]
+        edge_list = [
+            (0, 1),
+            (1, 0),
+            (1, 2),
+            (2, 1),
+            (2, 3),
+            (3, 2),
+            (3, 0),
+            (0, 3),
+        ]
         digraph.extend_from_edge_list(edge_list)
         self.assertTrue(digraph.is_symmetric())

--- a/tests/digraph/test_symmetric.py
+++ b/tests/digraph/test_symmetric.py
@@ -18,22 +18,13 @@ import retworkx
 class TestSymmetric(unittest.TestCase):
     def test_single_neighbor(self):
         digraph = retworkx.PyDiGraph()
-        node_a = digraph.add_node('a')
-        digraph.add_child(node_a, 'b', {'a': 1})
-        digraph.add_child(node_a, 'c', {'a': 2})
+        node_a = digraph.add_node("a")
+        digraph.add_child(node_a, "b", {"a": 1})
+        digraph.add_child(node_a, "c", {"a": 2})
         self.assertFalse(digraph.is_symmetric())
 
     def test_bidirectional_ring(self):
         digraph = retworkx.PyDiGraph()
-        edge_list = [
-            (0, 1),
-            (1, 0),
-            (1, 2),
-            (2, 1),
-            (2, 3),
-            (3, 2),
-            (3, 0),
-            (0, 3)
-        ]
+        edge_list = [(0, 1), (1, 0), (1, 2), (2, 1), (2, 3), (3, 2), (3, 0), (0, 3)]
         digraph.extend_from_edge_list(edge_list)
         self.assertTrue(digraph.is_symmetric())

--- a/tests/digraph/test_to_undirected.py
+++ b/tests/digraph/test_to_undirected.py
@@ -24,14 +24,18 @@ class TestToUndirected(unittest.TestCase):
     def test_single_direction_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         graph = digraph.to_undirected()
-        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
+        self.assertEqual(
+            digraph.weighted_edge_list(), graph.weighted_edge_list()
+        )
 
     def test_bidirectional_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         for i in range(0, 4):
             digraph.add_edge(i + 1, i, None)
         graph = digraph.to_undirected()
-        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
+        self.assertEqual(
+            digraph.weighted_edge_list(), graph.weighted_edge_list()
+        )
 
     def test_shared_ref(self):
         digraph = retworkx.PyDiGraph()

--- a/tests/digraph/test_to_undirected.py
+++ b/tests/digraph/test_to_undirected.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestToUndirected(unittest.TestCase):
-
     def test_to_undirected_empty_graph(self):
         digraph = retworkx.PyDiGraph()
         graph = digraph.to_undirected()
@@ -25,31 +24,29 @@ class TestToUndirected(unittest.TestCase):
     def test_single_direction_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         graph = digraph.to_undirected()
-        self.assertEqual(digraph.weighted_edge_list(),
-                         graph.weighted_edge_list())
+        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
 
     def test_bidirectional_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         for i in range(0, 4):
             digraph.add_edge(i + 1, i, None)
         graph = digraph.to_undirected()
-        self.assertEqual(digraph.weighted_edge_list(),
-                         graph.weighted_edge_list())
+        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
 
     def test_shared_ref(self):
         digraph = retworkx.PyDiGraph()
-        node_weight = {'a': 1}
+        node_weight = {"a": 1}
         node_a = digraph.add_node(node_weight)
-        edge_weight = {'a': 1}
-        digraph.add_child(node_a, 'b', edge_weight)
+        edge_weight = {"a": 1}
+        digraph.add_child(node_a, "b", edge_weight)
         graph = digraph.to_undirected()
-        self.assertEqual(digraph[node_a], {'a': 1})
-        self.assertEqual(graph[node_a], {'a': 1})
-        node_weight['b'] = 2
-        self.assertEqual(digraph[node_a], {'a': 1, 'b': 2})
-        self.assertEqual(graph[node_a], {'a': 1, 'b': 2})
-        self.assertEqual(digraph.get_edge_data(0, 1), {'a': 1})
-        self.assertEqual(graph.get_edge_data(0, 1), {'a': 1})
-        edge_weight['b'] = 2
-        self.assertEqual(digraph.get_edge_data(0, 1), {'a': 1, 'b': 2})
-        self.assertEqual(graph.get_edge_data(0, 1), {'a': 1, 'b': 2})
+        self.assertEqual(digraph[node_a], {"a": 1})
+        self.assertEqual(graph[node_a], {"a": 1})
+        node_weight["b"] = 2
+        self.assertEqual(digraph[node_a], {"a": 1, "b": 2})
+        self.assertEqual(graph[node_a], {"a": 1, "b": 2})
+        self.assertEqual(digraph.get_edge_data(0, 1), {"a": 1})
+        self.assertEqual(graph.get_edge_data(0, 1), {"a": 1})
+        edge_weight["b"] = 2
+        self.assertEqual(digraph.get_edge_data(0, 1), {"a": 1, "b": 2})
+        self.assertEqual(graph.get_edge_data(0, 1), {"a": 1, "b": 2})

--- a/tests/digraph/test_transitivity.py
+++ b/tests/digraph/test_transitivity.py
@@ -33,7 +33,9 @@ class TestTransitivity(unittest.TestCase):
     def test_transitivity_fulltriangle_directed(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(3)))
-        graph.add_edges_from_no_data([(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]
+        )
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 1.0)
 

--- a/tests/digraph/test_transitivity.py
+++ b/tests/digraph/test_transitivity.py
@@ -16,32 +16,24 @@ import retworkx
 
 
 class TestTransitivity(unittest.TestCase):
-
     def test_transitivity_directed(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(5)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (0, 3),
-            (1, 2)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 3 / 10)
 
     def test_transitivity_triangle_directed(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(3)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (1, 2)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (1, 2)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 0.5)
 
     def test_transitivity_fulltriangle_directed(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(3)))
-        graph.add_edges_from_no_data([
-            (0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 1.0)
 

--- a/tests/digraph/test_weakly_connected.py
+++ b/tests/digraph/test_weakly_connected.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestWeaklyConnected(unittest.TestCase):
-
     def test_number_weakly_connected_all_strong(self):
         G = retworkx.PyDAG()
         node_a = G.add_node(1)
@@ -36,51 +35,28 @@ class TestWeaklyConnected(unittest.TestCase):
         for i in range(100000):
             node = G.add_node(i)
             G.add_child(node, str(i), {})
-        self.assertEqual(retworkx.number_weakly_connected_components(G),
-                         100000)
+        self.assertEqual(retworkx.number_weakly_connected_components(G), 100000)
 
     def test_weakly_connected_components(self):
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (4, 5),
-            (5, 6),
-            (6, 7),
-            (7, 4)
-        ])
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
         components = retworkx.weakly_connected_components(graph)
         self.assertEqual([{0, 1, 2, 3}, {4, 5, 6, 7}], components)
 
     def test_is_weakly_connected_false(self):
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (4, 5),
-            (5, 6),
-            (6, 7),
-            (7, 4)
-        ])
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
         self.assertFalse(retworkx.is_weakly_connected(graph))
 
     def test_is_weakly_connected_true(self):
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (2, 4),
-            (4, 5),
-            (5, 6),
-            (6, 7),
-            (7, 4)
-        ])
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (2, 4), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
         self.assertTrue(retworkx.is_weakly_connected(graph))
 
     def test_is_weakly_connected_null_graph(self):

--- a/tests/digraph/test_weakly_connected.py
+++ b/tests/digraph/test_weakly_connected.py
@@ -55,7 +55,17 @@ class TestWeaklyConnected(unittest.TestCase):
     def test_is_weakly_connected_true(self):
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(
-            [(0, 1), (1, 2), (2, 3), (3, 0), (2, 4), (4, 5), (5, 6), (6, 7), (7, 4)]
+            [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (2, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 4),
+            ]
         )
         self.assertTrue(retworkx.is_weakly_connected(graph))
 

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestCycleGraph(unittest.TestCase):
-
     def test_directed_cycle_graph(self):
         graph = retworkx.generators.directed_cycle_graph(20)
         self.assertEqual(len(graph), 20)
@@ -26,8 +25,7 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
     def test_directed_cycle_graph_weights(self):
-        graph = retworkx.generators.directed_cycle_graph(
-            weights=list(range(20)))
+        graph = retworkx.generators.directed_cycle_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 20)
@@ -36,15 +34,12 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
     def test_directed_cycle_graph_bidirectional(self):
-        graph = retworkx.generators.directed_cycle_graph(
-            20, bidirectional=True)
+        graph = retworkx.generators.directed_cycle_graph(20, bidirectional=True)
         self.assertEqual(graph.out_edges(0), [(0, 19, None), (0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(19, 0, None), (1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(
-                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
-            self.assertEqual(
-                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
         self.assertEqual(graph.out_edges(19), [(19, 0, None), (19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(0, 19, None), (18, 19, None)])
 

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -25,7 +25,9 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
     def test_directed_cycle_graph_weights(self):
-        graph = retworkx.generators.directed_cycle_graph(weights=list(range(20)))
+        graph = retworkx.generators.directed_cycle_graph(
+            weights=list(range(20))
+        )
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 20)
@@ -38,8 +40,12 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(0), [(0, 19, None), (0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(19, 0, None), (1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
-            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
+            self.assertEqual(
+                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)]
+            )
+            self.assertEqual(
+                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)]
+            )
         self.assertEqual(graph.out_edges(19), [(19, 0, None), (19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(0, 19, None), (18, 19, None)])
 

--- a/tests/generators/test_grid.py
+++ b/tests/generators/test_grid.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestGridGraph(unittest.TestCase):
-
     def test_directed_grid_graph_dimensions(self):
         graph = retworkx.generators.directed_grid_graph(4, 5)
         self.assertEqual(len(graph), 20)
@@ -33,8 +32,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            weights=list(range(20)))
+        graph = retworkx.generators.directed_grid_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)
@@ -46,8 +44,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), [])
 
     def test_directed_grid_graph_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(20)))
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -63,8 +60,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_more_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(16)))
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(16)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(16)] + [None] * 4, graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -80,8 +76,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_less_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(24)))
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(24)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)

--- a/tests/generators/test_grid.py
+++ b/tests/generators/test_grid.py
@@ -44,7 +44,9 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), [])
 
     def test_directed_grid_graph_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(20)))
+        graph = retworkx.generators.directed_grid_graph(
+            4, 5, weights=list(range(20))
+        )
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -60,7 +62,9 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_more_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(16)))
+        graph = retworkx.generators.directed_grid_graph(
+            4, 5, weights=list(range(16))
+        )
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(16)] + [None] * 4, graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -76,7 +80,9 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_less_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(24)))
+        graph = retworkx.generators.directed_grid_graph(
+            4, 5, weights=list(range(24))
+        )
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)

--- a/tests/generators/test_mesh.py
+++ b/tests/generators/test_mesh.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestMeshGraph(unittest.TestCase):
-
     def test_directed_mesh_graph(self):
         graph = retworkx.generators.directed_mesh_graph(20)
         self.assertEqual(len(graph), 20)
@@ -29,8 +28,7 @@ class TestMeshGraph(unittest.TestCase):
             self.assertEqual(graph.out_edges(i), ls)
 
     def test_directed_mesh_graph_weights(self):
-        graph = retworkx.generators.directed_mesh_graph(
-            weights=list(range(20)))
+        graph = retworkx.generators.directed_mesh_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 380)

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestPathGraph(unittest.TestCase):
-
     def test_directed_path_graph(self):
         graph = retworkx.generators.directed_path_graph(20)
         self.assertEqual(len(graph), 20)
@@ -26,8 +25,7 @@ class TestPathGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [])
 
     def test_directed_path_graph_weights(self):
-        graph = retworkx.generators.directed_path_graph(
-            weights=list(range(20)))
+        graph = retworkx.generators.directed_path_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)
@@ -36,15 +34,12 @@ class TestPathGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [])
 
     def test_directed_path_graph_bidirectional(self):
-        graph = retworkx.generators.directed_path_graph(
-            20, bidirectional=True)
+        graph = retworkx.generators.directed_path_graph(20, bidirectional=True)
         self.assertEqual(graph.out_edges(0), [(0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(
-                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
-            self.assertEqual(
-                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
         self.assertEqual(graph.out_edges(19), [(19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(18, 19, None)])
 

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -38,8 +38,12 @@ class TestPathGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(0), [(0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
-            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
+            self.assertEqual(
+                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)]
+            )
+            self.assertEqual(
+                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)]
+            )
         self.assertEqual(graph.out_edges(19), [(19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(18, 19, None)])
 

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestStarGraph(unittest.TestCase):
-
     def test_directed_star_graph(self):
         graph = retworkx.generators.directed_star_graph(20)
         self.assertEqual(len(graph), 20)
@@ -32,8 +31,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(sorted(graph.in_edges(0)), sorted(expected_edges))
 
     def test_directed_star_graph_weights(self):
-        graph = retworkx.generators.directed_star_graph(
-            weights=list(range(20)))
+        graph = retworkx.generators.directed_star_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)
@@ -41,8 +39,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(sorted(graph.out_edges(0)), expected_edges)
 
     def test_directed_star_graph_bidirectional(self):
-        graph = retworkx.generators.directed_star_graph(
-            20, bidirectional=True)
+        graph = retworkx.generators.directed_star_graph(20, bidirectional=True)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -54,8 +51,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_directed_star_graph_bidirectional_inward(self):
-        graph = retworkx.generators.directed_star_graph(
-            20, bidirectional=True, inward=True)
+        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=True)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -65,8 +61,7 @@ class TestStarGraph(unittest.TestCase):
             self.assertEqual(graph.in_edges(i), [(0, i, None)])
         self.assertEqual(graph.out_edges(0), outw[::-1])
         self.assertEqual(graph.in_edges(0), inw[::-1])
-        graph = retworkx.generators.directed_star_graph(
-            20, bidirectional=True, inward=False)
+        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=False)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -78,8 +73,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_star_directed_graph_weights_inward(self):
-        graph = retworkx.generators.directed_star_graph(
-            weights=list(range(20)), inward=True)
+        graph = retworkx.generators.directed_star_graph(weights=list(range(20)), inward=True)
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -51,7 +51,9 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_directed_star_graph_bidirectional_inward(self):
-        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=True)
+        graph = retworkx.generators.directed_star_graph(
+            20, bidirectional=True, inward=True
+        )
         outw = []
         inw = []
         for i in range(1, 20):
@@ -61,7 +63,9 @@ class TestStarGraph(unittest.TestCase):
             self.assertEqual(graph.in_edges(i), [(0, i, None)])
         self.assertEqual(graph.out_edges(0), outw[::-1])
         self.assertEqual(graph.in_edges(0), inw[::-1])
-        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=False)
+        graph = retworkx.generators.directed_star_graph(
+            20, bidirectional=True, inward=False
+        )
         outw = []
         inw = []
         for i in range(1, 20):
@@ -73,7 +77,9 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_star_directed_graph_weights_inward(self):
-        graph = retworkx.generators.directed_star_graph(weights=list(range(20)), inward=True)
+        graph = retworkx.generators.directed_star_graph(
+            weights=list(range(20)), inward=True
+        )
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)

--- a/tests/graph/test_adj.py
+++ b/tests/graph/test_adj.py
@@ -18,15 +18,15 @@ import retworkx
 class TestAdj(unittest.TestCase):
     def test_single_neighbor(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, {'a': 1})
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_c, {'a': 2})
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, {"a": 1})
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_c, {"a": 2})
         res = graph.adj(node_a)
-        self.assertEqual({node_b: {'a': 1}, node_c: {'a': 2}}, res)
+        self.assertEqual({node_b: {"a": 1}, node_c: {"a": 2}}, res)
 
     def test_no_neighbor(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
+        node_a = graph.add_node("a")
         self.assertEqual({}, graph.adj(node_a))

--- a/tests/graph/test_adjencency_matrix.py
+++ b/tests/graph/test_adjencency_matrix.py
@@ -28,7 +28,11 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -43,7 +47,11 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -58,7 +66,11 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(
             np.array_equal(
-                np.array([[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64), res
+                np.array(
+                    [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
+                    dtype=np.float64,
+                ),
+                res,
             )
         )
 
@@ -106,7 +118,8 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
 
     def test_from_adjacency_matrix(self):
         input_array = np.array(
-            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
+            dtype=np.float64,
         )
         graph = retworkx.PyGraph.from_adjacency_matrix(input_array)
         out_array = retworkx.graph_adjacency_matrix(graph, lambda x: x)
@@ -120,13 +133,19 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
+        )
         with self.assertRaises(TypeError):
             retworkx.PyGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
-        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix.astype(np.float64, copy=False))
+        input_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
+        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(
+            input_matrix.astype(np.float64, copy=False)
+        )
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 

--- a/tests/graph/test_adjencency_matrix.py
+++ b/tests/graph/test_adjencency_matrix.py
@@ -19,69 +19,67 @@ import numpy as np
 class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_single_neighbor(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edge_a')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_b, node_c, 'edge_b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edge_a")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_b, node_c, "edge_b")
         res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_no_weight_fn(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edge_a')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_b, node_c, 'edge_b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edge_a")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_b, node_c, "edge_b")
         res = retworkx.graph_adjacency_matrix(graph)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_default_weight(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edge_a')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_b, node_c, 'edge_b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edge_a")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_b, node_c, "edge_b")
         res = retworkx.graph_adjacency_matrix(graph, default_weight=4)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array(
-                [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
-                dtype=np.float64),
-            res))
+        self.assertTrue(
+            np.array_equal(
+                np.array([[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64), res
+            )
+        )
 
     def test_float_cast_weight_func(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         res = retworkx.graph_adjacency_matrix(graph, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0.0, 7.0], [7.0, 0.0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0.0, 7.0], [7.0, 0.0]]), res))
 
     def test_multigraph_sum_cast_weight_func(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
         res = retworkx.graph_adjacency_matrix(graph, lambda x: float(x))
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0.0, 7.5], [7.5, 0.0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0.0, 7.5], [7.5, 0.0]]), res))
 
     def test_dag_to_graph_adjacency_matrix(self):
         dag = retworkx.PyDAG()
@@ -96,53 +94,44 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
 
     def test_graph_with_index_holes(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 1)
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_a, node_c, 1)
         graph.remove_node(node_b)
         res = retworkx.graph_adjacency_matrix(graph, lambda x: 1)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(np.array_equal(
-            np.array([[0, 1], [1, 0]]), res))
+        self.assertTrue(np.array_equal(np.array([[0, 1], [1, 0]]), res))
 
     def test_from_adjacency_matrix(self):
         input_array = np.array(
-            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]],
-            dtype=np.float64)
+            [[0.0, 4.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]], dtype=np.float64
+        )
         graph = retworkx.PyGraph.from_adjacency_matrix(input_array)
         out_array = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(input_array, out_array))
 
     def test_random_graph_full_path(self):
-        graph = retworkx.undirected_gnp_random_graph(100, .95, seed=42)
+        graph = retworkx.undirected_gnp_random_graph(100, 0.95, seed=42)
         adjacency_matrix = retworkx.graph_adjacency_matrix(graph)
         new_graph = retworkx.PyGraph.from_adjacency_matrix(adjacency_matrix)
         new_adjacency_matrix = retworkx.graph_adjacency_matrix(new_graph)
-        self.assertTrue(np.array_equal(adjacency_matrix,
-                                       new_adjacency_matrix))
+        self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=np.int64)
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=np.int64)
-        graph = retworkx.PyGraph.from_adjacency_matrix(
-            input_matrix.astype(np.float64, copy=False))
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix.astype(np.float64, copy=False))
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 
     def test_random_graph_float_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
-            dtype=float)
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=float)
         graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))

--- a/tests/graph/test_all_simple_paths.py
+++ b/tests/graph/test_all_simple_paths.py
@@ -142,7 +142,9 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         for i in range(6):
             graph.add_node(i)
         graph.add_edges_from_no_data(self.edges)
-        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4, cutoff=4)
+        paths = retworkx.graph_all_simple_paths(
+            graph, 0, 5, min_depth=4, cutoff=4
+        )
         expected = [
             [0, 3, 4, 5],
             [0, 3, 2, 5],
@@ -175,4 +177,6 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(TypeError, retworkx.graph_all_simple_paths, (dag, 0, 1))
+        self.assertRaises(
+            TypeError, retworkx.graph_all_simple_paths, (dag, 0, 1)
+        )

--- a/tests/graph/test_all_simple_paths.py
+++ b/tests/graph/test_all_simple_paths.py
@@ -31,7 +31,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             (4, 2),
             (4, 5),
             (5, 2),
-            (5, 3)]
+            (5, 3),
+        ]
 
     def test_all_simple_paths(self):
         graph = retworkx.PyGraph()
@@ -82,7 +83,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             [0, 1, 2, 4, 5],
             [0, 1, 2, 4, 3, 5],
             [0, 1, 2, 3, 4, 5],
-            [0, 1, 2, 3, 5]]
+            [0, 1, 2, 3, 5],
+        ]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -129,7 +131,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             [0, 2, 4, 5],
             [0, 2, 3, 5],
             [0, 1, 3, 5],
-            [0, 1, 2, 5]]
+            [0, 1, 2, 5],
+        ]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -139,8 +142,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         for i in range(6):
             graph.add_node(i)
         graph.add_edges_from_no_data(self.edges)
-        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4,
-                                                cutoff=4)
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4, cutoff=4)
         expected = [
             [0, 3, 4, 5],
             [0, 3, 2, 5],
@@ -150,7 +152,8 @@ class TestGraphAllSimplePaths(unittest.TestCase):
             [0, 2, 4, 5],
             [0, 2, 3, 5],
             [0, 1, 3, 5],
-            [0, 1, 2, 5]]
+            [0, 1, 2, 5],
+        ]
         self.assertEqual(len(expected), len(paths))
         for i in expected:
             self.assertIn(i, paths)
@@ -172,5 +175,4 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(TypeError, retworkx.graph_all_simple_paths,
-                          (dag, 0, 1))
+        self.assertRaises(TypeError, retworkx.graph_all_simple_paths, (dag, 0, 1))

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -74,7 +74,11 @@ class TestAstarGraph(unittest.TestCase):
 
         for index, end in enumerate([a, b, c, d, e, f]):
             path = retworkx.graph_astar_shortest_path(
-                g, a, lambda finish: finish_func(end, finish), lambda x: float(x), heuristic_func
+                g,
+                a,
+                lambda finish: finish_func(end, finish),
+                lambda x: float(x),
+                heuristic_func,
             )
             self.assertEqual(expected[index], path)
 
@@ -91,4 +95,6 @@ class TestAstarGraph(unittest.TestCase):
         g = retworkx.PyDAG()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.graph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)
+            retworkx.graph_astar_shortest_path(
+                g, 0, lambda x: x, lambda y: 1, lambda z: 0
+            )

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestAstarGraph(unittest.TestCase):
-
     def test_astar_null_heuristic(self):
         g = retworkx.PyGraph()
         a = g.add_node("A")
@@ -34,29 +33,28 @@ class TestAstarGraph(unittest.TestCase):
         g.add_edge(b, f, 15)
         g.add_edge(c, f, 11)
         g.add_edge(e, f, 6)
-        path = retworkx.graph_astar_shortest_path(g, a,
-                                                  lambda goal: goal == "E",
-                                                  lambda x: float(x),
-                                                  lambda y: 0)
+        path = retworkx.graph_astar_shortest_path(
+            g, a, lambda goal: goal == "E", lambda x: float(x), lambda y: 0
+        )
         expected = [a, c, d, e]
         self.assertEqual(expected, path)
 
     def test_astar_manhattan_heuristic(self):
         g = retworkx.PyGraph()
-        a = g.add_node((0., 0.))
-        b = g.add_node((2., 0.))
-        c = g.add_node((1., 1.))
-        d = g.add_node((0., 2.))
-        e = g.add_node((3., 3.))
-        f = g.add_node((4., 2.))
-        no_path = g.add_node((5., 5.))  # no path to node
-        g.add_edge(a, b, 2.)
-        g.add_edge(a, d, 4.)
-        g.add_edge(b, c, 1.)
-        g.add_edge(b, f, 7.)
-        g.add_edge(c, e, 5.)
-        g.add_edge(e, f, 1.)
-        g.add_edge(d, e, 1.)
+        a = g.add_node((0.0, 0.0))
+        b = g.add_node((2.0, 0.0))
+        c = g.add_node((1.0, 1.0))
+        d = g.add_node((0.0, 2.0))
+        e = g.add_node((3.0, 3.0))
+        f = g.add_node((4.0, 2.0))
+        no_path = g.add_node((5.0, 5.0))  # no path to node
+        g.add_edge(a, b, 2.0)
+        g.add_edge(a, d, 4.0)
+        g.add_edge(b, c, 1.0)
+        g.add_edge(b, f, 7.0)
+        g.add_edge(c, e, 5.0)
+        g.add_edge(e, f, 1.0)
+        g.add_edge(d, e, 1.0)
 
         def heuristic_func(f):
             x1, x2 = f
@@ -76,18 +74,21 @@ class TestAstarGraph(unittest.TestCase):
 
         for index, end in enumerate([a, b, c, d, e, f]):
             path = retworkx.graph_astar_shortest_path(
-                g, a, lambda finish: finish_func(end, finish),
-                lambda x: float(x), heuristic_func)
+                g, a, lambda finish: finish_func(end, finish), lambda x: float(x), heuristic_func
+            )
             self.assertEqual(expected[index], path)
 
         with self.assertRaises(retworkx.NoPathFound):
             retworkx.graph_astar_shortest_path(
-                g, a, lambda finish: finish_func(no_path, finish),
-                lambda x: float(x), heuristic_func)
+                g,
+                a,
+                lambda finish: finish_func(no_path, finish),
+                lambda x: float(x),
+                heuristic_func,
+            )
 
     def test_astar_graph_with_digraph_input(self):
         g = retworkx.PyDAG()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.graph_astar_shortest_path(
-                g, 0, lambda x: x, lambda y: 1, lambda z: 0)
+            retworkx.graph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)

--- a/tests/graph/test_complement.py
+++ b/tests/graph/test_complement.py
@@ -19,9 +19,7 @@ class TestComplement(unittest.TestCase):
     def test_clique(self):
         N = 5
         graph = retworkx.PyGraph()
-        graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i < j]
-        )
+        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -33,9 +31,7 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyGraph()
-        expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i < j]
-        )
+        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -55,22 +51,12 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyGraph()
         graph.extend_from_edge_list(
-            [
-                (j, i)
-                for i in range(N)
-                for j in range(N)
-                if i < j and (i + j) % 3 == 0
-            ]
+            [(j, i) for i in range(N) for j in range(N) if i < j and (i + j) % 3 == 0]
         )
 
         expected_graph = retworkx.PyGraph()
         expected_graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i < j and (i + j) % 3 != 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i < j and (i + j) % 3 != 0]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/graph/test_complement.py
+++ b/tests/graph/test_complement.py
@@ -19,7 +19,9 @@ class TestComplement(unittest.TestCase):
     def test_clique(self):
         N = 5
         graph = retworkx.PyGraph()
-        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
+        graph.extend_from_edge_list(
+            [(i, j) for i in range(N) for j in range(N) if i < j]
+        )
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -31,7 +33,9 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyGraph()
-        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
+        expected_graph.extend_from_edge_list(
+            [(i, j) for i in range(N) for j in range(N) if i < j]
+        )
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -51,12 +55,22 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyGraph()
         graph.extend_from_edge_list(
-            [(j, i) for i in range(N) for j in range(N) if i < j and (i + j) % 3 == 0]
+            [
+                (j, i)
+                for i in range(N)
+                for j in range(N)
+                if i < j and (i + j) % 3 == 0
+            ]
         )
 
         expected_graph = retworkx.PyGraph()
         expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i < j and (i + j) % 3 != 0]
+            [
+                (i, j)
+                for i in range(N)
+                for j in range(N)
+                if i < j and (i + j) % 3 != 0
+            ]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/graph/test_compose.py
+++ b/tests/graph/test_compose.py
@@ -16,73 +16,76 @@ import retworkx
 
 
 class TestCompose(unittest.TestCase):
-
     def test_simple_graph_composition(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, {'a': 1})
-        node_c = graph.add_node('c')
-        graph.add_edge(node_b, node_c, {'a': 2})
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, {"a": 1})
+        node_c = graph.add_node("c")
+        graph.add_edge(node_b, node_c, {"a": 2})
         graph_other = retworkx.PyGraph()
-        node_d = graph_other.add_node('d')
-        node_e = graph_other.add_node('e')
-        graph_other.add_edge(node_d, node_e, {'a': 3})
-        res = graph.compose(graph_other, {node_c: (node_d, {'b': 1})})
+        node_d = graph_other.add_node("d")
+        node_e = graph_other.add_node("e")
+        graph_other.add_edge(node_d, node_e, {"a": 3})
+        res = graph.compose(graph_other, {node_c: (node_d, {"b": 1})})
         self.assertEqual({0: 3, 1: 4}, res)
         self.assertEqual([0, 1, 2, 3, 4], graph.node_indexes())
 
     def test_edge_map_and_node_map_funcs_graph_compose(self):
         graph = retworkx.PyGraph()
-        original_input_nodes = graph.add_nodes_from(['qr[0]', 'qr[1]'])
-        original_op_nodes = graph.add_nodes_from(['h'])
-        output_nodes = graph.add_nodes_from(['qr[0]', 'qr[1]'])
-        graph.add_edge(original_input_nodes[0], original_op_nodes[0],
-                       'qr[0]')
-        graph.add_edge(original_op_nodes[0], output_nodes[0], 'qr[0]')
+        original_input_nodes = graph.add_nodes_from(["qr[0]", "qr[1]"])
+        original_op_nodes = graph.add_nodes_from(["h"])
+        output_nodes = graph.add_nodes_from(["qr[0]", "qr[1]"])
+        graph.add_edge(original_input_nodes[0], original_op_nodes[0], "qr[0]")
+        graph.add_edge(original_op_nodes[0], output_nodes[0], "qr[0]")
         # Setup other graph
         other_graph = retworkx.PyGraph()
-        input_nodes = other_graph.add_nodes_from(['qr[2]', 'qr[3]'])
-        op_nodes = other_graph.add_nodes_from(['cx'])
-        other_output_nodes = other_graph.add_nodes_from(['qr[2]', 'qr[3]'])
-        other_graph.add_edges_from([(input_nodes[0], op_nodes[0], 'qr[2]'),
-                                    (input_nodes[1], op_nodes[0], 'qr[3]')])
-        other_graph.add_edges_from([
-            (op_nodes[0], other_output_nodes[0], 'qr[2]'),
-            (op_nodes[0], other_output_nodes[1], 'qr[3]')])
+        input_nodes = other_graph.add_nodes_from(["qr[2]", "qr[3]"])
+        op_nodes = other_graph.add_nodes_from(["cx"])
+        other_output_nodes = other_graph.add_nodes_from(["qr[2]", "qr[3]"])
+        other_graph.add_edges_from(
+            [(input_nodes[0], op_nodes[0], "qr[2]"), (input_nodes[1], op_nodes[0], "qr[3]")]
+        )
+        other_graph.add_edges_from(
+            [
+                (op_nodes[0], other_output_nodes[0], "qr[2]"),
+                (op_nodes[0], other_output_nodes[1], "qr[3]"),
+            ]
+        )
 
         def map_fn(weight):
-            if weight == 'qr[2]':
-                return 'qr[0]'
-            elif weight == 'qr[3]':
-                return 'qr[1]'
+            if weight == "qr[2]":
+                return "qr[0]"
+            elif weight == "qr[3]":
+                return "qr[1]"
             else:
                 return weight
 
         graph.remove_nodes_from(output_nodes)
         other_graph.remove_nodes_from(input_nodes)
-        node_map = {original_op_nodes[0]: (op_nodes[0], 'qr[0]'),
-                    original_input_nodes[1]: (op_nodes[0], 'qr[1]')}
-        res = graph.compose(other_graph, node_map, node_map_func=map_fn,
-                            edge_map_func=map_fn)
+        node_map = {
+            original_op_nodes[0]: (op_nodes[0], "qr[0]"),
+            original_input_nodes[1]: (op_nodes[0], "qr[1]"),
+        }
+        res = graph.compose(other_graph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
-        self.assertEqual(graph[res[other_output_nodes[0]]], 'qr[0]')
-        self.assertEqual(graph[res[other_output_nodes[1]]], 'qr[1]')
+        self.assertEqual(graph[res[other_output_nodes[0]]], "qr[0]")
+        self.assertEqual(graph[res[other_output_nodes[1]]], "qr[1]")
         # qr[0] -> h
         self.assertTrue(graph.has_edge(0, 2))
-        self.assertTrue(graph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(graph.get_all_edge_data(0, 2), ["qr[0]"])
         # qr[1] -> cx
         self.assertTrue(graph.has_edge(1, 4))
-        self.assertTrue(graph.get_all_edge_data(0, 2), ['qr[1]'])
+        self.assertTrue(graph.get_all_edge_data(0, 2), ["qr[1]"])
         # h -> cx
         self.assertTrue(graph.has_edge(2, 4))
-        self.assertTrue(graph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(graph.get_all_edge_data(0, 2), ["qr[0]"])
         # cx -> qr[0]
         self.assertTrue(graph.has_edge(4, 3))
-        self.assertTrue(graph.get_all_edge_data(0, 2), ['qr[0]'])
+        self.assertTrue(graph.get_all_edge_data(0, 2), ["qr[0]"])
         # cx -> qr[1]
         self.assertTrue(graph.has_edge(4, 5))
-        self.assertTrue(graph.get_all_edge_data(0, 2), ['qr[1]'])
+        self.assertTrue(graph.get_all_edge_data(0, 2), ["qr[1]"])
 
     def test_compose_digraph_onto_graph_error(self):
         digraph = retworkx.PyDiGraph()

--- a/tests/graph/test_compose.py
+++ b/tests/graph/test_compose.py
@@ -44,7 +44,10 @@ class TestCompose(unittest.TestCase):
         op_nodes = other_graph.add_nodes_from(["cx"])
         other_output_nodes = other_graph.add_nodes_from(["qr[2]", "qr[3]"])
         other_graph.add_edges_from(
-            [(input_nodes[0], op_nodes[0], "qr[2]"), (input_nodes[1], op_nodes[0], "qr[3]")]
+            [
+                (input_nodes[0], op_nodes[0], "qr[2]"),
+                (input_nodes[1], op_nodes[0], "qr[3]"),
+            ]
         )
         other_graph.add_edges_from(
             [
@@ -67,7 +70,9 @@ class TestCompose(unittest.TestCase):
             original_op_nodes[0]: (op_nodes[0], "qr[0]"),
             original_input_nodes[1]: (op_nodes[0], "qr[1]"),
         }
-        res = graph.compose(other_graph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
+        res = graph.compose(
+            other_graph, node_map, node_map_func=map_fn, edge_map_func=map_fn
+        )
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
         self.assertEqual(graph[res[other_output_nodes[0]]], "qr[0]")
         self.assertEqual(graph[res[other_output_nodes[1]]], "qr[1]")

--- a/tests/graph/test_core_number.py
+++ b/tests/graph/test_core_number.py
@@ -82,7 +82,9 @@ class TestCoreNumber(unittest.TestCase):
     def test_undirected_all_3(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+        )
         res = retworkx.core_number(graph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/graph/test_core_number.py
+++ b/tests/graph/test_core_number.py
@@ -53,7 +53,7 @@ class TestCoreNumber(unittest.TestCase):
             (8, 19),
             (11, 16),
             (11, 17),
-            (12, 18)
+            (12, 18),
         ]
 
         example_core = {}
@@ -82,9 +82,7 @@ class TestCoreNumber(unittest.TestCase):
     def test_undirected_all_3(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
         res = retworkx.core_number(graph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/graph/test_cycle_basis.py
+++ b/tests/graph/test_cycle_basis.py
@@ -39,7 +39,9 @@ class TestCycleBasis(unittest.TestCase):
     def test_cycle_basis(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(6)))
-        graph.add_edges_from_no_data([(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)]
+        )
         res = sorted(sorted(c) for c in retworkx.cycle_basis(graph, 0))
         self.assertEqual([[0, 1, 2, 3], [0, 3, 4, 5]], res)
 
@@ -56,7 +58,9 @@ class TestCycleBasis(unittest.TestCase):
         self.graph.add_edges_from_no_data([(10, 11), (10, 12), (11, 12)])
         cycles = retworkx.cycle_basis(self.graph, 9)
         res = sorted(sorted(x) for x in cycles[:-1]) + [sorted(cycles[-1])]
-        self.assertEqual(res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [10, 11, 12]])
+        self.assertEqual(
+            res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [10, 11, 12]]
+        )
 
     def test_invalid_types(self):
         digraph = retworkx.PyDiGraph()
@@ -66,4 +70,6 @@ class TestCycleBasis(unittest.TestCase):
     def test_self_loop(self):
         self.graph.add_edge(1, 1, None)
         res = sorted(sorted(c) for c in retworkx.cycle_basis(self.graph, 0))
-        self.assertEqual([[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]], res)
+        self.assertEqual(
+            [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]], res
+        )

--- a/tests/graph/test_cycle_basis.py
+++ b/tests/graph/test_cycle_basis.py
@@ -19,26 +19,27 @@ class TestCycleBasis(unittest.TestCase):
     def setUp(self):
         self.graph = retworkx.PyGraph()
         self.graph.add_nodes_from(list(range(10)))
-        self.graph.add_edges_from_no_data([
-            (0, 1),
-            (0, 3),
-            (0, 5),
-            (0, 8),
-            (1, 2),
-            (1, 6),
-            (2, 3),
-            (3, 4),
-            (4, 5),
-            (6, 7),
-            (7, 8),
-            (8, 9)])
+        self.graph.add_edges_from_no_data(
+            [
+                (0, 1),
+                (0, 3),
+                (0, 5),
+                (0, 8),
+                (1, 2),
+                (1, 6),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (6, 7),
+                (7, 8),
+                (8, 9),
+            ]
+        )
 
     def test_cycle_basis(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(6)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)])
         res = sorted(sorted(c) for c in retworkx.cycle_basis(graph, 0))
         self.assertEqual([[0, 1, 2, 3], [0, 3, 4, 5]], res)
 
@@ -55,8 +56,7 @@ class TestCycleBasis(unittest.TestCase):
         self.graph.add_edges_from_no_data([(10, 11), (10, 12), (11, 12)])
         cycles = retworkx.cycle_basis(self.graph, 9)
         res = sorted(sorted(x) for x in cycles[:-1]) + [sorted(cycles[-1])]
-        self.assertEqual(res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5],
-                               [10, 11, 12]])
+        self.assertEqual(res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [10, 11, 12]])
 
     def test_invalid_types(self):
         digraph = retworkx.PyDiGraph()
@@ -66,5 +66,4 @@ class TestCycleBasis(unittest.TestCase):
     def test_self_loop(self):
         self.graph.add_edge(1, 1, None)
         res = sorted(sorted(c) for c in retworkx.cycle_basis(self.graph, 0))
-        self.assertEqual([[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]],
-                         res)
+        self.assertEqual([[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]], res)

--- a/tests/graph/test_deepcopy.py
+++ b/tests/graph/test_deepcopy.py
@@ -17,24 +17,23 @@ import retworkx
 
 
 class TestDeepcopy(unittest.TestCase):
-
     def test_deepcopy_returns_graph(self):
         dag_a = retworkx.PyGraph()
-        node_a = dag_a.add_node('a_1')
-        node_b = dag_a.add_node('a_2')
-        dag_a.add_edge(node_a, node_b, 'edge_1')
-        node_c = dag_a.add_node('a_3')
-        dag_a.add_edge(node_b, node_c, 'edge_2')
+        node_a = dag_a.add_node("a_1")
+        node_b = dag_a.add_node("a_2")
+        dag_a.add_edge(node_a, node_b, "edge_1")
+        node_c = dag_a.add_node("a_3")
+        dag_a.add_edge(node_b, node_c, "edge_2")
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyGraph)
 
     def test_deepcopy_with_holes_returns_graph(self):
         dag_a = retworkx.PyGraph()
-        node_a = dag_a.add_node('a_1')
-        node_b = dag_a.add_node('a_2')
-        dag_a.add_edge(node_a, node_b, 'edge_1')
-        node_c = dag_a.add_node('a_3')
-        dag_a.add_edge(node_b, node_c, 'edge_2')
+        node_a = dag_a.add_node("a_1")
+        node_b = dag_a.add_node("a_2")
+        dag_a.add_edge(node_a, node_b, "edge_1")
+        node_c = dag_a.add_node("a_3")
+        dag_a.add_edge(node_b, node_c, "edge_2")
         dag_a.remove_node(node_b)
         dag_b = copy.deepcopy(dag_a)
         self.assertIsInstance(dag_b, retworkx.PyGraph)

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -49,7 +49,9 @@ class TestDijkstraGraph(unittest.TestCase):
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
+        path = retworkx.graph_dijkstra_shortest_path_lengths(
+            self.graph, self.a, lambda x: 1
+        )
         expected = {1: 1.0, 2: 1.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
@@ -68,7 +70,9 @@ class TestDijkstraGraph(unittest.TestCase):
         g = retworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.graph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
+        path = retworkx.graph_dijkstra_shortest_path_lengths(
+            g, a, lambda x: float(x)
+        )
         expected = {}
         self.assertEqual(expected, path)
 
@@ -76,7 +80,9 @@ class TestDijkstraGraph(unittest.TestCase):
         g = retworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.graph_dijkstra_shortest_paths(g, a, weight_fn=lambda x: float(x))
+        path = retworkx.graph_dijkstra_shortest_paths(
+            g, a, weight_fn=lambda x: float(x)
+        )
         expected = {}
         self.assertEqual(expected, path)
 
@@ -88,7 +94,9 @@ class TestDijkstraGraph(unittest.TestCase):
         g.add_node("C")
         d = g.add_node("D")
         g.add_edge(b, d, 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: round(x, 1))
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(
+            g, a, lambda x: round(x, 1)
+        )
         # Computers never work:
         expected = {1: 1.2, 3: 3.5999999999999996}
         self.assertEqual(expected, path)

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestDijkstraGraph(unittest.TestCase):
-
     def setUp(self):
         self.graph = retworkx.PyGraph()
         self.a = self.graph.add_node("A")
@@ -37,27 +36,25 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra(self):
         path = retworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), self.e)
+            self.graph, self.a, lambda x: float(x), self.e
+        )
         expected = {4: 20.0}
         self.assertEqual(expected, path)
 
     def test_dijkstra_path(self):
         path = retworkx.graph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e)
-        expected = {
-            4: [0, 3, 4]
-        }
+            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+        )
+        expected = {4: [0, 3, 4]}
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: 1)
+        path = retworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
         expected = {1: 1.0, 2: 1.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
     def test_dijkstra_path_with_no_goal_set(self):
-        path = retworkx.graph_dijkstra_shortest_paths(
-            self.graph, self.a)
+        path = retworkx.graph_dijkstra_shortest_paths(self.graph, self.a)
         expected = {
             1: [0, 1],
             2: [0, 2],
@@ -69,32 +66,29 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra_with_no_path(self):
         g = retworkx.PyGraph()
-        a = g.add_node('A')
-        g.add_node('B')
-        path = retworkx.graph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: float(x))
+        a = g.add_node("A")
+        g.add_node("B")
+        path = retworkx.graph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
     def test_dijkstra_path_with_no_path(self):
         g = retworkx.PyGraph()
-        a = g.add_node('A')
-        g.add_node('B')
-        path = retworkx.graph_dijkstra_shortest_paths(
-            g, a, weight_fn=lambda x: float(x))
+        a = g.add_node("A")
+        g.add_node("B")
+        path = retworkx.graph_dijkstra_shortest_paths(g, a, weight_fn=lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_disconnected_nodes(self):
         g = retworkx.PyDiGraph()
-        a = g.add_node('A')
-        b = g.add_node('B')
+        a = g.add_node("A")
+        b = g.add_node("B")
         g.add_edge(a, b, 1.2)
-        g.add_node('C')
-        d = g.add_node('D')
+        g.add_node("C")
+        d = g.add_node("D")
         g.add_edge(b, d, 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: round(x, 1))
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: round(x, 1))
         # Computers never work:
         expected = {1: 1.2, 3: 3.5999999999999996}
         self.assertEqual(expected, path)
@@ -103,5 +97,4 @@ class TestDijkstraGraph(unittest.TestCase):
         g = retworkx.PyDAG()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.graph_dijkstra_shortest_path_lengths(
-                g, 0, lambda x: x)
+            retworkx.graph_dijkstra_shortest_path_lengths(g, 0, lambda x: x)

--- a/tests/graph/test_dist_matrix.py
+++ b/tests/graph/test_dist_matrix.py
@@ -18,33 +18,38 @@ import retworkx
 
 
 class TestDistanceMatrix(unittest.TestCase):
-
     def test_graph_distance_matrix(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_distance_matrix(graph)
-        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
-                                [1., 0., 1., 2., 3., 3., 2.],
-                                [2., 1., 0., 1., 2., 3., 3.],
-                                [3., 2., 1., 0., 1., 2., 3.],
-                                [3., 3., 2., 1., 0., 1., 2.],
-                                [2., 3., 3., 2., 1., 0., 1.],
-                                [1., 2., 3., 3., 2., 1., 0.]])
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [3.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [2.0, 3.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))
 
     def test_graph_distance_matrix_parallel(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_distance_matrix(graph, parallel_threshold=5)
-        expected = numpy.array([[0., 1., 2., 3., 3., 2., 1.],
-                                [1., 0., 1., 2., 3., 3., 2.],
-                                [2., 1., 0., 1., 2., 3., 3.],
-                                [3., 2., 1., 0., 1., 2., 3.],
-                                [3., 3., 2., 1., 0., 1., 2.],
-                                [2., 3., 3., 2., 1., 0., 1.],
-                                [1., 2., 3., 3., 2., 1., 0.]])
+        expected = numpy.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
+                [1.0, 0.0, 1.0, 2.0, 3.0, 3.0, 2.0],
+                [2.0, 1.0, 0.0, 1.0, 2.0, 3.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0, 1.0, 2.0, 3.0],
+                [3.0, 3.0, 2.0, 1.0, 0.0, 1.0, 2.0],
+                [2.0, 3.0, 3.0, 2.0, 1.0, 0.0, 1.0],
+                [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 0.0],
+            ]
+        )
         self.assertTrue(numpy.array_equal(dist, expected))

--- a/tests/graph/test_dist_matrix.py
+++ b/tests/graph/test_dist_matrix.py
@@ -21,7 +21,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.graph_distance_matrix(graph)
         expected = numpy.array(
             [
@@ -39,7 +41,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix_parallel(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.graph_distance_matrix(graph, parallel_threshold=5)
         expected = numpy.array(
             [

--- a/tests/graph/test_dot.py
+++ b/tests/graph/test_dot.py
@@ -25,8 +25,22 @@ class TestDot(unittest.TestCase):
 
     def test_graph_to_dot(self):
         graph = retworkx.PyGraph()
-        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
-        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "green",
+                "label": "a",
+                "style": "filled",
+            }
+        )
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "red",
+                "label": "a",
+                "style": "filled",
+            }
+        )
         graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'graph {\n0 [color=black, fillcolor=green, label="a", style=filled'
@@ -38,8 +52,22 @@ class TestDot(unittest.TestCase):
 
     def test_digraph_to_dot(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
-        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "green",
+                "label": "a",
+                "style": "filled",
+            }
+        )
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "red",
+                "label": "a",
+                "style": "filled",
+            }
+        )
         graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'digraph {\n0 [color=black, fillcolor=green, label="a", '
@@ -51,15 +79,31 @@ class TestDot(unittest.TestCase):
 
     def test_graph_to_dot_to_file(self):
         graph = retworkx.PyGraph()
-        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
-        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "green",
+                "label": "a",
+                "style": "filled",
+            }
+        )
+        graph.add_node(
+            {
+                "color": "black",
+                "fillcolor": "red",
+                "label": "a",
+                "style": "filled",
+            }
+        )
         graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'graph {\n0 [color=black, fillcolor=green, label="a", '
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
             'style=filled];\n0 -- 1 [label="1", name=1];\n}\n'
         )
-        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
+        res = graph.to_dot(
+            lambda node: node, lambda edge: edge, filename=self.path
+        )
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
         with open(self.path, "r") as fd:
@@ -69,16 +113,23 @@ class TestDot(unittest.TestCase):
     def test_graph_empty_dicts(self):
         graph = retworkx.undirected_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {})
-        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n2 -- 0 ;\n" "2 -- 1 ;\n}\n", dot_str)
+        self.assertEqual(
+            "graph {\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n2 -- 0 ;\n" "2 -- 1 ;\n}\n",
+            dot_str,
+        )
 
     def test_graph_graph_attrs(self):
         graph = retworkx.undirected_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
         self.assertEqual(
-            "graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n" "2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str
+            "graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n"
+            "2 -- 0 ;\n2 -- 1 ;\n}\n",
+            dot_str,
         )
 
     def test_graph_no_args(self):
         graph = retworkx.undirected_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str)
+        self.assertEqual(
+            "graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str
+        )

--- a/tests/graph/test_dot.py
+++ b/tests/graph/test_dot.py
@@ -25,65 +25,60 @@ class TestDot(unittest.TestCase):
 
     def test_graph_to_dot(self):
         graph = retworkx.PyGraph()
-        graph.add_node({'color': 'black', 'fillcolor': 'green',
-                        'label': "a", 'style': 'filled'})
-        graph.add_node({'color': 'black', 'fillcolor': 'red',
-                        'label': "a", 'style': 'filled'})
-        graph.add_edge(0, 1, dict(label='1', name='1'))
+        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
+        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'graph {\n0 [color=black, fillcolor=green, label="a", style=filled'
             '];\n1 [color=black, fillcolor=red, label="a", style=filled];'
-            '\n0 -- 1 [label="1", name=1];\n}\n')
+            '\n0 -- 1 [label="1", name=1];\n}\n'
+        )
         res = graph.to_dot(lambda node: node, lambda edge: edge)
         self.assertEqual(expected, res)
 
     def test_digraph_to_dot(self):
         graph = retworkx.PyDiGraph()
-        graph.add_node({'color': 'black', 'fillcolor': 'green',
-                        'label': "a", 'style': 'filled'})
-        graph.add_node({'color': 'black', 'fillcolor': 'red',
-                        'label': "a", 'style': 'filled'})
-        graph.add_edge(0, 1, dict(label='1', name='1'))
+        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
+        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'digraph {\n0 [color=black, fillcolor=green, label="a", '
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
-            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n')
+            'style=filled];\n0 -> 1 [label="1", name=1];\n}\n'
+        )
         res = graph.to_dot(lambda node: node, lambda edge: edge)
         self.assertEqual(expected, res)
 
     def test_graph_to_dot_to_file(self):
         graph = retworkx.PyGraph()
-        graph.add_node({'color': 'black', 'fillcolor': 'green',
-                        'label': "a", 'style': 'filled'})
-        graph.add_node({'color': 'black', 'fillcolor': 'red',
-                        'label': "a", 'style': 'filled'})
-        graph.add_edge(0, 1, dict(label='1', name='1'))
+        graph.add_node({"color": "black", "fillcolor": "green", "label": "a", "style": "filled"})
+        graph.add_node({"color": "black", "fillcolor": "red", "label": "a", "style": "filled"})
+        graph.add_edge(0, 1, dict(label="1", name="1"))
         expected = (
             'graph {\n0 [color=black, fillcolor=green, label="a", '
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
-            'style=filled];\n0 -- 1 [label="1", name=1];\n}\n')
-        res = graph.to_dot(lambda node: node, lambda edge: edge,
-                           filename=self.path)
+            'style=filled];\n0 -- 1 [label="1", name=1];\n}\n'
+        )
+        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
-        with open(self.path, 'r') as fd:
+        with open(self.path, "r") as fd:
             res = fd.read()
         self.assertEqual(expected, res)
 
     def test_graph_empty_dicts(self):
-        graph = retworkx.undirected_gnp_random_graph(3, .9, seed=42)
+        graph = retworkx.undirected_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {})
-        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n2 -- 0 ;\n"
-                         "2 -- 1 ;\n}\n", dot_str)
+        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n2 -- 0 ;\n" "2 -- 1 ;\n}\n", dot_str)
 
     def test_graph_graph_attrs(self):
-        graph = retworkx.undirected_gnp_random_graph(3, .9, seed=42)
-        dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {'bgcolor': 'red'})
-        self.assertEqual("graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n"
-                         "2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str)
+        graph = retworkx.undirected_gnp_random_graph(3, 0.9, seed=42)
+        dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
+        self.assertEqual(
+            "graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n" "2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str
+        )
 
     def test_graph_no_args(self):
-        graph = retworkx.undirected_gnp_random_graph(3, .95, seed=24)
+        graph = retworkx.undirected_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n",
-                         dot_str)
+        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str)

--- a/tests/graph/test_edgelist.py
+++ b/tests/graph/test_edgelist.py
@@ -18,21 +18,20 @@ import retworkx
 
 
 class TestEdgeList(unittest.TestCase):
-
     def test_empty_edge_list_graph(self):
         with tempfile.NamedTemporaryFile() as fd:
             graph = retworkx.PyGraph.read_edge_list(fd.name)
         self.assertEqual(graph.nodes(), [])
 
     def test_invalid_path_graph(self):
-        path = os.path.join(tempfile.gettempdir(), 'fake_file_name.txt')
+        path = os.path.join(tempfile.gettempdir(), "fake_file_name.txt")
         with self.assertRaises(FileNotFoundError):
             retworkx.PyGraph.read_edge_list(path)
 
     def test_simple_example_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('1 2\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("1 2\n")
             fd.flush()
             graph = retworkx.PyGraph.read_edge_list(fd.name)
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
@@ -43,10 +42,10 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_blank_line_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('\n')
-            fd.write('1 2\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("\n")
+            fd.write("1 2\n")
             fd.flush()
             graph = retworkx.PyGraph.read_edge_list(fd.name)
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
@@ -57,12 +56,12 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_comment_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('1 2 # test comments\n')
-            fd.write('#2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("1 2 # test comments\n")
+            fd.write("#2 3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(fd.name, comment='#')
+            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
@@ -71,12 +70,12 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_comment_leading_space_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1\n')
-            fd.write('1 2 # test comments\n')
-            fd.write('  #2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1\n")
+            fd.write("1 2 # test comments\n")
+            fd.write("  #2 3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(fd.name, comment='#')
+            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
@@ -85,32 +84,31 @@ class TestEdgeList(unittest.TestCase):
         self.assertFalse(graph.has_edge(0, 2))
 
     def test_weight_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0 1 0\n')
-            fd.write('1 2 1# test comments\n')
-            fd.write('#2 3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0 1 0\n")
+            fd.write("1 2 1# test comments\n")
+            fd.write("#2 3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(fd.name, comment='#')
+            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
         self.assertTrue(graph.has_edge(1, 0))
         self.assertTrue(graph.has_edge(2, 1))
         self.assertFalse(graph.has_edge(0, 2))
-        self.assertEqual(graph.edges(), ['0', '1'])
+        self.assertEqual(graph.edges(), ["0", "1"])
 
     def test_delim_graph(self):
-        with tempfile.NamedTemporaryFile('wt') as fd:
-            fd.write('0,1,0\n')
-            fd.write('1,2,1# test comments\n')
-            fd.write('#2,3\n')
+        with tempfile.NamedTemporaryFile("wt") as fd:
+            fd.write("0,1,0\n")
+            fd.write("1,2,1# test comments\n")
+            fd.write("#2,3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(fd.name, comment='#',
-                                                    deliminator=',')
+            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#", deliminator=",")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))
         self.assertTrue(graph.has_edge(1, 0))
         self.assertTrue(graph.has_edge(2, 1))
         self.assertFalse(graph.has_edge(0, 2))
-        self.assertEqual(graph.edges(), ['0', '1'])
+        self.assertEqual(graph.edges(), ["0", "1"])

--- a/tests/graph/test_edgelist.py
+++ b/tests/graph/test_edgelist.py
@@ -104,7 +104,9 @@ class TestEdgeList(unittest.TestCase):
             fd.write("1,2,1# test comments\n")
             fd.write("#2,3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#", deliminator=",")
+            graph = retworkx.PyGraph.read_edge_list(
+                fd.name, comment="#", deliminator=","
+            )
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -38,7 +38,9 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
+        )
 
     def test_update_edge(self):
         graph = retworkx.PyGraph()
@@ -52,7 +54,9 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.update_edge, node_a, node_b, None)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.update_edge, node_a, node_b, None
+        )
 
     def test_update_edge_by_index(self):
         graph = retworkx.PyGraph()
@@ -75,13 +79,18 @@ class TestEdges(unittest.TestCase):
         graph.add_edge(node_a, node_b, "not edgy")
         edge_index = graph.add_edge(node_a, node_b, "not edgy")
         graph.update_edge_by_index(edge_index, "Edgy")
-        self.assertEqual([(0, 1, "not edgy"), (0, 1, "Edgy")], list(graph.weighted_edge_list()))
+        self.assertEqual(
+            [(0, 1, "not edgy"), (0, 1, "Edgy")],
+            list(graph.weighted_edge_list()),
+        )
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
+        )
 
     def test_has_edge(self):
         graph = retworkx.PyGraph()
@@ -123,7 +132,9 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
+        )
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph()
@@ -189,7 +200,13 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         res = graph.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
@@ -229,7 +246,13 @@ class TestEdges(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
@@ -252,7 +275,13 @@ class TestEdges(unittest.TestCase):
     def test_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.add_edges_from(edge_list)
         self.assertEqual([(x[0], x[1]) for x in edge_list], graph.edge_list())
 
@@ -263,7 +292,13 @@ class TestEdges(unittest.TestCase):
     def test_weighted_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.add_edges_from(edge_list)
         self.assertEqual(edge_list, graph.weighted_edge_list())
 
@@ -309,7 +344,13 @@ class TestEdges(unittest.TestCase):
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyGraph()
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
 
@@ -359,13 +400,17 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
+        )
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
+        )
 
     def test_has_edge(self):
         graph = retworkx.PyGraph(False)
@@ -407,7 +452,9 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
+        self.assertRaises(
+            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
+        )
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph(False)
@@ -453,7 +500,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         res = graph.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
@@ -507,7 +560,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
@@ -561,7 +620,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyGraph(False)
-        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -16,178 +16,172 @@ import retworkx
 
 
 class TestEdges(unittest.TestCase):
-
     def test_get_edge_data(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
         res = graph.get_edge_data(node_a, node_b)
         self.assertEqual("Edgy", res)
 
     def test_get_all_edge_data(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        graph.add_edge(node_a, node_b, 'b')
+        graph.add_edge(node_a, node_b, "b")
         res = graph.get_all_edge_data(node_a, node_b)
-        self.assertIn('b', res)
-        self.assertIn('Edgy', res)
+        self.assertIn("b", res)
+        self.assertIn("Edgy", res)
 
     def test_no_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_update_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'not edgy')
-        graph.update_edge(node_a, node_b, 'Edgy')
-        self.assertEqual([(0, 1, 'Edgy')], graph.weighted_edge_list())
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "not edgy")
+        graph.update_edge(node_a, node_b, "Edgy")
+        self.assertEqual([(0, 1, "Edgy")], graph.weighted_edge_list())
 
     def test_update_edge_no_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.update_edge,
-                          node_a, node_b, None)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.update_edge, node_a, node_b, None)
 
     def test_update_edge_by_index(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        edge_index = graph.add_edge(node_a, node_b, 'not edgy')
-        graph.update_edge_by_index(edge_index, 'Edgy')
-        self.assertEqual([(0, 1, 'Edgy')], graph.weighted_edge_list())
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        edge_index = graph.add_edge(node_a, node_b, "not edgy")
+        graph.update_edge_by_index(edge_index, "Edgy")
+        self.assertEqual([(0, 1, "Edgy")], graph.weighted_edge_list())
 
     def test_update_edge_invalid_index(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
+        graph.add_node("a")
+        graph.add_node("b")
         self.assertRaises(IndexError, graph.update_edge_by_index, 0, None)
 
     def test_update_edge_parallel_edges(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'not edgy')
-        edge_index = graph.add_edge(node_a, node_b, 'not edgy')
-        graph.update_edge_by_index(edge_index, 'Edgy')
-        self.assertEqual([(0, 1, 'not edgy'), (0, 1, 'Edgy')],
-                         list(graph.weighted_edge_list()))
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "not edgy")
+        edge_index = graph.add_edge(node_a, node_b, "not edgy")
+        graph.update_edge_by_index(edge_index, "Edgy")
+        self.assertEqual([(0, 1, "not edgy"), (0, 1, "Edgy")], list(graph.weighted_edge_list()))
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, {})
         self.assertTrue(graph.has_edge(node_a, node_b))
         self.assertTrue(graph.has_edge(node_b, node_a))
 
     def test_has_edge_no_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         self.assertFalse(graph.has_edge(node_a, node_b))
 
     def test_edges(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(["Edgy", "Super edgy"], graph.edges())
 
     def test_edges_empty(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
+        graph.add_node("a")
         self.assertEqual([], graph.edges())
 
     def test_add_duplicates(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('a')
-        graph.add_edge(node_a, node_b, 'a')
-        graph.add_edge(node_a, node_b, 'b')
-        self.assertEqual(['a', 'b'], graph.edges())
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("a")
+        graph.add_edge(node_a, node_b, "a")
+        graph.add_edge(node_a, node_b, "b")
+        self.assertEqual(["a", "b"], graph.edges())
 
     def test_remove_no_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge(node_a, node_b)
         self.assertEqual([], graph.edges())
 
     def test_remove_multiple(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_b, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_b, "super_edgy")
         graph.remove_edge_from_index(0)
-        self.assertEqual(['super_edgy'], graph.edges())
+        self.assertEqual(["super_edgy"], graph.edges())
 
     def test_remove_edge_from_index(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edge_no_edge(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
+        graph.add_node("a")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edges_from(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_c, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_c, "super_edgy")
         graph.remove_edges_from([(node_a, node_b), (node_a, node_c)])
         self.assertEqual([], graph.edges())
 
     def test_remove_edges_from_invalid(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_c, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_c, "super_edgy")
         with self.assertRaises(retworkx.NoEdgeBetweenNodes):
             graph.remove_edges_from([(node_b, node_c), (node_a, node_c)])
 
     def test_degree(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(2, graph.degree(node_b))
 
@@ -195,11 +189,10 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         res = graph.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
         self.assertEqual(3, graph.degree(0))
         self.assertEqual(2, graph.degree(1))
         self.assertEqual(3, graph.degree(2))
@@ -214,8 +207,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         res = graph.add_edges_from_no_data(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual([None, None, None, None, None], graph.edges())
@@ -237,26 +229,30 @@ class TestEdges(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
 
     def test_extend_from_weighted_edge_list_edges_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e'), (0, 1, 'not_a')]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+            (0, 1, "not_a"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e', 'not_a'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e", "not_a"], graph.edges())
 
     def test_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.add_edges_from(edge_list)
         self.assertEqual([(x[0], x[1]) for x in edge_list], graph.edge_list())
 
@@ -267,8 +263,7 @@ class TestEdges(unittest.TestCase):
     def test_weighted_edge_list(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.add_edges_from(edge_list)
         self.assertEqual(edge_list, graph.weighted_edge_list())
 
@@ -278,8 +273,7 @@ class TestEdges(unittest.TestCase):
 
     def test_extend_from_edge_list(self):
         graph = retworkx.PyGraph()
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
@@ -296,8 +290,7 @@ class TestEdges(unittest.TestCase):
     def test_extend_from_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
@@ -309,16 +302,14 @@ class TestEdges(unittest.TestCase):
     def test_extend_from_edge_list_existing_edge(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3), (0, 1)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3), (0, 1)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 6, graph.edges())
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyGraph()
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
 
@@ -342,123 +333,119 @@ class TestEdges(unittest.TestCase):
 
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
-
     def test_multigraph_attr(self):
         graph = retworkx.PyGraph(multigraph=False)
         self.assertFalse(graph.multigraph)
 
     def test_get_edge_data(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
         res = graph.get_edge_data(node_a, node_b)
         self.assertEqual("Edgy", res)
 
     def test_get_all_edge_data(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        graph.add_edge(node_a, node_b, 'b')
+        graph.add_edge(node_a, node_b, "b")
         res = graph.get_all_edge_data(node_a, node_b)
-        self.assertIn('b', res)
-        self.assertNotIn('Edgy', res)
+        self.assertIn("b", res)
+        self.assertNotIn("Edgy", res)
 
     def test_no_edge(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, {})
         self.assertTrue(graph.has_edge(node_a, node_b))
         self.assertTrue(graph.has_edge(node_b, node_a))
 
     def test_has_edge_no_edge(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         self.assertFalse(graph.has_edge(node_a, node_b))
 
     def test_edges(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(["Edgy", "Super edgy"], graph.edges())
 
     def test_edges_empty(self):
         graph = retworkx.PyGraph(False)
-        graph.add_node('a')
+        graph.add_node("a")
         self.assertEqual([], graph.edges())
 
     def test_add_duplicates(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('a')
-        graph.add_edge(node_a, node_b, 'a')
-        graph.add_edge(node_a, node_b, 'b')
-        self.assertEqual(['b'], graph.edges())
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("a")
+        graph.add_edge(node_a, node_b, "a")
+        graph.add_edge(node_a, node_b, "b")
+        self.assertEqual(["b"], graph.edges())
 
     def test_remove_no_edge(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge,
-                          node_a, node_b)
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge(node_a, node_b)
         self.assertEqual([], graph.edges())
 
     def test_remove_multiple(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
-        graph.add_edge(node_a, node_b, 'super_edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
+        graph.add_edge(node_a, node_b, "super_edgy")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edge_from_index(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'edgy')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "edgy")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_remove_edge_no_edge(self):
         graph = retworkx.PyGraph(False)
-        graph.add_node('a')
+        graph.add_node("a")
         graph.remove_edge_from_index(0)
         self.assertEqual([], graph.edges())
 
     def test_degree(self):
         graph = retworkx.PyGraph(False)
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(2, graph.degree(node_b))
 
@@ -466,11 +453,10 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         res = graph.add_edges_from(edge_list)
         self.assertEqual(len(res), 5)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
         self.assertEqual(3, graph.degree(0))
         self.assertEqual(2, graph.degree(1))
         self.assertEqual(3, graph.degree(2))
@@ -485,8 +471,7 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         nodes = list(range(4))
         graph.add_nodes_from(nodes)
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         res = graph.add_edges_from_no_data(edge_list)
         self.assertEqual(len(res), 5)
         self.assertEqual([None, None, None, None, None], graph.edges())
@@ -522,25 +507,29 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_weighted_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())
 
     def test_extend_from_weighted_edge_list_edges_exist(self):
         graph = retworkx.PyGraph(False)
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e'), (0, 1, 'not_a')]
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+            (0, 1, "not_a"),
+        ]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['not_a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["not_a", "b", "c", "d", "e"], graph.edges())
 
     def test_extend_from_edge_list(self):
         graph = retworkx.PyGraph(False)
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
@@ -553,8 +542,7 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_edge_list_nodes_exist(self):
         graph = retworkx.PyGraph(False)
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
@@ -566,16 +554,14 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_extend_from_edge_list_existing_edge(self):
         graph = retworkx.PyGraph(False)
         graph.add_nodes_from(list(range(4)))
-        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3),
-                     (0, 3), (0, 1)]
+        edge_list = [(0, 1), (1, 2), (0, 2), (2, 3), (0, 3), (0, 1)]
         graph.extend_from_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
         self.assertEqual([None] * 5, graph.edges())
 
     def test_extend_from_weighted_edge_list(self):
         graph = retworkx.PyGraph(False)
-        edge_list = [(0, 1, 'a'), (1, 2, 'b'), (0, 2, 'c'), (2, 3, 'd'),
-                     (0, 3, 'e')]
+        edge_list = [(0, 1, "a"), (1, 2, "b"), (0, 2, "c"), (2, 3, "d"), (0, 3, "e")]
         graph.extend_from_weighted_edge_list(edge_list)
         self.assertEqual(len(graph), 4)
-        self.assertEqual(['a', 'b', 'c', 'd', 'e'], graph.edges())
+        self.assertEqual(["a", "b", "c", "d", "e"], graph.edges())

--- a/tests/graph/test_floyd_warshall.py
+++ b/tests/graph/test_floyd_warshall.py
@@ -72,7 +72,9 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_cycle(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -93,7 +95,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -104,7 +108,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 3)
@@ -113,7 +119,9 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/graph/test_floyd_warshall.py
+++ b/tests/graph/test_floyd_warshall.py
@@ -35,16 +35,18 @@ class TestFloydWarshall(unittest.TestCase):
     def test_weighted_numpy_two_edges(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
-        graph.add_edges_from([
-            (0, 1, 2),
-            (1, 2, 2),
-            (2, 3, 1),
-            (3, 4, 1),
-            (4, 5, 1),
-            (5, 6, 1),
-            (6, 7, 1),
-            (7, 0, 1),
-        ])
+        graph.add_edges_from(
+            [
+                (0, 1, 2),
+                (1, 2, 2),
+                (2, 3, 1),
+                (3, 4, 1),
+                (4, 5, 1),
+                (5, 6, 1),
+                (6, 7, 1),
+                (7, 0, 1),
+            ]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: x, parallel_threshold=self.parallel_threshold
         )
@@ -54,12 +56,14 @@ class TestFloydWarshall(unittest.TestCase):
     def test_weighted_numpy_negative_cycle(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        graph.add_edges_from([
-            (0, 1, 1),
-            (1, 2, -1),
-            (2, 3, -1),
-            (3, 0, -1),
-        ])
+        graph.add_edges_from(
+            [
+                (0, 1, 1),
+                (1, 2, -1),
+                (2, 3, -1),
+                (3, 0, -1),
+            ]
+        )
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: x, parallel_threshold=self.parallel_threshold
         )
@@ -68,8 +72,7 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_cycle(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -90,8 +93,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -102,8 +104,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 3)
@@ -112,8 +113,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -21,40 +21,58 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
+                self.assertTrue(
+                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
+                )
 
     def test_isomorphic_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
+                self.assertTrue(
+                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
+                )
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_is_isomorphic_nodes_compare_raises(self):
@@ -62,29 +80,41 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(TypeError, retworkx.is_isomorphic, (g_a, g_b, compare_nodes))
+        self.assertRaises(
+            TypeError, retworkx.is_isomorphic, (g_a, g_b, compare_nodes)
+        )
 
     def test_isomorphic_compare_nodes_identical(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_isomorphic_compare_edges_identical(self):
@@ -92,15 +122,22 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
                     retworkx.is_isomorphic(
-                        g_a, g_b, edge_matcher=lambda x, y: x == y, id_order=id_order
+                        g_a,
+                        g_b,
+                        edge_matcher=lambda x, y: x == y,
+                        id_order=id_order,
                     )
                 )
 
@@ -109,7 +146,9 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
 
         nodes = g_b.add_nodes_from(["a_0", "a_2", "a_1", "a_3"])
         g_b.add_edges_from(
@@ -124,7 +163,9 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                    retworkx.is_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
                 )
 
     def test_isomorphic_node_count_not_equal(self):
@@ -139,13 +180,17 @@ class TestIsomorphic(unittest.TestCase):
         g_b.remove_node(nodes[0])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
+                self.assertFalse(
+                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
+                )
 
     def test_same_degrees_non_isomorphic(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
+        nodes = g_a.add_nodes_from(
+            ["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"]
+        )
         g_a.add_edges_from(
             [
                 (nodes[0], nodes[1], "a_1"),
@@ -161,7 +206,9 @@ class TestIsomorphic(unittest.TestCase):
             ]
         )
 
-        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
+        nodes = g_b.add_nodes_from(
+            ["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"]
+        )
         g_b.add_edges_from(
             [
                 (nodes[0], nodes[1], "a_1"),
@@ -178,4 +225,6 @@ class TestIsomorphic(unittest.TestCase):
         )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
+                self.assertFalse(
+                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
+                )

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -16,205 +16,166 @@ import retworkx
 
 
 class TestIsomorphic(unittest.TestCase):
-
     def test_isomorphic_identical(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, id_order=id_order))
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_isomorphic_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
-        ])
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, id_order=id_order))
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
-        ])
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_is_isomorphic_nodes_compare_raises(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['b_1', 'b_2', 'b_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'b_1'), (nodes[1], nodes[2], 'b_2')
-        ])
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(
-            TypeError,
-            retworkx.is_isomorphic,
-            (g_a, g_b, compare_nodes))
+        self.assertRaises(TypeError, retworkx.is_isomorphic, (g_a, g_b, compare_nodes))
 
     def test_isomorphic_compare_nodes_identical(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_isomorphic_compare_edges_identical(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
                     retworkx.is_isomorphic(
-                        g_a, g_b, edge_matcher=lambda x, y: x == y,
-                        id_order=id_order))
+                        g_a, g_b, edge_matcher=lambda x, y: x == y, id_order=id_order
+                    )
+                )
 
     def test_isomorphic_removed_nodes_in_second_graph(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'), (nodes[1], nodes[2], 'a_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
-        nodes = g_b.add_nodes_from(['a_0', 'a_2', 'a_1', 'a_3'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'e_01'), (nodes[0], nodes[3], 'e_03'),
-            (nodes[2], nodes[1], 'a_1'), (nodes[1], nodes[3], 'a_2')
-        ])
+        nodes = g_b.add_nodes_from(["a_0", "a_2", "a_1", "a_3"])
+        g_b.add_edges_from(
+            [
+                (nodes[0], nodes[1], "e_01"),
+                (nodes[0], nodes[3], "e_03"),
+                (nodes[2], nodes[1], "a_1"),
+                (nodes[1], nodes[3], "a_2"),
+            ]
+        )
         g_b.remove_node(nodes[0])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order))
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
+                )
 
     def test_isomorphic_node_count_not_equal(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(['a_1', 'a_2', 'a_3'])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1")])
 
-        nodes = g_b.add_nodes_from(['a_0', 'a_1'])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'a_1')
-        ])
+        nodes = g_b.add_nodes_from(["a_0", "a_1"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1")])
         g_b.remove_node(nodes[0])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, id_order=id_order))
+                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_same_degrees_non_isomorphic(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from([
-            'a_1', 'a_2', 'a_3', 'a_4',
-            'b_1', 'b_2', 'b_3', 'b_4'
-        ])
-        g_a.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'),
-            (nodes[1], nodes[2], 'a_2'),
-            (nodes[2], nodes[3], 'a_3'),
-            (nodes[3], nodes[0], 'a_4'),
-            (nodes[4], nodes[5], 'b_1'),
-            (nodes[5], nodes[6], 'b_2'),
-            (nodes[6], nodes[7], 'b_3'),
-            (nodes[7], nodes[4], 'b_4'),
-            (nodes[0], nodes[4], 'e_1'),
-            (nodes[1], nodes[5], 'e_2')
-        ])
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"),
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[2], nodes[3], "a_3"),
+                (nodes[3], nodes[0], "a_4"),
+                (nodes[4], nodes[5], "b_1"),
+                (nodes[5], nodes[6], "b_2"),
+                (nodes[6], nodes[7], "b_3"),
+                (nodes[7], nodes[4], "b_4"),
+                (nodes[0], nodes[4], "e_1"),
+                (nodes[1], nodes[5], "e_2"),
+            ]
+        )
 
-        nodes = g_b.add_nodes_from([
-            'a_1', 'a_2', 'a_3', 'a_4',
-            'b_1', 'b_2', 'b_3', 'b_4'
-        ])
-        g_b.add_edges_from([
-            (nodes[0], nodes[1], 'a_1'),
-            (nodes[1], nodes[2], 'a_2'),
-            (nodes[2], nodes[3], 'a_3'),
-            (nodes[3], nodes[0], 'a_4'),
-            (nodes[4], nodes[5], 'b_1'),
-            (nodes[5], nodes[6], 'b_2'),
-            (nodes[6], nodes[7], 'b_3'),
-            (nodes[7], nodes[4], 'b_4'),
-            (nodes[0], nodes[4], 'e_1'),
-            (nodes[2], nodes[6], 'e_2')
-        ])
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
+        g_b.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"),
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[2], nodes[3], "a_3"),
+                (nodes[3], nodes[0], "a_4"),
+                (nodes[4], nodes[5], "b_1"),
+                (nodes[5], nodes[6], "b_2"),
+                (nodes[6], nodes[7], "b_3"),
+                (nodes[7], nodes[4], "b_4"),
+                (nodes[0], nodes[4], "e_1"),
+                (nodes[2], nodes[6], "e_2"),
+            ]
+        )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, id_order=id_order))
+                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -16,21 +16,12 @@ import retworkx
 
 
 class TestKShortestpath(unittest.TestCase):
-
     def test_graph_k_shortest_path_lengths(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
-        graph.add_edges_from_no_data([
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 0),
-            (4, 5),
-            (1, 4),
-            (5, 6),
-            (6, 7),
-            (7, 5)
-        ])
+        graph.add_edges_from_no_data(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+        )
         res = retworkx.graph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1)
         expected = {0: 3, 1: 2, 2: 3, 3: 2, 4: 3, 5: 4, 6: 4, 7: 4}
         self.assertEqual(res, expected)
@@ -38,8 +29,6 @@ class TestKShortestpath(unittest.TestCase):
     def test_k_graph_shortest_path_with_goal(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        res = retworkx.graph_k_shortest_path_lengths(graph, 0, 2, lambda _: 1,
-                                                     3)
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        res = retworkx.graph_k_shortest_path_lengths(graph, 0, 2, lambda _: 1, 3)
         self.assertEqual({3: 4}, res)

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -20,7 +20,17 @@ class TestKShortestpath(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.add_edges_from_no_data(
-            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (1, 4), (5, 6), (6, 7), (7, 5)]
+            [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (4, 5),
+                (1, 4),
+                (5, 6),
+                (6, 7),
+                (7, 5),
+            ]
         )
         res = retworkx.graph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1)
         expected = {0: 3, 1: 2, 2: 3, 3: 2, 4: 3, 5: 4, 6: 4, 7: 4}
@@ -29,6 +39,10 @@ class TestKShortestpath(unittest.TestCase):
     def test_k_graph_shortest_path_with_goal(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
-        res = retworkx.graph_k_shortest_path_lengths(graph, 0, 2, lambda _: 1, 3)
+        graph.add_edges_from_no_data(
+            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
+        )
+        res = retworkx.graph_k_shortest_path_lengths(
+            graph, 0, 2, lambda _: 1, 3
+        )
         self.assertEqual({3: 4}, res)

--- a/tests/graph/test_layout.py
+++ b/tests/graph/test_layout.py
@@ -16,7 +16,6 @@ import retworkx
 
 
 class TestRandomLayout(unittest.TestCase):
-
     def setUp(self):
         self.graph = retworkx.generators.path_graph(10)
 
@@ -32,13 +31,12 @@ class TestRandomLayout(unittest.TestCase):
             6: (0.462700947802672, 0.44025745918644743),
             7: (0.3125895420208278, 0.0893209773065271),
             8: (0.5567725240957387, 0.21079648777222115),
-            9: (0.7586719404939911, 0.43090704138697045)
+            9: (0.7586719404939911, 0.43090704138697045),
         }
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.graph_random_layout(self.graph, center=(0.5, 0.5),
-                                           seed=42)
+        res = retworkx.graph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],
@@ -49,7 +47,7 @@ class TestRandomLayout(unittest.TestCase):
             0: [0.7265125179283135, 0.7391066903185995],
             2: [1.4704763177409157, 0.8754626814145194],
             6: [0.962700947802672, 0.9402574591864474],
-            3: [0.6879083014236631, 1.0246576629278041]
+            3: [0.6879083014236631, 1.0246576629278041],
         }
         self.assertEqual(expected, res)
 

--- a/tests/graph/test_layout.py
+++ b/tests/graph/test_layout.py
@@ -36,7 +36,9 @@ class TestRandomLayout(unittest.TestCase):
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.graph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
+        res = retworkx.graph_random_layout(
+            self.graph, center=(0.5, 0.5), seed=42
+        )
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],

--- a/tests/graph/test_matching.py
+++ b/tests/graph/test_matching.py
@@ -15,7 +15,6 @@ import retworkx
 
 
 class TestMatching(unittest.TestCase):
-
     def test_valid(self):
         graph = retworkx.generators.path_graph(4)
         matching = {(0, 1), (2, 3)}

--- a/tests/graph/test_max_weight_matching.py
+++ b/tests/graph/test_max_weight_matching.py
@@ -27,26 +27,23 @@ def match_dict_to_set(match):
 
 
 class TestMaxWeightMatching(testtools.TestCase):
-
     def setUp(self):
         super().setUp()
-        stdout = self.useFixture(fixtures.StringStream('stdout')).stream
-        self.useFixture(fixtures.MonkeyPatch('sys.stdout', stdout))
-        stderr = self.useFixture(fixtures.StringStream('stderr')).stream
-        self.useFixture(fixtures.MonkeyPatch('sys.stderr', stderr))
+        stdout = self.useFixture(fixtures.StringStream("stdout")).stream
+        self.useFixture(fixtures.MonkeyPatch("sys.stdout", stdout))
+        stderr = self.useFixture(fixtures.StringStream("stderr")).stream
+        self.useFixture(fixtures.MonkeyPatch("sys.stderr", stderr))
 
     def compare_match_sets(self, rx_match, expected_match):
         for (u, v) in rx_match:
-            if (u, v) not in expected_match and \
-                    (v, u) not in expected_match:
-                self.fail("Element %s and it's reverse %s not found in "
-                          "expected output.\nretworkx output: %s\nexpected "
-                          "output: %s" % (
-                              (u, v), (v, u), rx_match, expected_match))
+            if (u, v) not in expected_match and (v, u) not in expected_match:
+                self.fail(
+                    "Element %s and it's reverse %s not found in "
+                    "expected output.\nretworkx output: %s\nexpected "
+                    "output: %s" % ((u, v), (v, u), rx_match, expected_match)
+                )
 
-    def compare_rx_nx_sets(self, rx_graph, rx_matches, nx_matches, seed,
-                           nx_graph):
-
+    def compare_rx_nx_sets(self, rx_graph, rx_matches, nx_matches, seed, nx_graph):
         def get_rx_weight(edge):
             weight = rx_graph.get_edge_data(*edge)
             if weight is None:
@@ -57,27 +54,40 @@ class TestMaxWeightMatching(testtools.TestCase):
             weight = nx_graph.get_edge_data(*edge)
             if not weight:
                 return 1
-            return weight['weight']
+            return weight["weight"]
 
         not_match = False
         for (u, v) in rx_matches:
             if (u, v) not in nx_matches:
                 if (v, u) not in nx_matches:
-                    print("seed %s failed. Element %s and it's "
-                          "reverse %s not found in networkx output.\nretworkx"
-                          " output: %s\nnetworkx output: %s\nedge list: %s\n"
-                          "falling back to checking for a valid solution" % (
-                              seed, (u, v), (v, u), rx_matches,
-                              nx_matches, list(rx_graph.weighted_edge_list())))
+                    print(
+                        "seed %s failed. Element %s and it's "
+                        "reverse %s not found in networkx output.\nretworkx"
+                        " output: %s\nnetworkx output: %s\nedge list: %s\n"
+                        "falling back to checking for a valid solution"
+                        % (
+                            seed,
+                            (u, v),
+                            (v, u),
+                            rx_matches,
+                            nx_matches,
+                            list(rx_graph.weighted_edge_list()),
+                        )
+                    )
                     not_match = True
                     break
         if not_match:
-            self.assertTrue(retworkx.is_matching(rx_graph, rx_matches),
-                            "%s is not a valid matching" % rx_matches)
-            self.assertTrue(retworkx.is_maximal_matching(rx_graph, rx_matches),
-                            "%s is not a maximal matching" % rx_matches)
-            self.assertEqual(sum(map(get_rx_weight, rx_matches)),
-                             sum(map(get_nx_weight, nx_matches)))
+            self.assertTrue(
+                retworkx.is_matching(rx_graph, rx_matches),
+                "%s is not a valid matching" % rx_matches,
+            )
+            self.assertTrue(
+                retworkx.is_maximal_matching(rx_graph, rx_matches),
+                "%s is not a maximal matching" % rx_matches,
+            )
+            self.assertEqual(
+                sum(map(get_rx_weight, rx_matches)), sum(map(get_nx_weight, nx_matches))
+            )
 
     def test_empty_graph(self):
         graph = retworkx.PyGraph()
@@ -89,7 +99,10 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph.add_edges_from([(0, 1, 1)])
         self.compare_match_sets(
             retworkx.max_weight_matching(graph, verify_optimum=True),
-            {(0, 1), })
+            {
+                (0, 1),
+            },
+        )
 
     def test_single_edge_no_verification(self):
         graph = retworkx.PyGraph()
@@ -97,7 +110,10 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph.add_edges_from([(0, 1, 1)])
         self.compare_match_sets(
             retworkx.max_weight_matching(graph, verify_optimum=False),
-            {(0, 1), })
+            {
+                (0, 1),
+            },
+        )
 
     def test_single_self_edge(self):
         graph = retworkx.PyGraph()
@@ -108,310 +124,334 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 10), (2, 3, 11)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(2, 3), })
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {
+                (2, 3),
+            },
+        )
 
     def test_path_graph(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list(
-            [(1, 2, 5), (2, 3, 11), (3, 4, 5)])
+        graph.extend_from_weighted_edge_list([(1, 2, 5), (2, 3, 11), (3, 4, 5)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(2, 3), })
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {
+                (2, 3),
+            },
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), (3, 4)})
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 2), (3, 4)},
+        )
 
     def test_negative_weights(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 2),
-            (1, 3, -2),
-            (2, 3, 1),
-            (2, 4, -1),
-            (3, 4, -6),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 2),
+                (1, 3, -2),
+                (2, 3, 1),
+                (2, 4, -1),
+                (3, 4, -6),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), })
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {
+                (1, 2),
+            },
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 3), (2, 4)})
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 3), (2, 4)},
+        )
 
     def test_s_blossom(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (0, 1, 8),
-            (0, 2, 9),
-            (1, 2, 10),
-            (2, 3, 7),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (0, 1, 8),
+                (0, 2, 9),
+                (1, 2, 10),
+                (2, 3, 7),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(0, 1), (2, 3)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(0, 1), (2, 3)},
+        )
         graph.extend_from_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(0, 5), (1, 2), (3, 4)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(0, 5), (1, 2), (3, 4)},
+        )
 
     def test_s_t_blossom(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 9),
-            (1, 3, 8),
-            (2, 3, 10),
-            (1, 4, 5),
-            (4, 5, 4),
-            (1, 6, 3),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 9),
+                (1, 3, 8),
+                (2, 3, 10),
+                (1, 4, 5),
+                (4, 5, 4),
+                (1, 6, 3),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 6), (2, 3), (4, 5)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 6), (2, 3), (4, 5)},
+        )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 5)
         graph.extend_from_weighted_edge_list([(4, 5, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 6), (2, 3), (4, 5)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 6), (2, 3), (4, 5)},
+        )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), (3, 6), (4, 5)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 2), (3, 6), (4, 5)},
+        )
 
     def test_s_t_blossom_with_removed_nodes(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 9),
-            (1, 3, 8),
-            (2, 3, 10),
-            (1, 4, 5),
-            (4, 5, 4),
-            (1, 6, 3),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 9),
+                (1, 3, 8),
+                (2, 3, 10),
+                (1, 4, 5),
+                (4, 5, 4),
+                (1, 6, 3),
+            ]
+        )
         node_id = graph.add_node(None)
         graph.remove_node(5)
         graph.add_edge(4, node_id, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 6), (2, 3), (4, 7)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 6), (2, 3), (4, 7)},
+        )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 7)
         graph.extend_from_weighted_edge_list([(4, node_id, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 6), (2, 3), (4, 7)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 6), (2, 3), (4, 7)},
+        )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), (3, 6), (4, 7)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 2), (3, 6), (4, 7)},
+        )
 
     def test_nested_s_blossom(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 9),
-            (1, 3, 9),
-            (2, 3, 10),
-            (2, 4, 8),
-            (3, 5, 8),
-            (4, 5, 10),
-            (5, 6, 6),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 9),
+                (1, 3, 9),
+                (2, 3, 10),
+                (2, 4, 8),
+                (3, 5, 8),
+                (4, 5, 10),
+                (5, 6, 6),
+            ]
+        )
         expected = {(1, 3), (2, 4), (5, 6)}
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            expected)
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            expected,
+        )
 
     def test_nested_s_blossom_relabel(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 10),
-            (1, 7, 10),
-            (2, 3, 12),
-            (3, 4, 20),
-            (3, 5, 20),
-            (4, 5, 25),
-            (5, 6, 10),
-            (6, 7, 10),
-            (7, 8, 8),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 10),
+                (1, 7, 10),
+                (2, 3, 12),
+                (3, 4, 20),
+                (3, 5, 20),
+                (4, 5, 25),
+                (5, 6, 10),
+                (6, 7, 10),
+                (7, 8, 8),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), (3, 4), (5, 6), (7, 8)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 2), (3, 4), (5, 6), (7, 8)},
+        )
 
     def test_nested_s_blossom_expand(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 8),
-            (1, 3, 8),
-            (2, 3, 10),
-            (2, 4, 12),
-            (3, 5, 12),
-            (4, 5, 14),
-            (4, 6, 12),
-            (5, 7, 12),
-            (6, 7, 14),
-            (7, 8, 12),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 8),
+                (1, 3, 8),
+                (2, 3, 10),
+                (2, 4, 12),
+                (3, 5, 12),
+                (4, 5, 14),
+                (4, 6, 12),
+                (5, 7, 12),
+                (6, 7, 14),
+                (7, 8, 12),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 2), (3, 5), (4, 6), (7, 8)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 2), (3, 5), (4, 6), (7, 8)},
+        )
 
     def test_s_blossom_relabel_expand(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 23),
-            (1, 5, 22),
-            (1, 6, 15),
-            (2, 3, 25),
-            (3, 4, 22),
-            (4, 5, 25),
-            (4, 8, 14),
-            (5, 7, 13),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 23),
+                (1, 5, 22),
+                (1, 6, 15),
+                (2, 3, 25),
+                (3, 4, 22),
+                (4, 5, 25),
+                (4, 8, 14),
+                (5, 7, 13),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            {(1, 6), (2, 3), (4, 8), (5, 7)})
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            {(1, 6), (2, 3), (4, 8), (5, 7)},
+        )
 
     def test_nested_s_blossom_relabel_expand(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 19),
-            (1, 3, 20),
-            (1, 8, 8),
-            (2, 3, 25),
-            (2, 4, 18),
-            (3, 5, 18),
-            (4, 5, 13),
-            (4, 7, 7),
-            (5, 6, 7),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 19),
+                (1, 3, 20),
+                (1, 8, 8),
+                (2, 3, 25),
+                (2, 4, 18),
+                (3, 5, 18),
+                (4, 5, 13),
+                (4, 7, 7),
+                (5, 6, 7),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(
-                {1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1}))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1}),
+        )
 
     def test_blossom_relabel_multiple_paths(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 45),
-            (1, 5, 45),
-            (2, 3, 50),
-            (3, 4, 45),
-            (4, 5, 50),
-            (1, 6, 30),
-            (3, 9, 35),
-            (4, 8, 35),
-            (5, 7, 26),
-            (9, 10, 5),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 45),
+                (1, 5, 45),
+                (2, 3, 50),
+                (3, 4, 45),
+                (4, 5, 50),
+                (1, 6, 30),
+                (3, 9, 35),
+                (4, 8, 35),
+                (5, 7, 26),
+                (9, 10, 5),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
-                 10: 9}))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+        )
 
     def test_blossom_relabel_multiple_path_alternate(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 45),
-            (1, 5, 45),
-            (2, 3, 50),
-            (3, 4, 45),
-            (4, 5, 50),
-            (1, 6, 30),
-            (3, 9, 35),
-            (4, 8, 26),
-            (5, 7, 40),
-            (9, 10, 5),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 45),
+                (1, 5, 45),
+                (2, 3, 50),
+                (3, 4, 45),
+                (4, 5, 50),
+                (1, 6, 30),
+                (3, 9, 35),
+                (4, 8, 26),
+                (5, 7, 40),
+                (9, 10, 5),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
-                 10: 9}))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+        )
 
     def test_blossom_relabel_multiple_paths_least_slack(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 45),
-            (1, 5, 45),
-            (2, 3, 50),
-            (3, 4, 45),
-            (4, 5, 50),
-            (1, 6, 30),
-            (3, 9, 35),
-            (4, 8, 28),
-            (5, 7, 26),
-            (9, 10, 5),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 45),
+                (1, 5, 45),
+                (2, 3, 50),
+                (3, 4, 45),
+                (4, 5, 50),
+                (1, 6, 30),
+                (3, 9, 35),
+                (4, 8, 28),
+                (5, 7, 26),
+                (9, 10, 5),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10,
-                 10: 9}))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+        )
 
     def test_nested_blossom_expand_recursively(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 40),
-            (1, 3, 40),
-            (2, 3, 60),
-            (2, 4, 55),
-            (3, 5, 55),
-            (4, 5, 50),
-            (1, 8, 15),
-            (5, 7, 30),
-            (7, 6, 10),
-            (8, 10, 10),
-            (4, 9, 30),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 40),
+                (1, 3, 40),
+                (2, 3, 60),
+                (2, 4, 55),
+                (3, 5, 55),
+                (4, 5, 50),
+                (1, 8, 15),
+                (5, 7, 30),
+                (7, 6, 10),
+                (8, 10, 10),
+                (4, 9, 30),
+            ]
+        )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(
-                {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4,
-                 10: 8}))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}),
+        )
 
     def test_nested_blossom_augmented(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list([
-            (1, 2, 45),
-            (1, 7, 45),
-            (2, 3, 50),
-            (3, 4, 45),
-            (4, 5, 95),
-            (4, 6, 94),
-            (5, 6, 94),
-            (6, 7, 50),
-            (1, 8, 30),
-            (3, 11, 35),
-            (5, 9, 36),
-            (7, 10, 26),
-            (11, 12, 5),
-        ])
+        graph.extend_from_weighted_edge_list(
+            [
+                (1, 2, 45),
+                (1, 7, 45),
+                (2, 3, 50),
+                (3, 4, 45),
+                (4, 5, 95),
+                (4, 6, 94),
+                (5, 6, 94),
+                (6, 7, 50),
+                (1, 8, 30),
+                (3, 11, 35),
+                (5, 9, 36),
+                (7, 10, 26),
+                (11, 12, 5),
+            ]
+        )
         expected = {
             1: 8,
             2: 3,
@@ -427,119 +467,104 @@ class TestMaxWeightMatching(testtools.TestCase):
             12: 11,
         }
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x,
-                                         verify_optimum=True),
-            match_dict_to_set(expected))
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set(expected),
+        )
 
     def test_gnp_random_against_networkx(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
             nx_graph = networkx.Graph(list(rx_graph.edge_list()))
             nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                      verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                    42 + i, nx_graph)
+            rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_weight(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(0, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+            )
             nx_matches = networkx.max_weight_matching(nx_graph)
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                    42 + i, nx_graph)
+                rx_graph, weight_fn=lambda x: x, verify_optimum=True
+            )
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_negative_weight(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(-5000, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
+                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+            )
             nx_matches = networkx.max_weight_matching(nx_graph)
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                    42 + i, nx_graph)
+                rx_graph, weight_fn=lambda x: x, verify_optimum=True
+            )
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_max_cardinality(self):
-        rx_graph = retworkx.undirected_gnp_random_graph(10, .78, seed=428)
+        rx_graph = retworkx.undirected_gnp_random_graph(10, 0.78, seed=428)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
-        nx_matches = networkx.max_weight_matching(
-            nx_graph, maxcardinality=True)
+        nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
         rx_matches = retworkx.max_weight_matching(
-            rx_graph, max_cardinality=True, verify_optimum=True)
-        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 428,
-                                nx_graph)
+            rx_graph, max_cardinality=True, verify_optimum=True
+        )
+        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 428, nx_graph)
 
     def test_gnp_random_against_networkx_with_weight_max_cardinality(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(0, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph,
-                                                      maxcardinality=True)
+                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+            )
+            nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, max_cardinality=True,
-                verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                    42 + i, nx_graph)
+                rx_graph, weight_fn=lambda x: x, max_cardinality=True, verify_optimum=True
+            )
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, .75,
-                                                            seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(-5000, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1],
-                 {'weight': x[2]}) for x in rx_graph.weighted_edge_list()])
-            nx_matches = networkx.max_weight_matching(nx_graph,
-                                                      maxcardinality=True)
+                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+            )
+            nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, max_cardinality=True,
-                verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches,
-                                    42 + i, nx_graph)
+                rx_graph, weight_fn=lambda x: x, max_cardinality=True, verify_optimum=True
+            )
+            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
         nx_matches = networkx.max_weight_matching(nx_graph)
-        rx_matches = retworkx.max_weight_matching(rx_graph,
-                                                  verify_optimum=True)
-        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42,
-                                nx_graph)
+        rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
+        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42, nx_graph)
 
     def test_gnm_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 12, seed=42)
         nx_graph = networkx.Graph(list(rx_graph.edge_list()))
-        nx_matches = networkx.max_weight_matching(
-            nx_graph, maxcardinality=True)
+        nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
         rx_matches = retworkx.max_weight_matching(
-            rx_graph, max_cardinality=True, verify_optimum=True)
-        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42,
-                                nx_graph)
+            rx_graph, max_cardinality=True, verify_optimum=True
+        )
+        self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42, nx_graph)

--- a/tests/graph/test_max_weight_matching.py
+++ b/tests/graph/test_max_weight_matching.py
@@ -43,7 +43,9 @@ class TestMaxWeightMatching(testtools.TestCase):
                     "output: %s" % ((u, v), (v, u), rx_match, expected_match)
                 )
 
-    def compare_rx_nx_sets(self, rx_graph, rx_matches, nx_matches, seed, nx_graph):
+    def compare_rx_nx_sets(
+        self, rx_graph, rx_matches, nx_matches, seed, nx_graph
+    ):
         def get_rx_weight(edge):
             weight = rx_graph.get_edge_data(*edge)
             if weight is None:
@@ -86,7 +88,8 @@ class TestMaxWeightMatching(testtools.TestCase):
                 "%s is not a maximal matching" % rx_matches,
             )
             self.assertEqual(
-                sum(map(get_rx_weight, rx_matches)), sum(map(get_nx_weight, nx_matches))
+                sum(map(get_rx_weight, rx_matches)),
+                sum(map(get_nx_weight, nx_matches)),
             )
 
     def test_empty_graph(self):
@@ -124,7 +127,9 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 10), (2, 3, 11)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {
                 (2, 3),
             },
@@ -134,13 +139,17 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 5), (2, 3, 11), (3, 4, 5)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {
                 (2, 3),
             },
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, True, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 2), (3, 4)},
         )
 
@@ -156,13 +165,17 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {
                 (1, 2),
             },
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, True, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 3), (2, 4)},
         )
 
@@ -177,12 +190,16 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(0, 1), (2, 3)},
         )
         graph.extend_from_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(0, 5), (1, 2), (3, 4)},
         )
 
@@ -199,20 +216,26 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 6), (2, 3), (4, 5)},
         )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 5)
         graph.extend_from_weighted_edge_list([(4, 5, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 6), (2, 3), (4, 5)},
         )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 2), (3, 6), (4, 5)},
         )
 
@@ -232,20 +255,26 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph.remove_node(5)
         graph.add_edge(4, node_id, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 6), (2, 3), (4, 7)},
         )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 7)
         graph.extend_from_weighted_edge_list([(4, node_id, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 6), (2, 3), (4, 7)},
         )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 2), (3, 6), (4, 7)},
         )
 
@@ -264,7 +293,9 @@ class TestMaxWeightMatching(testtools.TestCase):
         )
         expected = {(1, 3), (2, 4), (5, 6)}
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             expected,
         )
 
@@ -284,7 +315,9 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 2), (3, 4), (5, 6), (7, 8)},
         )
 
@@ -305,7 +338,9 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 2), (3, 5), (4, 6), (7, 8)},
         )
 
@@ -324,7 +359,9 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             {(1, 6), (2, 3), (4, 8), (5, 7)},
         )
 
@@ -344,7 +381,9 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             match_dict_to_set({1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1}),
         )
 
@@ -365,8 +404,12 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
-            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
+            match_dict_to_set(
+                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
+            ),
         )
 
     def test_blossom_relabel_multiple_path_alternate(self):
@@ -386,8 +429,12 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
-            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
+            match_dict_to_set(
+                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
+            ),
         )
 
     def test_blossom_relabel_multiple_paths_least_slack(self):
@@ -407,8 +454,12 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
-            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
+            match_dict_to_set(
+                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
+            ),
         )
 
     def test_nested_blossom_expand_recursively(self):
@@ -429,8 +480,12 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
-            match_dict_to_set({1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
+            match_dict_to_set(
+                {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}
+            ),
         )
 
     def test_nested_blossom_augmented(self):
@@ -467,50 +522,72 @@ class TestMaxWeightMatching(testtools.TestCase):
             12: 11,
         }
         self.compare_match_sets(
-            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            retworkx.max_weight_matching(
+                graph, weight_fn=lambda x: x, verify_optimum=True
+            ),
             match_dict_to_set(expected),
         )
 
     def test_gnp_random_against_networkx(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
-            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(
+                10, 0.75, seed=42 + i
+            )
             nx_graph = networkx.Graph(list(rx_graph.edge_list()))
             nx_matches = networkx.max_weight_matching(nx_graph)
-            rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
+            rx_matches = retworkx.max_weight_matching(
+                rx_graph, verify_optimum=True
+            )
+            self.compare_rx_nx_sets(
+                rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
+            )
 
     def test_gnp_random_against_networkx_with_weight(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(
+                10, 0.75, seed=42 + i
+            )
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(0, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+                [
+                    (x[0], x[1], {"weight": x[2]})
+                    for x in rx_graph.weighted_edge_list()
+                ]
             )
             nx_matches = networkx.max_weight_matching(nx_graph)
             rx_matches = retworkx.max_weight_matching(
                 rx_graph, weight_fn=lambda x: x, verify_optimum=True
             )
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
+            self.compare_rx_nx_sets(
+                rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
+            )
 
     def test_gnp_random_against_networkx_with_negative_weight(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(
+                10, 0.75, seed=42 + i
+            )
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(-5000, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+                [
+                    (x[0], x[1], {"weight": x[2]})
+                    for x in rx_graph.weighted_edge_list()
+                ]
             )
             nx_matches = networkx.max_weight_matching(nx_graph)
             rx_matches = retworkx.max_weight_matching(
                 rx_graph, weight_fn=lambda x: x, verify_optimum=True
             )
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
+            self.compare_rx_nx_sets(
+                rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
+            )
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, 0.78, seed=428)
@@ -525,33 +602,57 @@ class TestMaxWeightMatching(testtools.TestCase):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(
+                10, 0.75, seed=42 + i
+            )
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(0, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+                [
+                    (x[0], x[1], {"weight": x[2]})
+                    for x in rx_graph.weighted_edge_list()
+                ]
             )
-            nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
+            nx_matches = networkx.max_weight_matching(
+                nx_graph, maxcardinality=True
+            )
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, max_cardinality=True, verify_optimum=True
+                rx_graph,
+                weight_fn=lambda x: x,
+                max_cardinality=True,
+                verify_optimum=True,
             )
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
+            self.compare_rx_nx_sets(
+                rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
+            )
 
     def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
         for i in range(1024):
             # TODO: add back subTest usage on new testtools release
             random.seed(i)
-            rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
+            rx_graph = retworkx.undirected_gnp_random_graph(
+                10, 0.75, seed=42 + i
+            )
             for edge in rx_graph.edge_list():
                 rx_graph.update_edge(*edge, random.randint(-5000, 5000))
             nx_graph = networkx.Graph(
-                [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
+                [
+                    (x[0], x[1], {"weight": x[2]})
+                    for x in rx_graph.weighted_edge_list()
+                ]
             )
-            nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
+            nx_matches = networkx.max_weight_matching(
+                nx_graph, maxcardinality=True
+            )
             rx_matches = retworkx.max_weight_matching(
-                rx_graph, weight_fn=lambda x: x, max_cardinality=True, verify_optimum=True
+                rx_graph,
+                weight_fn=lambda x: x,
+                max_cardinality=True,
+                verify_optimum=True,
             )
-            self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
+            self.compare_rx_nx_sets(
+                rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
+            )
 
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)

--- a/tests/graph/test_mst.py
+++ b/tests/graph/test_mst.py
@@ -51,16 +51,24 @@ class TestMinimumSpanningTree(unittest.TestCase):
             self.assertTrue(edge in expected)
 
     def test_edges(self):
-        mst_edges = retworkx.minimum_spanning_edges(self.graph, weight_fn=lambda x: x)
+        mst_edges = retworkx.minimum_spanning_edges(
+            self.graph, weight_fn=lambda x: x
+        )
         self.assertEqual(len(self.graph.nodes()) - 1, len(mst_edges))
         for edge in mst_edges:
             self.assertTrue(edge in self.expected_edges)
 
     def test_tree(self):
-        mst_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
+        mst_graph = retworkx.minimum_spanning_tree(
+            self.graph, weight_fn=lambda x: x
+        )
         self.assertEqual(self.graph.nodes(), mst_graph.nodes())
-        self.assertEqual(len(self.graph.nodes()) - 1, len(mst_graph.edge_list()))
-        self.assertEqualEdgeList(self.expected_edges, mst_graph.weighted_edge_list())
+        self.assertEqual(
+            len(self.graph.nodes()) - 1, len(mst_graph.edge_list())
+        )
+        self.assertEqualEdgeList(
+            self.expected_edges, mst_graph.weighted_edge_list()
+        )
 
     def test_forest(self):
         s = self.graph.add_node("S")
@@ -69,19 +77,31 @@ class TestMinimumSpanningTree(unittest.TestCase):
         self.graph.add_edges_from([(s, t, 10), (t, u, 9), (s, u, 8)])
         forest_expected_edges = self.expected_edges + [(s, u, 8), (t, u, 9)]
 
-        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
+        msf_graph = retworkx.minimum_spanning_tree(
+            self.graph, weight_fn=lambda x: x
+        )
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
-        self.assertEqualEdgeList(forest_expected_edges, msf_graph.weighted_edge_list())
+        self.assertEqual(
+            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
+        )
+        self.assertEqualEdgeList(
+            forest_expected_edges, msf_graph.weighted_edge_list()
+        )
 
     def test_isolated(self):
         s = self.graph.add_node("S")
 
-        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
+        msf_graph = retworkx.minimum_spanning_tree(
+            self.graph, weight_fn=lambda x: x
+        )
         self.assertEqual("S", msf_graph.nodes()[s])
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
-        self.assertEqualEdgeList(self.expected_edges, msf_graph.weighted_edge_list())
+        self.assertEqual(
+            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
+        )
+        self.assertEqualEdgeList(
+            self.expected_edges, msf_graph.weighted_edge_list()
+        )
 
     def test_multigraph(self):
         mutligraph = retworkx.PyGraph(multigraph=True)
@@ -89,8 +109,12 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1, 1), (0, 2, 3), (1, 2, 2), (0, 0, -10), (1, 2, 1)]
         )
 
-        mst_graph = retworkx.minimum_spanning_tree(mutligraph, weight_fn=lambda x: x)
-        self.assertEqualEdgeList([(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list())
+        mst_graph = retworkx.minimum_spanning_tree(
+            mutligraph, weight_fn=lambda x: x
+        )
+        self.assertEqualEdgeList(
+            [(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list()
+        )
 
     def test_default_weight(self):
         weightless_graph = retworkx.PyGraph()
@@ -98,8 +122,12 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5), (2, 6), (3, 7), (4, 8)]
         )  # MST of the graph is itself
 
-        mst_graph_default_weight = retworkx.minimum_spanning_tree(weightless_graph)
-        mst_graph_weight_2 = retworkx.minimum_spanning_tree(weightless_graph, default_weight=2.0)
+        mst_graph_default_weight = retworkx.minimum_spanning_tree(
+            weightless_graph
+        )
+        mst_graph_weight_2 = retworkx.minimum_spanning_tree(
+            weightless_graph, default_weight=2.0
+        )
 
         self.assertTrue(
             retworkx.is_isomorphic(
@@ -116,7 +144,9 @@ class TestMinimumSpanningTree(unittest.TestCase):
 
     def test_nan_weight(self):
         invalid_graph = retworkx.PyGraph()
-        invalid_graph.extend_from_weighted_edge_list([(0, 1, 0.5), (0, 2, float("nan"))])
+        invalid_graph.extend_from_weighted_edge_list(
+            [(0, 1, 0.5), (0, 2, float("nan"))]
+        )
 
         with self.assertRaises(ValueError):
             retworkx.minimum_spanning_tree(invalid_graph, lambda x: x)

--- a/tests/graph/test_mst.py
+++ b/tests/graph/test_mst.py
@@ -51,24 +51,16 @@ class TestMinimumSpanningTree(unittest.TestCase):
             self.assertTrue(edge in expected)
 
     def test_edges(self):
-        mst_edges = retworkx.minimum_spanning_edges(
-            self.graph, weight_fn=lambda x: x
-        )
+        mst_edges = retworkx.minimum_spanning_edges(self.graph, weight_fn=lambda x: x)
         self.assertEqual(len(self.graph.nodes()) - 1, len(mst_edges))
         for edge in mst_edges:
             self.assertTrue(edge in self.expected_edges)
 
     def test_tree(self):
-        mst_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        mst_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual(self.graph.nodes(), mst_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 1, len(mst_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            self.expected_edges, mst_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 1, len(mst_graph.edge_list()))
+        self.assertEqualEdgeList(self.expected_edges, mst_graph.weighted_edge_list())
 
     def test_forest(self):
         s = self.graph.add_node("S")
@@ -77,31 +69,19 @@ class TestMinimumSpanningTree(unittest.TestCase):
         self.graph.add_edges_from([(s, t, 10), (t, u, 9), (s, u, 8)])
         forest_expected_edges = self.expected_edges + [(s, u, 8), (t, u, 9)]
 
-        msf_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            forest_expected_edges, msf_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
+        self.assertEqualEdgeList(forest_expected_edges, msf_graph.weighted_edge_list())
 
     def test_isolated(self):
         s = self.graph.add_node("S")
 
-        msf_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual("S", msf_graph.nodes()[s])
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            self.expected_edges, msf_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
+        self.assertEqualEdgeList(self.expected_edges, msf_graph.weighted_edge_list())
 
     def test_multigraph(self):
         mutligraph = retworkx.PyGraph(multigraph=True)
@@ -109,12 +89,8 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1, 1), (0, 2, 3), (1, 2, 2), (0, 0, -10), (1, 2, 1)]
         )
 
-        mst_graph = retworkx.minimum_spanning_tree(
-            mutligraph, weight_fn=lambda x: x
-        )
-        self.assertEqualEdgeList(
-            [(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list()
-        )
+        mst_graph = retworkx.minimum_spanning_tree(mutligraph, weight_fn=lambda x: x)
+        self.assertEqualEdgeList([(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list())
 
     def test_default_weight(self):
         weightless_graph = retworkx.PyGraph()
@@ -122,12 +98,8 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5), (2, 6), (3, 7), (4, 8)]
         )  # MST of the graph is itself
 
-        mst_graph_default_weight = retworkx.minimum_spanning_tree(
-            weightless_graph
-        )
-        mst_graph_weight_2 = retworkx.minimum_spanning_tree(
-            weightless_graph, default_weight=2.0
-        )
+        mst_graph_default_weight = retworkx.minimum_spanning_tree(weightless_graph)
+        mst_graph_weight_2 = retworkx.minimum_spanning_tree(weightless_graph, default_weight=2.0)
 
         self.assertTrue(
             retworkx.is_isomorphic(
@@ -144,9 +116,7 @@ class TestMinimumSpanningTree(unittest.TestCase):
 
     def test_nan_weight(self):
         invalid_graph = retworkx.PyGraph()
-        invalid_graph.extend_from_weighted_edge_list(
-            [(0, 1, 0.5), (0, 2, float("nan"))]
-        )
+        invalid_graph.extend_from_weighted_edge_list([(0, 1, 0.5), (0, 2, float("nan"))])
 
         with self.assertRaises(ValueError):
             retworkx.minimum_spanning_tree(invalid_graph, lambda x: x)

--- a/tests/graph/test_neighbors.py
+++ b/tests/graph/test_neighbors.py
@@ -18,26 +18,26 @@ import retworkx
 class TestNeighbors(unittest.TestCase):
     def test_single_neighbor(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, {'a': 1})
-        node_c = graph.add_node('c')
-        graph.add_edge(node_a, node_c, {'a': 2})
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, {"a": 1})
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_c, {"a": 2})
         res = graph.neighbors(node_a)
         self.assertCountEqual([node_c, node_b], res)
 
     def test_unique_neighbors_on_graphs(self):
         dag = retworkx.PyGraph()
-        node_a = dag.add_node('a')
-        node_b = dag.add_node('b')
-        node_c = dag.add_node('c')
-        dag.add_edge(node_a, node_b, ['edge a->b'])
-        dag.add_edge(node_a, node_b, ['edge a->b bis'])
-        dag.add_edge(node_a, node_c, ['edge a->c'])
+        node_a = dag.add_node("a")
+        node_b = dag.add_node("b")
+        node_c = dag.add_node("c")
+        dag.add_edge(node_a, node_b, ["edge a->b"])
+        dag.add_edge(node_a, node_b, ["edge a->b bis"])
+        dag.add_edge(node_a, node_c, ["edge a->c"])
         res = dag.neighbors(node_a)
         self.assertCountEqual([node_c, node_b], res)
 
     def test_no_neighbor(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
+        node_a = graph.add_node("a")
         self.assertEqual([], graph.neighbors(node_a))

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -16,13 +16,12 @@ import retworkx
 
 
 class TestNodes(unittest.TestCase):
-
     def test_nodes(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
+        graph.add_node("a")
+        graph.add_node("b")
         res = graph.nodes()
-        self.assertEqual(['a', 'b'], res)
+        self.assertEqual(["a", "b"], res)
         self.assertEqual([0, 1], graph.node_indexes())
 
     def test_no_nodes(self):
@@ -32,65 +31,65 @@ class TestNodes(unittest.TestCase):
 
     def test_remove_node(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_node('c')
+        graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_node("c")
         graph.remove_node(node_b)
         res = graph.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], graph.node_indexes())
 
     def test_remove_node_invalid_index(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
         graph.remove_node(76)
         res = graph.nodes()
-        self.assertEqual(['a', 'b', 'c'], res)
+        self.assertEqual(["a", "b", "c"], res)
         self.assertEqual([0, 1, 2], graph.node_indexes())
 
     def test_remove_nodes_from(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Edgy_mk2")
         graph.remove_nodes_from([node_b, node_c])
         res = graph.nodes()
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
         self.assertEqual([0], graph.node_indexes())
 
     def test_remove_nodes_from_with_invalid_index(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Edgy_mk2")
         graph.remove_nodes_from([node_b, node_c, 76])
         res = graph.nodes()
-        self.assertEqual(['a'], res)
+        self.assertEqual(["a"], res)
         self.assertEqual([0], graph.node_indexes())
 
     def test_get_node_data(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        node_b = graph.add_node('b')
-        self.assertEqual('b', graph.get_node_data(node_b))
+        graph.add_node("a")
+        node_b = graph.add_node("b")
+        self.assertEqual("b", graph.get_node_data(node_b))
 
     def test_get_node_data_bad_index(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
+        graph.add_node("a")
+        graph.add_node("b")
         self.assertRaises(IndexError, graph.get_node_data, 42)
 
     def test_pygraph_length(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
-        graph.add_edge(node_a, node_b, 'An_edge')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "An_edge")
         self.assertEqual(2, len(graph))
 
     def test_pygraph_length_empty(self):
@@ -111,54 +110,54 @@ class TestNodes(unittest.TestCase):
 
     def test_get_node_data_getitem(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        self.assertEqual('b', graph[node_b])
+        self.assertEqual("b", graph[node_b])
 
     def test_get_node_data_getitem_bad_index(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
         with self.assertRaises(IndexError):
             graph[42]
 
     def test_set_node_data_setitem(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        graph[node_b] = 'Oh so cool'
-        self.assertEqual('Oh so cool', graph[node_b])
+        graph[node_b] = "Oh so cool"
+        self.assertEqual("Oh so cool", graph[node_b])
 
     def test_set_node_data_setitem_bad_index(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
         with self.assertRaises(IndexError):
-            graph[42] = 'Oh so cool'
+            graph[42] = "Oh so cool"
 
     def test_remove_node_delitem(self):
         graph = retworkx.PyGraph()
-        node_a = graph.add_node('a')
-        node_b = graph.add_node('b')
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, "Edgy")
-        node_c = graph.add_node('c')
+        node_c = graph.add_node("c")
         graph.add_edge(node_b, node_c, "Edgy_mk2")
         del graph[node_b]
         res = graph.nodes()
-        self.assertEqual(['a', 'c'], res)
+        self.assertEqual(["a", "c"], res)
         self.assertEqual([0, 2], graph.node_indexes())
 
     def test_remove_node_delitem_invalid_index(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
         with self.assertRaises(IndexError):
             del graph[76]
         res = graph.nodes()
-        self.assertEqual(['a', 'b', 'c'], res)
+        self.assertEqual(["a", "b", "c"], res)
         self.assertEqual([0, 1, 2], graph.node_indexes())

--- a/tests/graph/test_subgraph.py
+++ b/tests/graph/test_subgraph.py
@@ -57,7 +57,9 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(
+            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
+        )
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0]["a"] = 4
         self.assertEqual(subgraph[0]["a"], 4)
@@ -70,7 +72,9 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(
+            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
+        )
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
         self.assertEqual(subgraph[0]["a"], 0)

--- a/tests/graph/test_subgraph.py
+++ b/tests/graph/test_subgraph.py
@@ -16,24 +16,23 @@ import retworkx
 
 
 class TestSubgraph(unittest.TestCase):
-
     def test_subgraph(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([1, 3])
         self.assertEqual([(0, 1, 4)], subgraph.weighted_edge_list())
-        self.assertEqual(['b', 'd'], subgraph.nodes())
+        self.assertEqual(["b", "d"], subgraph.nodes())
 
     def test_subgraph_empty_list(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([])
         self.assertEqual([], subgraph.weighted_edge_list())
@@ -41,10 +40,10 @@ class TestSubgraph(unittest.TestCase):
 
     def test_subgraph_invalid_entry(self):
         graph = retworkx.PyGraph()
-        graph.add_node('a')
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([42])
         self.assertEqual([], subgraph.weighted_edge_list())
@@ -52,28 +51,26 @@ class TestSubgraph(unittest.TestCase):
 
     def test_subgraph_pass_by_reference(self):
         graph = retworkx.PyGraph()
-        graph.add_node({'a': 0})
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node({"a": 0})
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)],
-                         subgraph.weighted_edge_list())
-        self.assertEqual([{'a': 0}, 'b', 'd'], subgraph.nodes())
-        graph[0]['a'] = 4
-        self.assertEqual(subgraph[0]['a'], 4)
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
+        graph[0]["a"] = 4
+        self.assertEqual(subgraph[0]["a"], 4)
 
     def test_subgraph_replace_weight_no_reference(self):
         graph = retworkx.PyGraph()
-        graph.add_node({'a': 0})
-        graph.add_node('b')
-        graph.add_node('c')
-        graph.add_node('d')
+        graph.add_node({"a": 0})
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)],
-                         subgraph.weighted_edge_list())
-        self.assertEqual([{'a': 0}, 'b', 'd'], subgraph.nodes())
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+        self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
-        self.assertEqual(subgraph[0]['a'], 0)
+        self.assertEqual(subgraph[0]["a"], 0)

--- a/tests/graph/test_transitivity.py
+++ b/tests/graph/test_transitivity.py
@@ -16,32 +16,24 @@ import retworkx
 
 
 class TestTransitivity(unittest.TestCase):
-
     def test_transitivity(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(5)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (0, 3), (0, 4),
-            (1, 2)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (0, 4), (1, 2)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 3 / 8)
 
     def test_transitivity_triangle(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(3)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (1, 2)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (1, 2)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 1.0)
 
     def test_transitivity_star(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(5)))
-        graph.add_edges_from_no_data([
-            (0, 1), (0, 2), (0, 3), (0, 4)
-        ])
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (0, 4)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 0.0)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -16,14 +16,12 @@ import networkx
 
 
 class TestNetworkxConverter(unittest.TestCase):
-
     def test_undirected_gnm_graph(self):
         g = networkx.gnm_random_graph(10, 10, seed=42)
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_directed_gnm_graph(self):
@@ -31,8 +29,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_graph(self):
@@ -40,8 +37,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_multigraph(self):
@@ -49,8 +45,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_graph(self):
@@ -58,8 +53,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_multigraph(self):
@@ -67,8 +61,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_graph(self):
@@ -76,8 +69,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_multigraph(self):
@@ -85,8 +77,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_random_k_out_graph(self):
@@ -94,6 +85,5 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(),
-                         list(g.edges(data=True)))
+        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
         self.assertEqual(out_graph.multigraph, g.is_multigraph())

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -21,7 +21,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_directed_gnm_graph(self):
@@ -29,7 +31,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_graph(self):
@@ -37,7 +41,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_multigraph(self):
@@ -45,7 +51,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_graph(self):
@@ -53,7 +61,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_multigraph(self):
@@ -61,7 +71,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_graph(self):
@@ -69,7 +81,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_multigraph(self):
@@ -77,7 +91,9 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_random_k_out_graph(self):
@@ -85,5 +101,7 @@ class TestNetworkxConverter(unittest.TestCase):
         out_graph = retworkx.networkx_converter(g)
         self.assertIsInstance(out_graph, retworkx.PyDiGraph)
         self.assertEqual(out_graph.nodes(), list(g.nodes))
-        self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
+        self.assertEqual(
+            out_graph.weighted_edge_list(), list(g.edges(data=True))
+        )
         self.assertEqual(out_graph.multigraph, g.is_multigraph())

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -18,52 +18,46 @@ import retworkx
 
 
 class TestBFSSuccessorsComparisons(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(retworkx.bfs_successors(self.dag, 0) == [('a', ['b'])])
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) == [("a", ["b"])])
 
     def test__eq__not_match(self):
-        self.assertFalse(retworkx.bfs_successors(
-            self.dag, 0) == [('b', ['c'])])
+        self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("b", ["c"])])
 
     def test_eq_not_match_inner(self):
-        self.assertFalse(retworkx.bfs_successors(
-            self.dag, 0) == [('a', ['c'])])
+        self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["c"])])
 
     def test__eq__different_length(self):
-        self.assertFalse(retworkx.bfs_successors(
-            self.dag, 0) == [('a', ['b']), ('b', ['c'])])
+        self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["b"]), ("b", ["c"])])
 
     def test__eq__invalid_type(self):
         with self.assertRaises(TypeError):
-            retworkx.bfs_successors(self.dag, 0) == ['a']
+            retworkx.bfs_successors(self.dag, 0) == ["a"]
 
     def test__ne__match(self):
-        self.assertFalse(retworkx.bfs_successors(
-            self.dag, 0) != [('a', ['b'])])
+        self.assertFalse(retworkx.bfs_successors(self.dag, 0) != [("a", ["b"])])
 
     def test__ne__not_match(self):
-        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [('b', ['c'])])
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("b", ["c"])])
 
     def test_ne_not_match_inner(self):
-        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [('a', ['c'])])
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["c"])])
 
     def test__ne__different_length(self):
-        self.assertTrue(retworkx.bfs_successors(
-            self.dag, 0) != [('a', ['b']), ('b', ['c'])])
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["b"]), ("b", ["c"])])
 
     def test__ne__invalid_type(self):
         with self.assertRaises(TypeError):
-            retworkx.bfs_successors(self.dag, 0) != ['a']
+            retworkx.bfs_successors(self.dag, 0) != ["a"]
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.bfs_successors(self.dag, 0) > [('b', ['c'])]
+            retworkx.bfs_successors(self.dag, 0) > [("b", ["c"])]
 
     def test_deepcopy(self):
         bfs = retworkx.bfs_successors(self.dag, 0)
@@ -88,18 +82,17 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         self.assertEqual(hash_res, hash(res))
 
     def test_hash_invalid_type(self):
-        self.dag.add_child(0, [1, 2, 3], 'edgy')
+        self.dag.add_child(0, [1, 2, 3], "edgy")
         res = retworkx.bfs_successors(self.dag, 0)
         with self.assertRaises(TypeError):
             hash(res)
 
 
 class TestNodeIndicesComparisons(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
         self.assertTrue(self.dag.node_indexes() == [0, 1])
@@ -112,7 +105,7 @@ class TestNodeIndicesComparisons(unittest.TestCase):
 
     def test__eq__invalid_type(self):
         with self.assertRaises(TypeError):
-            self.dag.node_indexes() == ['a', None]
+            self.dag.node_indexes() == ["a", None]
 
     def test__ne__match(self):
         self.assertFalse(self.dag.node_indexes() != [0, 1])
@@ -125,7 +118,7 @@ class TestNodeIndicesComparisons(unittest.TestCase):
 
     def test__ne__invalid_type(self):
         with self.assertRaises(TypeError):
-            self.dag.node_indexes() != ['a', None]
+            self.dag.node_indexes() != ["a", None]
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -155,11 +148,10 @@ class TestNodeIndicesComparisons(unittest.TestCase):
 
 
 class TestEdgeListComparisons(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
         self.assertTrue(self.dag.edge_list() == [(0, 1)])
@@ -171,7 +163,7 @@ class TestEdgeListComparisons(unittest.TestCase):
         self.assertFalse(self.dag.edge_list() == [(0, 1), (2, 3)])
 
     def test__eq__invalid_type(self):
-        self.assertFalse(self.dag.edge_list() == ['a', None])
+        self.assertFalse(self.dag.edge_list() == ["a", None])
 
     def test__ne__match(self):
         self.assertFalse(self.dag.edge_list() != [(0, 1)])
@@ -183,7 +175,7 @@ class TestEdgeListComparisons(unittest.TestCase):
         self.assertTrue(self.dag.edge_list() != [(0, 1), (2, 3)])
 
     def test__ne__invalid_type(self):
-        self.assertTrue(self.dag.edge_list() != ['a', None])
+        self.assertTrue(self.dag.edge_list() != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -213,41 +205,38 @@ class TestEdgeListComparisons(unittest.TestCase):
 
 
 class TestWeightedEdgeListComparisons(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(self.dag.weighted_edge_list() == [(0, 1, 'Edgy')])
+        self.assertTrue(self.dag.weighted_edge_list() == [(0, 1, "Edgy")])
 
     def test__eq__not_match(self):
         self.assertFalse(self.dag.weighted_edge_list() == [(1, 2, None)])
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            self.dag.weighted_edge_list() == [
-                (0, 1, 'Edgy'), (2, 3, 'Not Edgy')])
+        self.assertFalse(self.dag.weighted_edge_list() == [(0, 1, "Edgy"), (2, 3, "Not Edgy")])
 
     def test__eq__invalid_type(self):
-        self.assertFalse(self.dag.weighted_edge_list() == ['a', None])
+        self.assertFalse(self.dag.weighted_edge_list() == ["a", None])
 
     def test__ne__match(self):
-        self.assertFalse(self.dag.weighted_edge_list() != [(0, 1, 'Edgy')])
+        self.assertFalse(self.dag.weighted_edge_list() != [(0, 1, "Edgy")])
 
     def test__ne__not_match(self):
-        self.assertTrue(self.dag.weighted_edge_list() != [(1, 2, 'Not Edgy')])
+        self.assertTrue(self.dag.weighted_edge_list() != [(1, 2, "Not Edgy")])
 
     def test__ne__different_length(self):
         self.assertTrue(self.dag.node_indexes() != [0, 1, 2, 3])
 
     def test__ne__invalid_type(self):
-        self.assertTrue(self.dag.weighted_edge_list() != ['a', None])
+        self.assertTrue(self.dag.weighted_edge_list() != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            self.dag.weighted_edge_list() > [(2, 1, 'Not Edgy')]
+            self.dag.weighted_edge_list() > [(2, 1, "Not Edgy")]
 
     def test_deepcopy(self):
         edges = self.dag.weighted_edge_list()
@@ -272,68 +261,56 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         self.assertEqual(hash_res, hash(res))
 
     def test_hash_invalid_type(self):
-        self.dag.add_child(0, 'c', ['edgy', 'not_edgy'])
+        self.dag.add_child(0, "c", ["edgy", "not_edgy"])
         res = self.dag.weighted_edge_list()
         with self.assertRaises(TypeError):
             hash(res)
 
 
 class TestPathMapping(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]})
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]})
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]})
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]})
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {
-                1: [0, 1], 2: [0, 2]})
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1], 2: [0, 2]})
 
     def test_eq__same_type(self):
-        self.assertEqual(retworkx.dijkstra_shortest_paths(self.dag, 0),
-                         retworkx.dijkstra_shortest_paths(self.dag, 0))
+        self.assertEqual(
+            retworkx.dijkstra_shortest_paths(self.dag, 0),
+            retworkx.dijkstra_shortest_paths(self.dag, 0),
+        )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == ['a', None])
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == ["a", None])
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {'a': None}})
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {"a": None}})
 
     def test__ne__match(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]})
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]})
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]})
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]})
 
     def test__ne__different_length(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {
-                1: [0, 1], 2: [0, 2]})
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1], 2: [0, 2]})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != ['a', None])
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -379,8 +356,7 @@ class TestPathMapping(unittest.TestCase):
         self.assertEqual([(1, [0, 1])], list(items))
 
     def test_iter(self):
-        mapping_iter = iter(
-            retworkx.dijkstra_shortest_paths(self.dag, 0))
+        mapping_iter = iter(retworkx.dijkstra_shortest_paths(self.dag, 0))
         output = list(mapping_iter)
         self.assertEqual(output, [1])
 
@@ -394,78 +370,62 @@ class TestPathMapping(unittest.TestCase):
 
 
 class TestPathLengthMapping(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node('a')
-        self.dag.add_child(node_a, 'b', "Edgy")
+        node_a = self.dag.add_node("a")
+        self.dag.add_child(node_a, "b", "Edgy")
         self.fn = lambda _: 1.0
 
     def test__eq__match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == {1: 1.0})
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == {2: 1.0})
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {2: 1.0})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == {1: 2.0})
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 2.0})
 
     def test__eq__different_length(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == {
-                1: 1.0, 2: 2.0})
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0, 2: 2.0}
+        )
 
     def test_eq__same_type(self):
         self.assertEqual(
             retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn),
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn))
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn),
+        )
 
     def test__eq__invalid_type(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == ['a', None])
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == ["a", None]
+        )
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) == {0: 'a'})
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {0: "a"})
 
     def test__ne__match(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) != {1: 1.0})
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) != {2: 1.0})
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {2: 1.0})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) != {1: 2.0})
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 2.0})
 
     def test__ne__different_length(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) != {1: 1.0, 2: 2.0})
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0, 2: 2.0}
+        )
 
     def test__ne__invalid_type(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) != ['a', None])
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != ["a", None]
+        )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.dijkstra_shortest_path_lengths(
-                self.dag, 0, self.fn) > {1: 1.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) > {1: 1.0}
 
     def test_deepcopy(self):
         paths = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
@@ -479,8 +439,7 @@ class TestPathLengthMapping(unittest.TestCase):
         self.assertEqual(paths, paths_copy)
 
     def test_str(self):
-        res = retworkx.dijkstra_shortest_path_lengths(self.dag, 0,
-                                                      lambda _: 3.14)
+        res = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, lambda _: 3.14)
         self.assertEqual("PathLengthMapping{1: 3.14}", str(res))
 
     def test_hash(self):
@@ -496,24 +455,19 @@ class TestPathLengthMapping(unittest.TestCase):
             res[42]
 
     def test_keys(self):
-        keys = retworkx.dijkstra_shortest_path_lengths(self.dag, 0,
-                                                       self.fn).keys()
+        keys = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).keys()
         self.assertEqual([1], list(keys))
 
     def test_values(self):
-        values = retworkx.dijkstra_shortest_path_lengths(self.dag, 0,
-                                                         self.fn).values()
+        values = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).values()
         self.assertEqual([1.0], list(values))
 
     def test_items(self):
-        items = retworkx.dijkstra_shortest_path_lengths(self.dag, 0,
-                                                        self.fn).items()
+        items = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).items()
         self.assertEqual([(1, 1.0)], list(items))
 
     def test_iter(self):
-        mapping_iter = iter(retworkx.dijkstra_shortest_path_lengths(self.dag,
-                                                                    0,
-                                                                    self.fn))
+        mapping_iter = iter(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn))
         output = list(mapping_iter)
         self.assertEqual(output, [1])
 
@@ -527,22 +481,19 @@ class TestPathLengthMapping(unittest.TestCase):
 
 
 class TestPos2DMapping(unittest.TestCase):
-
     def setUp(self):
         self.dag = retworkx.PyDiGraph()
-        self.dag.add_node('a')
+        self.dag.add_node("a")
 
     def test__eq__match(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
         self.assertTrue(res == {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0})
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0})
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0})
 
     def test__eq__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -551,23 +502,21 @@ class TestPos2DMapping(unittest.TestCase):
     def test_eq__same_type(self):
         self.assertEqual(
             retworkx.random_layout(self.dag, seed=10244242),
-            retworkx.random_layout(self.dag, seed=10244242))
+            retworkx.random_layout(self.dag, seed=10244242),
+        )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {'a': None})
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {"a": None})
 
     def test__ne__match(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
         self.assertFalse(res != {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0})
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0})
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0})
 
     def test__ne__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -575,8 +524,7 @@ class TestPos2DMapping(unittest.TestCase):
         self.assertTrue(res != {1: 1.0, 2: 2.0})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != ['a', None])
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -595,9 +543,7 @@ class TestPos2DMapping(unittest.TestCase):
 
     def test_str(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
-        self.assertEqual(
-            "Pos2DMapping{0: (0.4883489113112722, 0.6545867364101975)}",
-            str(res))
+        self.assertEqual("Pos2DMapping{0: (0.4883489113112722, 0.6545867364101975)}", str(res))
 
     def test_hash(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -622,8 +568,7 @@ class TestPos2DMapping(unittest.TestCase):
 
     def test_items(self):
         items = retworkx.random_layout(self.dag, seed=10244242).items()
-        self.assertEqual([(0, [0.4883489113112722, 0.6545867364101975])],
-                         list(items))
+        self.assertEqual([(0, [0.4883489113112722, 0.6545867364101975])], list(items))
 
     def test_iter(self):
         mapping_iter = iter(retworkx.random_layout(self.dag, seed=10244242))

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -33,7 +33,9 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["c"])])
 
     def test__eq__different_length(self):
-        self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["b"]), ("b", ["c"])])
+        self.assertFalse(
+            retworkx.bfs_successors(self.dag, 0) == [("a", ["b"]), ("b", ["c"])]
+        )
 
     def test__eq__invalid_type(self):
         with self.assertRaises(TypeError):
@@ -49,7 +51,9 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["c"])])
 
     def test__ne__different_length(self):
-        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["b"]), ("b", ["c"])])
+        self.assertTrue(
+            retworkx.bfs_successors(self.dag, 0) != [("a", ["b"]), ("b", ["c"])]
+        )
 
     def test__ne__invalid_type(self):
         with self.assertRaises(TypeError):
@@ -217,7 +221,10 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         self.assertFalse(self.dag.weighted_edge_list() == [(1, 2, None)])
 
     def test__eq__different_length(self):
-        self.assertFalse(self.dag.weighted_edge_list() == [(0, 1, "Edgy"), (2, 3, "Not Edgy")])
+        self.assertFalse(
+            self.dag.weighted_edge_list()
+            == [(0, 1, "Edgy"), (2, 3, "Not Edgy")]
+        )
 
     def test__eq__invalid_type(self):
         self.assertFalse(self.dag.weighted_edge_list() == ["a", None])
@@ -274,16 +281,25 @@ class TestPathMapping(unittest.TestCase):
         self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]}
+        )
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]}
+        )
 
     def test__eq__not_match_values(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]}
+        )
 
     def test__eq__different_length(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1], 2: [0, 2]})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0)
+            == {1: [0, 1], 2: [0, 2]}
+        )
 
     def test_eq__same_type(self):
         self.assertEqual(
@@ -292,25 +308,40 @@ class TestPathMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == ["a", None])
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) == ["a", None]
+        )
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {"a": None}})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {"a": None}}
+        )
 
     def test__ne__match(self):
-        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]}
+        )
 
     def test__ne__not_match(self):
-        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]}
+        )
 
     def test__ne__not_match_values(self):
-        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]}
+        )
 
     def test__ne__different_length(self):
-        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1], 2: [0, 2]})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_paths(self.dag, 0)
+            != {1: [0, 1], 2: [0, 2]}
+        )
 
     def test__ne__invalid_type(self):
-        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != ["a", None])
+        self.assertTrue(
+            retworkx.dijkstra_shortest_paths(self.dag, 0) != ["a", None]
+        )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -377,17 +408,27 @@ class TestPathLengthMapping(unittest.TestCase):
         self.fn = lambda _: 1.0
 
     def test__eq__match(self):
-        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == {1: 1.0}
+        )
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {2: 1.0})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == {2: 1.0}
+        )
 
     def test__eq__not_match_values(self):
-        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 2.0})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == {1: 2.0}
+        )
 
     def test__eq__different_length(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0, 2: 2.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == {1: 1.0, 2: 2.0}
         )
 
     def test_eq__same_type(self):
@@ -398,34 +439,51 @@ class TestPathLengthMapping(unittest.TestCase):
 
     def test__eq__invalid_type(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == ["a", None]
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == ["a", None]
         )
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {0: "a"})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            == {0: "a"}
+        )
 
     def test__ne__match(self):
-        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0})
+        self.assertFalse(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            != {1: 1.0}
+        )
 
     def test__ne__not_match(self):
-        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {2: 1.0})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            != {2: 1.0}
+        )
 
     def test__ne__not_match_values(self):
-        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 2.0})
+        self.assertTrue(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            != {1: 2.0}
+        )
 
     def test__ne__different_length(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0, 2: 2.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            != {1: 1.0, 2: 2.0}
         )
 
     def test__ne__invalid_type(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != ["a", None]
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+            != ["a", None]
         )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) > {1: 1.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) > {
+                1: 1.0
+            }
 
     def test_deepcopy(self):
         paths = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
@@ -439,7 +497,9 @@ class TestPathLengthMapping(unittest.TestCase):
         self.assertEqual(paths, paths_copy)
 
     def test_str(self):
-        res = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, lambda _: 3.14)
+        res = retworkx.dijkstra_shortest_path_lengths(
+            self.dag, 0, lambda _: 3.14
+        )
         self.assertEqual("PathLengthMapping{1: 3.14}", str(res))
 
     def test_hash(self):
@@ -455,19 +515,27 @@ class TestPathLengthMapping(unittest.TestCase):
             res[42]
 
     def test_keys(self):
-        keys = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).keys()
+        keys = retworkx.dijkstra_shortest_path_lengths(
+            self.dag, 0, self.fn
+        ).keys()
         self.assertEqual([1], list(keys))
 
     def test_values(self):
-        values = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).values()
+        values = retworkx.dijkstra_shortest_path_lengths(
+            self.dag, 0, self.fn
+        ).values()
         self.assertEqual([1.0], list(values))
 
     def test_items(self):
-        items = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).items()
+        items = retworkx.dijkstra_shortest_path_lengths(
+            self.dag, 0, self.fn
+        ).items()
         self.assertEqual([(1, 1.0)], list(items))
 
     def test_iter(self):
-        mapping_iter = iter(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn))
+        mapping_iter = iter(
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
+        )
         output = list(mapping_iter)
         self.assertEqual(output, [1])
 
@@ -490,10 +558,14 @@ class TestPos2DMapping(unittest.TestCase):
         self.assertTrue(res == {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0})
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0}
+        )
 
     def test__eq__not_match_values(self):
-        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0})
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0}
+        )
 
     def test__eq__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -506,17 +578,23 @@ class TestPos2DMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {"a": None})
+        self.assertFalse(
+            retworkx.random_layout(self.dag, seed=10244242) == {"a": None}
+        )
 
     def test__ne__match(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
         self.assertFalse(res != {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__ne__not_match(self):
-        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0})
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0}
+        )
 
     def test__ne__not_match_values(self):
-        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0})
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0}
+        )
 
     def test__ne__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -524,7 +602,9 @@ class TestPos2DMapping(unittest.TestCase):
         self.assertTrue(res != {1: 1.0, 2: 2.0})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != ["a", None])
+        self.assertTrue(
+            retworkx.random_layout(self.dag, seed=10244242) != ["a", None]
+        )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -543,7 +623,10 @@ class TestPos2DMapping(unittest.TestCase):
 
     def test_str(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
-        self.assertEqual("Pos2DMapping{0: (0.4883489113112722, 0.6545867364101975)}", str(res))
+        self.assertEqual(
+            "Pos2DMapping{0: (0.4883489113112722, 0.6545867364101975)}",
+            str(res),
+        )
 
     def test_hash(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -568,7 +651,9 @@ class TestPos2DMapping(unittest.TestCase):
 
     def test_items(self):
         items = retworkx.random_layout(self.dag, seed=10244242).items()
-        self.assertEqual([(0, [0.4883489113112722, 0.6545867364101975])], list(items))
+        self.assertEqual(
+            [(0, [0.4883489113112722, 0.6545867364101975])], list(items)
+        )
 
     def test_iter(self):
         mapping_iter = iter(retworkx.random_layout(self.dag, seed=10244242))

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -59,7 +59,9 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertTrue(numpy.array_equal(expected_res, res))
 
     def test_astar_shortest_path(self):
-        res = retworkx.astar_shortest_path(self.graph, 0, lambda _: True, lambda _: 1, lambda _: 1)
+        res = retworkx.astar_shortest_path(
+            self.graph, 0, lambda _: True, lambda _: 1, lambda _: 1
+        )
         self.assertIsInstance(list(res), list)
 
     def test_dijkstra_shortest_paths(self):
@@ -67,7 +69,9 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertIsInstance(res, retworkx.PathMapping)
 
     def test_dijkstra_shortest_path_lengths(self):
-        res = retworkx.dijkstra_shortest_path_lengths(self.graph, 0, lambda _: 1)
+        res = retworkx.dijkstra_shortest_path_lengths(
+            self.graph, 0, lambda _: 1
+        )
         self.assertIsInstance(res, retworkx.PathLengthMapping)
 
     def test_k_shortest_path_lengths(self):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -23,9 +23,9 @@ class TestDispatchPyGraph(unittest.TestCase):
     def setUp(self):
         super().setUp()
         if self.class_type == "PyGraph":
-            self.graph = retworkx.undirected_gnp_random_graph(10, .5, seed=42)
+            self.graph = retworkx.undirected_gnp_random_graph(10, 0.5, seed=42)
         else:
-            self.graph = retworkx.directed_gnp_random_graph(10, .5, seed=42)
+            self.graph = retworkx.directed_gnp_random_graph(10, 0.5, seed=42)
 
     def test_distance_matrix(self):
         res = retworkx.distance_matrix(self.graph)
@@ -59,8 +59,7 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertTrue(numpy.array_equal(expected_res, res))
 
     def test_astar_shortest_path(self):
-        res = retworkx.astar_shortest_path(self.graph, 0, lambda _: True,
-                                           lambda _: 1, lambda _: 1)
+        res = retworkx.astar_shortest_path(self.graph, 0, lambda _: True, lambda _: 1, lambda _: 1)
         self.assertIsInstance(list(res), list)
 
     def test_dijkstra_shortest_paths(self):
@@ -68,8 +67,7 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertIsInstance(res, retworkx.PathMapping)
 
     def test_dijkstra_shortest_path_lengths(self):
-        res = retworkx.dijkstra_shortest_path_lengths(self.graph, 0,
-                                                      lambda _: 1)
+        res = retworkx.dijkstra_shortest_path_lengths(self.graph, 0, lambda _: 1)
         self.assertIsInstance(res, retworkx.PathLengthMapping)
 
     def test_k_shortest_path_lengths(self):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -16,9 +16,8 @@ import retworkx
 
 
 class TestGNPRandomGraph(unittest.TestCase):
-
     def test_random_gnp_directed(self):
-        graph = retworkx.directed_gnp_random_graph(20, .5, seed=10)
+        graph = retworkx.directed_gnp_random_graph(20, 0.5, seed=10)
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 104)
 
@@ -34,14 +33,14 @@ class TestGNPRandomGraph(unittest.TestCase):
 
     def test_random_gnp_directed_invalid_num_nodes(self):
         with self.assertRaises(ValueError):
-            retworkx.directed_gnp_random_graph(-23, .5)
+            retworkx.directed_gnp_random_graph(-23, 0.5)
 
     def test_random_gnp_directed_invalid_probability(self):
         with self.assertRaises(ValueError):
             retworkx.directed_gnp_random_graph(23, 123.5)
 
     def test_random_gnp_undirected(self):
-        graph = retworkx.undirected_gnp_random_graph(20, .5, seed=10)
+        graph = retworkx.undirected_gnp_random_graph(20, 0.5, seed=10)
         self.assertEqual(len(graph), 20)
         self.assertEqual(len(graph.edges()), 105)
 
@@ -57,7 +56,7 @@ class TestGNPRandomGraph(unittest.TestCase):
 
     def test_random_gnp_undirected_invalid_num_nodes(self):
         with self.assertRaises(ValueError):
-            retworkx.undirected_gnp_random_graph(-23, .5)
+            retworkx.undirected_gnp_random_graph(-23, 0.5)
 
     def test_random_gnp_undirected_invalid_probability(self):
         with self.assertRaises(ValueError):
@@ -65,7 +64,6 @@ class TestGNPRandomGraph(unittest.TestCase):
 
 
 class TestGNMRandomGraph(unittest.TestCase):
-
     def test_random_gnm_directed(self):
         graph = retworkx.directed_gnm_random_graph(20, 100)
         self.assertEqual(len(graph), 20)
@@ -152,7 +150,6 @@ class TestGNMRandomGraph(unittest.TestCase):
 
 
 class TestGeometricRandomGraph(unittest.TestCase):
-
     def test_random_geometric_empty(self):
         graph = retworkx.random_geometric_graph(20, 0)
         self.assertEqual(len(graph), 20)
@@ -172,14 +169,14 @@ class TestGeometricRandomGraph(unittest.TestCase):
 
     def test_random_geometric_dim(self):
         graph = retworkx.random_geometric_graph(10, 0.5, dim=3)
-        self.assertEqual(len(graph[0]['pos']), 3)
+        self.assertEqual(len(graph[0]["pos"]), 3)
 
     def test_random_geometric_pos(self):
         pos = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
         graph = retworkx.random_geometric_graph(3, 0.15, pos=pos)
         self.assertEqual(set(graph.edge_list()), {(0, 1), (1, 2)})
         for i in range(3):
-            self.assertEqual(graph[i]['pos'], pos[i])
+            self.assertEqual(graph[i]["pos"], pos[i])
 
     def test_random_geometric_pos_1norm(self):
         pos = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
@@ -188,8 +185,7 @@ class TestGeometricRandomGraph(unittest.TestCase):
 
     def test_random_geometric_pos_inf_norm(self):
         pos = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
-        graph = retworkx.random_geometric_graph(3, 0.11, pos=pos,
-                                                p=float('inf'))
+        graph = retworkx.random_geometric_graph(3, 0.11, pos=pos, p=float("inf"))
         self.assertEqual(set(graph.edge_list()), {(0, 1), (1, 2)})
 
     def test_random_geometric_num_nodes_invalid(self):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -185,7 +185,9 @@ class TestGeometricRandomGraph(unittest.TestCase):
 
     def test_random_geometric_pos_inf_norm(self):
         pos = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
-        graph = retworkx.random_geometric_graph(3, 0.11, pos=pos, p=float("inf"))
+        graph = retworkx.random_geometric_graph(
+            3, 0.11, pos=pos, p=float("inf")
+        )
         self.assertEqual(set(graph.edge_list()), {(0, 1), (1, 2)})
 
     def test_random_geometric_num_nodes_invalid(self):

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,12 @@ commands =
 [testenv:lint]
 basepython = python3
 deps =
-  black
+  black==21.5b0
   flake8
   setuptools-rust
 whitelist_externals=cargo
 commands =
-  black --check {posargs} '../retworkx' '../tests'
+  black --check --diff {posargs} '../retworkx' '../tests'
   flake8 --per-file-ignores='../retworkx/__init__.py:F405,F403' ../setup.py ../retworkx
   cargo fmt -- --check
 
@@ -44,7 +44,7 @@ commands =
 [testenv:black]
 basepython = python3
 deps =
-  black
+  black==21.5b0
 commands = black {posargs} '../retworkx' '../tests'
 
 [flake8]
@@ -57,4 +57,3 @@ max-line-length = 105
 ignore = E125,E123,E129,E711
 extend-ignore = E203, W503
 exclude = .venv,.git,.tox,dist,doc,*egg,build
-

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands = black {posargs} '../retworkx' '../tests'
 # E129 skipped because it is too limiting when combined with other rules
 # E711 skipped because sqlalchemy filter() requires using == instead of is
 # max-line-length, E203, W503 are added for black compatibility
-max-line-length = 105
+max-line-length = 85
 ignore = E125,E123,E129,E711
 extend-ignore = E203, W503
 exclude = .venv,.git,.tox,dist,doc,*egg,build

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,12 @@ commands =
 [testenv:lint]
 basepython = python3
 deps =
+  black
   flake8
   setuptools-rust
 whitelist_externals=cargo
 commands =
+  black --check {posargs} '../retworkx' '../tests'
   flake8 --per-file-ignores='../retworkx/__init__.py:F405,F403' ../setup.py ../retworkx
   cargo fmt -- --check
 
@@ -38,6 +40,12 @@ deps =
 changedir = {toxinidir}/docs
 commands =
   sphinx-build -W -b html source build/html {posargs}
+
+[testenv:black]
+basepython = python3
+deps =
+  black
+commands = black {posargs} '../retworkx' '../tests'
 
 [flake8]
 # E125 is deliberately excluded. See https://github.com/jcrocholl/pep8/issues/126

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
 
 [testenv:lint]
 basepython = python3
+envdir = .tox/lint
 deps =
   black==21.5b0
   flake8
@@ -43,6 +44,7 @@ commands =
 
 [testenv:black]
 basepython = python3
+envdir = .tox/lint
 deps =
   black==21.5b0
 commands = black {posargs} '../retworkx' '../tests'

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,9 @@ commands = black {posargs} '../retworkx' '../tests'
 # E123 skipped because it is ignored by default in the default pep8
 # E129 skipped because it is too limiting when combined with other rules
 # E711 skipped because sqlalchemy filter() requires using == instead of is
+# max-line-length, E203, W503 are added for black compatibility
+max-line-length = 105
 ignore = E125,E123,E129,E711
+extend-ignore = E203, W503
 exclude = .venv,.git,.tox,dist,doc,*egg,build
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Format Python code with [black](https://github.com/psf/black) to align code formatting with [recent changes to other Qiskit repositories](https://github.com/Qiskit/qiskit-terra/pull/6361).

This formatting changes a massive amount of test files, so I will highlight the files that actually need to be reviewed:
*  `tox.ini` for adding `tox -eblack` and making `flake8` agree with `black`
* `pyproject.toml` for adding `black` settings
* `CONTRIBUTING.md` with instructions to run `black` for new contributors
* `.github/workflows/main.yml` for checking `black` codestyle in CI 