### PR TITLE
Add `is_subgraph_isomorphic` function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -61,6 +61,8 @@ Specific Graph Type Methods
    retworkx.is_directed_acyclic_graph
    retworkx.digraph_is_isomorphic
    retworkx.graph_is_isomorphic
+   retworkx.digraph_is_subgraph_isomorphic
+   retworkx.graph_is_subgraph_isomorphic
    retworkx.topological_sort
    retworkx.descendants
    retworkx.ancestors
@@ -127,6 +129,7 @@ type functions in the algorithms API but can be run with a
    retworkx.k_shortest_path_lengths
    retworkx.dfs_edges
    retworkx.is_isomorphic
+   retworkx.is_subgraph_isomorphic
    retworkx.is_isomorphic_node_match
    retworkx.transitivity
    retworkx.core_number

--- a/releasenotes/notes/add-subgraph-isomorphism-d22c1b5b015769ec.yaml
+++ b/releasenotes/notes/add-subgraph-isomorphism-d22c1b5b015769ec.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    A new function, :func:`~retworkx.is_subgraph_isomorphic` was added to
+    determine if two graphs of type :class:`~retworkx.PyGraph` or
+    :class:`~retworkx.PyDiGraph` are induced subgraph isomorphic.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -621,6 +621,69 @@ def _graph_is_isomorphic_node_match(first, second, matcher, id_order=True):
 
 
 @functools.singledispatch
+def is_subgraph_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
+    """Determine if 2 graphs are subgraph isomorphic
+
+    This checks if 2 graphs are subgraph isomorphic both structurally and also
+    comparing the node and edge data using the provided matcher functions.
+    The matcher functions take in 2 data objects and will compare them. A
+    simple example that checks if they're just equal would be::
+
+            graph_a = retworkx.PyGraph()
+            graph_b = retworkx.PyGraph()
+            retworkx.is_subgraph_isomorphic(graph_a, graph_b,
+                                            lambda x, y: x == y)
+
+    .. note::
+
+        For better performance on large graphs, consider setting
+        `id_order=False`.
+
+    :param first: The first graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param second: The second graph to compare. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+        It should be the same type as the first graph.
+    :param callable node_matcher: A python callable object that takes 2
+        positional one for each node data object. If the return of this
+        function evaluates to True then the nodes passed to it are viewed
+        as matching.
+    :param callable edge_matcher: A python callable object that takes 2
+        positional one for each edge data object. If the return of this
+        function evaluates to True then the edges passed to it are viewed
+        as matching.
+    :param bool id_order: If set to ``False`` this function will use a
+        heuristic matching order based on [VF2]_ paper. Otherwise it will
+        default to matching the nodes in order specified by their ids.
+
+    :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`
+        , ``False`` if there is not.
+    :rtype: bool
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(first))
+
+
+@is_subgraph_isomorphic.register(PyDiGraph)
+def _digraph_is_subgraph_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
+    return digraph_is_subgraph_isomorphic(
+        first, second, node_matcher, edge_matcher, id_order
+    )
+
+
+@is_subgraph_isomorphic.register(PyGraph)
+def _graph_is_subgraph_isomorphic(
+    first, second, node_matcher=None, edge_matcher=None, id_order=True
+):
+    return graph_is_subgraph_isomorphic(
+        first, second, node_matcher, edge_matcher, id_order
+    )
+
+
+@functools.singledispatch
 def transitivity(graph):
     """Compute the transitivity of a graph.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,6 +426,142 @@ fn graph_is_isomorphic(
     Ok(res)
 }
 
+/// Determine if 2 directed graphs are subgraph - isomorphic
+///
+/// This checks if 2 graphs are subgraph isomorphic both structurally and also
+/// comparing the node data and edge data using the provided matcher functions.
+/// The matcher function takes in 2 data objects and will compare them. A simple
+/// example that checks if they're just equal would be::
+///
+///     graph_a = retworkx.PyDiGraph()
+///     graph_b = retworkx.PyDiGraph()
+///     retworkx.is_subgraph_isomorphic(graph_a, graph_b,
+///                                     lambda x, y: x == y)
+///
+/// .. note::
+///
+///     For better performance on large graphs, consider setting `id_order=False`.
+///
+/// :param PyDiGraph first: The first graph to compare
+/// :param PyDiGraph second: The second graph to compare
+/// :param callable node_matcher: A python callable object that takes 2 positional
+///     one for each node data object. If the return of this
+///     function evaluates to True then the nodes passed to it are vieded
+///     as matching.
+/// :param callable edge_matcher: A python callable object that takes 2 positional
+///     one for each edge data object. If the return of this
+///     function evaluates to True then the edges passed to it are vieded
+///     as matching.
+/// :param bool id_order: If set to ``False`` this function will use a
+///     heuristic matching order based on [VF2]_ paper. Otherwise it will
+///     default to matching the nodes in order specified by their ids.
+///
+/// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
+///     ``False`` if there is not.
+/// :rtype: bool
+#[pyfunction(id_order = "true")]
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=True, /)"]
+fn digraph_is_subgraph_isomorphic(
+    py: Python,
+    first: &digraph::PyDiGraph,
+    second: &digraph::PyDiGraph,
+    node_matcher: Option<PyObject>,
+    edge_matcher: Option<PyObject>,
+    id_order: bool,
+) -> PyResult<bool> {
+    let compare_nodes = node_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let compare_edges = edge_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let res = isomorphism::is_subgraph_isomorphic(
+        py,
+        &first.graph,
+        &second.graph,
+        compare_nodes,
+        compare_edges,
+        id_order,
+    )?;
+    Ok(res)
+}
+
+/// Determine if 2 undirected graphs are subgraph - isomorphic
+///
+/// This checks if 2 graphs are subgraph isomorphic both structurally and also
+/// comparing the node data and edge data using the provided matcher functions.
+/// The matcher function takes in 2 data objects and will compare them. A simple
+/// example that checks if they're just equal would be::
+///
+///     graph_a = retworkx.PyGraph()
+///     graph_b = retworkx.PyGraph()
+///     retworkx.is_subgraph_isomorphic(graph_a, graph_b,
+///                                     lambda x, y: x == y)
+///
+/// .. note::
+///
+///     For better performance on large graphs, consider setting `id_order=False`.
+///
+/// :param PyGraph first: The first graph to compare
+/// :param PyGraph second: The second graph to compare
+/// :param callable node_matcher: A python callable object that takes 2 positional
+///     one for each node data object. If the return of this
+///     function evaluates to True then the nodes passed to it are vieded
+///     as matching.
+/// :param callable edge_matcher: A python callable object that takes 2 positional
+///     one for each edge data object. If the return of this
+///     function evaluates to True then the edges passed to it are vieded
+///     as matching.
+/// :param bool (default=True) id_order:  If set to true, the algorithm matches the
+///     nodes in order specified by their ids. Otherwise, it uses a heuristic
+///     matching order based in [VF2]_ paper.
+///
+/// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
+///     ``False`` if there is not.
+/// :rtype: bool
+#[pyfunction(id_order = "true")]
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=True, /)"]
+fn graph_is_subgraph_isomorphic(
+    py: Python,
+    first: &graph::PyGraph,
+    second: &graph::PyGraph,
+    node_matcher: Option<PyObject>,
+    edge_matcher: Option<PyObject>,
+    id_order: bool,
+) -> PyResult<bool> {
+    let compare_nodes = node_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let compare_edges = edge_matcher.map(|f| {
+        move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
+            let res = f.call1(py, (a, b))?;
+            Ok(res.is_true(py).unwrap())
+        }
+    });
+
+    let res = isomorphism::is_subgraph_isomorphic(
+        py,
+        &first.graph,
+        &second.graph,
+        compare_nodes,
+        compare_edges,
+        id_order,
+    )?;
+    Ok(res)
+}
+
 /// Return the topological sort of node indexes from the provided graph
 ///
 /// :param PyDiGraph graph: The DAG to get the topological sort on
@@ -3567,6 +3703,8 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(is_directed_acyclic_graph))?;
     m.add_wrapped(wrap_pyfunction!(digraph_is_isomorphic))?;
     m.add_wrapped(wrap_pyfunction!(graph_is_isomorphic))?;
+    m.add_wrapped(wrap_pyfunction!(digraph_is_subgraph_isomorphic))?;
+    m.add_wrapped(wrap_pyfunction!(graph_is_subgraph_isomorphic))?;
     m.add_wrapped(wrap_pyfunction!(digraph_union))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(descendants))?;

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -1,0 +1,186 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestSubgraphIsomorphic(unittest.TestCase):
+    def test_subgraph_isomorphic_identical(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
+                )
+
+    def test_subgraph_isomorphic_mismatch_node_data(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )
+
+    def test_subgraph_isomorphic_compare_nodes_mismatch_node_data(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
+                )
+
+    def test_subgraph_isomorphic_compare_nodes_identical(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
+                )
+
+    def test_is_subgraph_isomorphic_nodes_compare_raises(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+
+        def compare_nodes(a, b):
+            raise TypeError("Failure")
+
+        self.assertRaises(
+            TypeError, retworkx.is_subgraph_isomorphic, (g_a, g_a, compare_nodes)
+        )
+
+    def test_subgraph_isomorphic_compare_edges_identical(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a,
+                        g_b,
+                        edge_matcher=lambda x, y: x == y,
+                        id_order=id_order,
+                    )
+                )
+
+    def test_subgraph_isomorphic_node_count_not_ge(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1")])
+
+        nodes = g_b.add_nodes_from(["a_0", "a_1", "a_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1")])
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )
+
+    def test_non_induced_subgraph_isomorphic(self):
+        g_a = retworkx.PyDiGraph()
+        g_b = retworkx.PyDiGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[2], nodes[0], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -1,0 +1,186 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestSubgraphIsomorphic(unittest.TestCase):
+    def test_subgraph_isomorphic_identical(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
+                )
+
+    def test_subgraph_isomorphic_mismatch_node_data(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )
+
+    def test_subgraph_isomorphic_compare_nodes_mismatch_node_data(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
+                )
+
+    def test_subgraph_isomorphic_compare_nodes_identical(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, lambda x, y: x == y, id_order=id_order
+                    )
+                )
+
+    def test_is_subgraph_isomorphic_nodes_compare_raises(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+
+        def compare_nodes(a, b):
+            raise TypeError("Failure")
+
+        self.assertRaises(
+            TypeError, retworkx.is_subgraph_isomorphic, (g_a, g_a, compare_nodes)
+        )
+
+    def test_subgraph_isomorphic_compare_edges_identical(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[0], nodes[3], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a,
+                        g_b,
+                        edge_matcher=lambda x, y: x == y,
+                        id_order=id_order,
+                    )
+                )
+
+    def test_subgraph_isomorphic_node_count_not_ge(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2"])
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1")])
+
+        nodes = g_b.add_nodes_from(["a_0", "a_1", "a_3"])
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1")])
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )
+
+    def test_non_induced_subgraph_isomorphic(self):
+        g_a = retworkx.PyGraph()
+        g_b = retworkx.PyGraph()
+
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_a.add_edges_from(
+            [
+                (nodes[0], nodes[1], "a_1"), 
+                (nodes[1], nodes[2], "a_2"),
+                (nodes[2], nodes[0], "a_3"),
+            ]
+        )
+
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
+        g_b.add_edges_from(
+            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
+        )
+        for id_order in [False, True]:
+            with self.subTest(id_order=id_order):
+                self.assertFalse(
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                )


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
Adds a function to determine if two graphs are induced subgraph isomorphic. 
This new feature is simple to implement since it's the same code with `is_isomorphic` function except in feasibility rules we check `>=` relation instead of `==`.