### PR TITLE
Allow failures on ppc64le linux travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
   fast_finish: true
   allow_failures:
     - name: Python 3.7 Tests s390x Linux
+    - name: Python 3.7 Tests ppc64le Linux
   include:
     - name: Python 3.7 Tests ppc64le Linux
       stage: Linux non-x86_64


### PR DESCRIPTION
In recent weeks we've seen a spike in job timeouts and other spurious
failures for the ppc64le CI. It looks like the travis ppc64le
environment is facing some issues. Since none of the recent failures
have caught any real code issues when running or building on ppc64le
and are all caused by infrastructure issues, this commit adds it to
the allowed failure list. We can remove it when and if the ppc64le ci
environment stabilizes.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
