### PR TITLE
Add missing doc theme template file

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,24 @@
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="rst-current-version-label">{{ version_label }}</span>
+    <span class="rst-versions-dropdown-icon"></span>
+  </span>
+  <div class="rst-other-versions">
+    {% if translations %}
+    <dl>
+      <dt>{{ _('Languages') }}</dt>
+      {% for code, language in translations_list %}
+        <dd><a class="version" href="{{ translation_url(code, pagename) }}">{{ language }}</a></dd>
+      {% endfor %}
+    </dl>
+    {% endif %}
+  </div>
+  <script>
+    jQuery('.version').click((evt) => {
+      const hash = window.location.hash
+      const complete_url = evt.target.href + hash
+      window.location = complete_url
+      evt.preventDefault()
+    })
+  </script>
+</div>


### PR DESCRIPTION
This commit adds a missing template file for the qiskit-sphinx-theme.
PR #329 previously attempted to fix the RTD docs builds and update the
theme formatting. While that worked fine for PR mode after it merged the
builds for the latest version of the docs did not work and fail with an
error about the missing template file. This will hopefully fix the
builds so we can see the rendered docs for the current state of the main
branch.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
