### PR TITLE
Add stable versions to the documentation

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -8,6 +8,10 @@
       <dt>Versions</dt>
           <dd><a class="version" href="/documentation/retworkx/index.html">Current Release</a></dd>
           <dd><a class="version" href="/documentation/retworkx/dev/index.html">Development</a></dd>
+      <dt>Previous Releases</dt>
+        {% for version in version_list %}
+            <dd><a class="version" href"/documentation/retworkx/stable/{{ version }}">{{ version }}</a></dd>
+        {% endfor %}
     </dl>
   </div>
   <script>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys, os
+import subprocess
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -303,3 +304,34 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+def _get_versions(app, config):
+    context = config.html_context
+    start_version = (0, 8, 0)
+    proc = subprocess.run(['git', 'describe', '--abbrev=0'],
+                          capture_output=True)
+    proc.check_returncode()
+    current_version = proc.stdout.decode('utf8')
+    current_version_info = current_version.split('.')
+    if current_version_info[0] == '0':
+        version_list = [
+            '0.%s' % x for x in range(start_version[1],
+                                      int(current_version_info[1]) + 1)]
+    else:
+        #TODO: When 1.0.0 add code to handle 0.x version list
+        version_list = []
+        pass
+    context['version_list'] = version_list
+    context['version_label'] = _get_version_label(current_version)
+
+
+def _get_version_label(current_version):
+    if not os.getenv('RETWORKX_DEV_DOCS', None):
+        current_version_info = current_version.split('.')
+        return ".".join(current_version_info[:-1])
+    else:
+        return "Development"
+
+
+def setup(app):
+    app.connect('config-inited', _get_versions)

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -36,4 +36,4 @@ openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/
 echo "Pushing built docs to website"
 rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx
 echo "Pushing built docs to stable site"
-rclone sync --progress ./docs/build/html "IBMCOS:qiskit-org-web-resources/documentation/retworkx/stable/$STABLE_VERSION"
+rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx/stable/$STABLE_VERSION

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -26,7 +26,14 @@ tox -edocs
 echo "show current dir: "
 pwd
 
+CURRENT_TAG=`git describe --abbrev=0`
+IFS='.'
+read -ra VERSION <<< "$CURRENT_TAG"
+STABLE_VERSION="${VERSION[0]}\.${VERSION[1]}"
+
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
 rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx
+echo "Pushing built docs to stable site"
+rclone sync --progress ./docs/build/html "IBMCOS:qiskit-org-web-resources/documentation/retworkx/stable/$STABLE_VERSION"

--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -1,1 +1,2 @@
 dev/**
+stable/**


### PR DESCRIPTION
This commit adds support for keeping multiple released versions of the
documentation on the documentation page. It will keep a single version
of the doc for each minor release of retworkx (for example 0.8, 0.9,
etc). Each tag documentation build will upload it's built docs to both
the latest stable url and the appropriate url on stable/. The version
table for the drop down will also be populated with the previous versions
from 0.8 to current.

TODO:

- [x] Add stable/0.8 version of docs to hosted docs so dev version links correctly.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
