### PR TITLE
Add methods to get number of nodes and edges in the graph

### DIFF
--- a/releasenotes/notes/add-num-methods-08ac0963b9961f5e.yaml
+++ b/releasenotes/notes/add-num-methods-08ac0963b9961f5e.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added a new method, :meth:`~retworkx.PyDiGraph.num_nodes`, to the
+    :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph`
+    (:meth:`~retworkx.PyGraph.num_nodes`) for returning the number of nodes
+    in the graph.
+  - |
+    Added a new method, :meth:`~retworkx.PyDiGraph.num_edges`, to the
+    :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph`
+    (:meth:`~retworkx.PyGraph.num_edges`) for returning the number of edges
+    in the graph.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -522,6 +522,19 @@ impl PyDiGraph {
     fn multigraph(&self) -> bool {
         self.multigraph
     }
+
+    /// Return the number of nodes in the graph
+    #[text_signature = "(self)"]
+    pub fn num_nodes(&self) -> usize {
+        self.graph.node_count()
+    }
+
+    /// Return the number of edges in the graph
+    #[text_signature = "(self)"]
+    pub fn num_edges(&self) -> usize {
+        self.graph.edge_count()
+    }
+
     /// Return a list of all edge data.
     ///
     /// :returns: A list of all the edge data objects in the graph

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -370,6 +370,18 @@ impl PyGraph {
         self.multigraph
     }
 
+    /// Return the number of nodes in the graph
+    #[text_signature = "(self)"]
+    pub fn num_nodes(&self) -> usize {
+        self.graph.node_count()
+    }
+
+    /// Return the number of edges in the graph
+    #[text_signature = "(self)"]
+    pub fn num_edges(&self) -> usize {
+        self.graph.edge_count()
+    }
+
     /// Return a list of all edge data.
     ///
     /// :returns: A list of all the edge data objects in the graph

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -40,6 +40,20 @@ class TestEdges(unittest.TestCase):
             retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b
         )
 
+    def test_num_edges(self):
+        graph = retworkx.PyDiGraph()
+        graph.add_node(1)
+        graph.add_node(42)
+        graph.add_node(146)
+        graph.add_edges_from_no_data([(0, 1), (1, 2)])
+        self.assertEqual(2, graph.num_edges())
+
+    def test_num_edges_no_edges(self):
+        graph = retworkx.PyDiGraph()
+        graph.add_node(1)
+        graph.add_node(42)
+        self.assertEqual(0, graph.num_edges())
+
     def test_update_edge(self):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -280,6 +280,17 @@ class TestNodes(unittest.TestCase):
         dag = retworkx.PyDAG()
         self.assertEqual(0, len(dag))
 
+    def test_pydigraph_num_nodes(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "An_edge")
+        self.assertEqual(2, graph.num_nodes())
+
+    def test_pydigraph_num_nodes_empty(self):
+        graph = retworkx.PyDiGraph()
+        self.assertEqual(0, graph.num_nodes())
+
     def test_add_nodes_from(self):
         dag = retworkx.PyDAG()
         nodes = list(range(100))

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -42,6 +42,20 @@ class TestEdges(unittest.TestCase):
             retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
         )
 
+    def test_num_edges(self):
+        graph = retworkx.PyGraph()
+        graph.add_node(1)
+        graph.add_node(42)
+        graph.add_node(146)
+        graph.add_edges_from_no_data([(0, 1), (1, 2)])
+        self.assertEqual(2, graph.num_edges())
+
+    def test_num_edges_no_edges(self):
+        graph = retworkx.PyGraph()
+        graph.add_node(1)
+        graph.add_node(42)
+        self.assertEqual(0, graph.num_edges())
+
     def test_update_edge(self):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -92,9 +92,20 @@ class TestNodes(unittest.TestCase):
         graph.add_edge(node_a, node_b, "An_edge")
         self.assertEqual(2, len(graph))
 
+    def test_pygraph_num_nodes(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, "An_edge")
+        self.assertEqual(2, graph.num_nodes())
+
     def test_pygraph_length_empty(self):
         graph = retworkx.PyGraph()
         self.assertEqual(0, len(graph))
+
+    def test_pygraph_num_nodes_empty(self):
+        graph = retworkx.PyGraph()
+        self.assertEqual(0, graph.num_nodes())
 
     def test_add_nodes_from(self):
         graph = retworkx.PyGraph()


### PR DESCRIPTION
This commit adds two new methods num_nodes() and num_edges() to the
graph classes for returning the number of nodes and edges respectively
in the graph. While a user could do len(graph) to get the number of
nodes having an explicit method also is useful as it might not be
obvious that you can use len() on the graph.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
