### PR TITLE
Add copy() method to graph classes

### DIFF
--- a/releasenotes/notes/add-copy-method-f2abb1222b323dab.yaml
+++ b/releasenotes/notes/add-copy-method-f2abb1222b323dab.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    A new method, :meth:`~retworkx.PyDiGraph.copy`, has been added to the
+    :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph`
+    (:meth:`~retworkx.PyGraph.copy`) classes. This method will return a shallow
+    copy of a graph object.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2287,6 +2287,15 @@ impl PyDiGraph {
             multigraph: true,
         }
     }
+
+    /// Return a shallow copy of the graph
+    ///
+    /// All node and edge weight/data payloads in the copy will have a
+    /// shared reference to the original graph.
+    #[text_signature = "(self)"]
+    pub fn copy(&self) -> PyDiGraph {
+        self.clone()
+    }
 }
 
 #[pyproto]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1485,6 +1485,15 @@ impl PyGraph {
             multigraph: self.multigraph,
         }
     }
+
+    /// Return a shallow copy of the graph
+    ///
+    /// All node and edge weight/data payloads in the copy will have a
+    /// shared reference to the original graph.
+    #[text_signature = "(self)"]
+    pub fn copy(&self) -> PyGraph {
+        self.clone()
+    }
 }
 
 #[pyproto]

--- a/tests/digraph/test_copy.py
+++ b/tests/digraph/test_copy.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestDeepcopy(unittest.TestCase):
+    def test_copy_returns_graph(self):
+        graph_a = retworkx.PyDiGraph()
+        node_a = graph_a.add_node("a_1")
+        node_b = graph_a.add_node("a_2")
+        graph_a.add_edge(node_a, node_b, "edge_1")
+        node_c = graph_a.add_node("a_3")
+        graph_a.add_edge(node_b, node_c, "edge_2")
+        graph_b = graph_a.copy()
+        self.assertIsInstance(graph_b, retworkx.PyDiGraph)
+
+    def test_copy_with_holes_returns_graph(self):
+        graph_a = retworkx.PyDiGraph()
+        node_a = graph_a.add_node("a_1")
+        node_b = graph_a.add_node("a_2")
+        graph_a.add_edge(node_a, node_b, "edge_1")
+        node_c = graph_a.add_node("a_3")
+        graph_a.add_edge(node_b, node_c, "edge_2")
+        graph_a.remove_node(node_b)
+        graph_b = graph_a.copy()
+        self.assertIsInstance(graph_b, retworkx.PyDiGraph)
+        self.assertEqual([node_a, node_c], graph_b.node_indexes())
+
+    def test_copy_empty(self):
+        graph = retworkx.PyDiGraph()
+        empty_copy = graph.copy()
+        self.assertEqual(len(empty_copy), 0)
+
+    def test_copy_shared_ref(self):
+        graph_a = retworkx.PyDiGraph()
+        node_a = graph_a.add_node({"a": 1})
+        node_b = graph_a.add_node({"b": 2})
+        graph_a.add_edge(node_a, node_b, {"edge": 1})
+        graph_b = graph_a.copy()
+        graph_a[0]["a"] = 42
+        graph_b.get_edge_data(0, 1)["edge"] = 162
+        self.assertEqual(graph_b[0]["a"], 42)
+        self.assertEqual(graph_a.get_edge_data(0, 1), {"edge": 162})

--- a/tests/digraph/test_copy.py
+++ b/tests/digraph/test_copy.py
@@ -15,7 +15,7 @@ import unittest
 import retworkx
 
 
-class TestDeepcopy(unittest.TestCase):
+class TestCopy(unittest.TestCase):
     def test_copy_returns_graph(self):
         graph_a = retworkx.PyDiGraph()
         node_a = graph_a.add_node("a_1")

--- a/tests/graph/test_copy.py
+++ b/tests/graph/test_copy.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestDeepcopy(unittest.TestCase):
+    def test_copy_returns_graph(self):
+        graph_a = retworkx.PyGraph()
+        node_a = graph_a.add_node("a_1")
+        node_b = graph_a.add_node("a_2")
+        graph_a.add_edge(node_a, node_b, "edge_1")
+        node_c = graph_a.add_node("a_3")
+        graph_a.add_edge(node_b, node_c, "edge_2")
+        graph_b = graph_a.copy()
+        self.assertIsInstance(graph_b, retworkx.PyGraph)
+
+    def test_copy_with_holes_returns_graph(self):
+        graph_a = retworkx.PyGraph()
+        node_a = graph_a.add_node("a_1")
+        node_b = graph_a.add_node("a_2")
+        graph_a.add_edge(node_a, node_b, "edge_1")
+        node_c = graph_a.add_node("a_3")
+        graph_a.add_edge(node_b, node_c, "edge_2")
+        graph_a.remove_node(node_b)
+        graph_b = graph_a.copy()
+        self.assertIsInstance(graph_b, retworkx.PyGraph)
+        self.assertEqual([node_a, node_c], graph_b.node_indexes())
+
+    def test_copy_empty(self):
+        graph = retworkx.PyGraph()
+        empty_copy = graph.copy()
+        self.assertEqual(len(empty_copy), 0)
+
+    def test_copy_shared_ref(self):
+        graph_a = retworkx.PyGraph()
+        node_a = graph_a.add_node({"a": 1})
+        node_b = graph_a.add_node({"b": 2})
+        graph_a.add_edge(node_a, node_b, {"edge": 1})
+        graph_b = graph_a.copy()
+        graph_a[0]["a"] = 42
+        graph_b.get_edge_data(0, 1)["edge"] = 162
+        self.assertEqual(graph_b[0]["a"], 42)
+        self.assertEqual(graph_a.get_edge_data(0, 1), {"edge": 162})

--- a/tests/graph/test_copy.py
+++ b/tests/graph/test_copy.py
@@ -15,7 +15,7 @@ import unittest
 import retworkx
 
 
-class TestDeepcopy(unittest.TestCase):
+class TestCopy(unittest.TestCase):
     def test_copy_returns_graph(self):
         graph_a = retworkx.PyGraph()
         node_a = graph_a.add_node("a_1")


### PR DESCRIPTION
This commit adds a new copy() method to the graph classes to return a
shallow copy (with shared references to weight/data payload objects) of
a graph object.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
