### PR TITLE
Remove sphinx pinning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.todo',
               'sphinx.ext.viewcode',
               'm2r2',
-              'jupyter_sphinx.execute',
+              'jupyter_sphinx',
               'reno.sphinxext',
               'sphinx.ext.intersphinx',
              ]

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,7 +1,7 @@
 m2r2
-sphinx<3.3.0
+sphinx>=3.0.0
 sphinx_rtd_theme
-jupyter-sphinx==0.2.3
+jupyter-sphinx
 pydot
 pillow>=4.2.1
 reno>=3.2.0


### PR DESCRIPTION
Now that we've moved our docs publishing away from read the docs to our
own hosting we are no longer constrained by the build environment for
read the docs as we're running builds in github actions now. This means
we no longer need to pin our sphinx version, or jupyter-sphinx version
for our docs jobs. This commit updates the docs requirements list and
the sphinx config to no longer pin these requirements.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
