### PR TITLE
Add section to retworkx for networkx users guide on matrix converters

### DIFF
--- a/docs/source/networkx.rst
+++ b/docs/source/networkx.rst
@@ -285,6 +285,27 @@ Graph Modifiers
 (note the retworkx version links to the :class:`~retworkx.PyDiGraph` version,
 but there are also equivalent :class:`~retworkx.PyGraph` methods available)
 
+Matrix Converter Functions
+--------------------------
+
+NetworkX has several functions for going back and forth between a NetworkX
+graph and matrices in other libraries. This includes ``to_numpy_matrix()``,
+``to_numpy_array()``, ``to_numpy_recarray()``, ``to_scipy_sparse_matrix()``,
+``to_pandas_adjacency()``, and ``adjacency_matrix()`` (which is equivalent to
+``to_scipy_sparse_matrix()`` and returns a scipy csr sparse matrix of the
+adjacency matrix).
+
+However, in retworkx there is **only** a :meth:`~retworkx.adjacency_matrix`
+function (and it's per type variants :meth:`~retworkx.digraph_adjacency_matrix`
+and :meth:`~retworkx.graph_adjacency_matrix`) which will return a numpy array
+of the adjacency matrix (**not** a scipy csr sparse matrix like networkx's
+function). This function is equivalent to networkx's ``to_numpy_array()``
+function.
+
+This difference with retworkx is primarily because numpy exposes a public C
+interface which retworkx can interface with directly, while the other
+libraries and types only expose Python APIs.
+
 .. _networkx_converter:
 
 Converting from a networkx graph


### PR DESCRIPTION
This commit adds documentation to the retworkx for networkx users guide
on the differences between networkx and retworkx when it comes to matrix
generation. Right now retworkx only has an `adjacency_matrix()` function
which is equivalent to networkx's `to_numpy_array()` and returns a numpy
array of the adjacency matrix. This is different from networkx's
`adjacency_matrix()` function which returns a scipy sparse array (and is
just an alias for networkx's `to_scipy_sparse_matrix()`). Documenting
this gap is important because it's easy to get confused by these API
differences.

This difference is fundamentally because we can effeciently create numpy
arrays in retworkx by just pass a pointer to numpy with a 2d array
that was constructed natively in rust (using rust-numpy) while other
matrix formats (such as scipy sparse matrices) don't expose a C api so
to create those objects we'd have to go through Python. Eventually we
might expand the API to include pure python functions to do additional
conversions (although I worry about increasing the external dependency
list) but numpy arrays will still be the default because of the inherent
performance benefits.

Fixes #342

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
