### PR TITLE
Bump cibuildwheel version to latest release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.9.0 twine
+          python -m pip install cibuildwheel==1.11.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: joerick/cibuildwheel@v1.11.1
         env:
           CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64 universal2
@@ -113,7 +113,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.9.0 twine
+          python -m pip install cibuildwheel==1.11.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,10 +2,8 @@
 name: Wheel Builds
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+    tags:
+      - '*'
 jobs:
   sdist:
     name: Build sdist
@@ -24,7 +22,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -60,7 +62,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-10.15
@@ -83,7 +89,11 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -116,4 +126,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,8 +2,10 @@
 name: Wheel Builds
 on:
   push:
-    tags:
-      - '*'
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   sdist:
     name: Build sdist
@@ -22,11 +24,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -62,11 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-10.15
@@ -89,11 +83,7 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -126,8 +116,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx testtools fixtures
+        - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS blank
@@ -87,7 +87,7 @@ jobs:
         - CIBW_BEFORE_BUILD="bash {project}/tools/install_rust.sh"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx testtools fixtures
+        - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS blank
@@ -108,7 +108,7 @@ jobs:
         - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin"'
-        - CIBW_TEST_REQUIRES=networkx testtools fixtures
+        - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS blank

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -97,7 +97,7 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - stage: deploy
@@ -119,6 +119,6 @@ jobs:
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
       if: tag IS present
       script:
-        - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
+        - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ script:
   - tox -epy
 stages:
   - name: Linux non-x86_64
-    if: tag IS present
-  - name: deploy
     if: tag IS blank
+  - name: deploy
+    if: tag IS present
 
 jobs:
   fast_finish: true
@@ -69,10 +69,11 @@ jobs:
         - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS blank
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
       python: 3.7
@@ -90,10 +91,11 @@ jobs:
         - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS blank
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
       python: 3.7
@@ -111,7 +113,8 @@ jobs:
         - CIBW_TEST_REQUIRES="networkx testtools fixtures"
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS blank
+      if: tag IS present
       script:
         - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
       services:
         - docker
       before_install:
-        - echo ""
+        - sudo chown travis -R $TRAVIS_HOME/.cargo
       install:
         - echo ""
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,11 +79,7 @@ jobs:
       services:
         - docker
       before_install:
-        - which python
-        - sh tools/install_rust.sh
-        - export PATH=~/.cargo/bin:$PATH
-        - which python
-        - pip install -U pip virtualenv tox
+        - echo ""
       install:
         - echo ""
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ script:
   - tox -epy
 stages:
   - name: Linux non-x86_64
-    if: tag IS blank
-  - name: deploy
     if: tag IS present
+  - name: deploy
+    if: tag IS blank
 
 jobs:
   fast_finish: true
@@ -69,11 +69,10 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+      if: tag IS blank
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
     - stage: deploy
       arch: ppc64le
       python: 3.7
@@ -95,11 +94,10 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+      if: tag IS blank
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
     - stage: deploy
       arch: s390x
       python: 3.7
@@ -117,8 +115,7 @@ jobs:
         - CIBW_TEST_REQUIRES=networkx testtools fixtures
         - TWINE_USERNAME=retworkx-ci
         - CIBW_TEST_COMMAND="python -m unittest discover {project}/tests"
-      if: tag IS present
+      if: tag IS blank
       script:
         - sudo pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*


### PR DESCRIPTION
This commit bumps the cibuildwheel version we use for the release jobs
to the latest release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
