### PR TITLE
[Discussion] Use FnvHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +531,7 @@ name = "retworkx"
 version = "0.9.0"
 dependencies = [
  "fixedbitset",
+ "fnv",
  "hashbrown",
  "ndarray",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ numpy = "0.13.1"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1.5"
+fnv = "1.0.7"
 
 [dependencies.pyo3]
 version = "0.13.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use petgraph::visit::{
 };
 use petgraph::EdgeType;
 
+use fnv::FnvHashMap;
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
 use rand::distributions::{Distribution, Uniform};
@@ -898,7 +899,7 @@ fn graph_greedy_color(
     py: Python,
     graph: &graph::PyGraph,
 ) -> PyResult<PyObject> {
-    let mut colors: HashMap<usize, usize> = HashMap::new();
+    let mut colors: FnvHashMap<usize, usize> = FnvHashMap::default();
     let mut node_vec: Vec<NodeIndex> = graph.graph.node_indices().collect();
     let mut sort_map: HashMap<NodeIndex, usize> =
         HashMap::with_capacity(graph.node_count());


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Discussion for #347.
FNV hash is faster hash than Rust's default hash.
See https://crates.io/crates/fnv more details.

This can fix the order of the result.

Unfortunately, the results of my benchmarking were almost the same.