### PR TITLE
Bump version post-release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Black Codestyle Format
         run: black --check --diff retworkx tests
       - name: Python Lint
-        run: flake8 setup.py tests
+        run: flake8 --per-file-ignores='retworkx/__init__.py:F405,F403' setup.py retworkx tests
   tests:
     needs: [build_lint]
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retworkx"
 description = "A python graph library implemented in Rust"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,9 +83,9 @@ copyright = u'2021, retworkx Contributors'
 # built documents.
 #
 # The short X.Y version.
-version = '0.9.0'
+version = '0.10.0'
 # The full version, including alpha/beta/rc tags.
-release = '0.9.0'
+release = '0.10.0'
 
 if not os.getenv('RETWORKX_DEV_DOCS', None):
     rst_prolog = """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ graphviz_extras = ['pydot>=1.4', 'pillow>=5.4']
 
 setup(
     name="retworkx",
-    version="0.9.0",
+    version="0.10.0",
     description="A python graph library implemented in Rust",
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Now that 0.9.0 is out the door this commit bumps the package version on
the main development branch to enable landing new features. It doesn't
look like we're going to have a bugfix release (and if we do we can just
branch from the 0.9.0 tag). Bumping the version strings enables us t
differentiate the development branch from the previous release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
