### PR TITLE
Fix execution of graphivz tests in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
   stestr
 extras =
   mpl
-  pydot
+  graphviz
 passenv = RETWORKX_TEST_PRESERVE_IMAGES
 changedir = {toxinidir}/tests
 commands =


### PR DESCRIPTION
This commit fixes the tox job configuration so we actually install the
requirements for running the graphviz drawer tests. To run the graphviz
drawer tests you need graphviz installed in addition to the retworkx
extras requirements 'graphviz' (which contains pillow and pydot).
However, prior to #339 the extra was called 'pydot' not 'graphviz' and
this was never updated in the tox.ini. This has resulted in the graphivz
drawer tests all being skipped because we're not installing the python
requirements in the test environment. This commit fixes this oversight
and configures tox to install the correct extra so we can run the tests
(at least on linux where we install graphviz in CI).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
