### PR TITLE
Add a gitattributes file for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/* linguist-documentation
+releasenotes/* linguist-documentation

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -1,8 +1,0 @@
-$env:PATH="$env:PYTHON;$env:PYTHON\\Scripts;$env:PATH"
-
-Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.msi"
-Start-Process -FilePath "msiexec.exe" -ArgumentList "/i rust-nightly-$env:TARGET.msi INSTALLDIR=`"$((Get-Location).Path)\rust-nightly-$env:TARGET`" /quiet /qn /norestart" -Wait
-$env:PATH="$env:PATH;$((Get-Location).Path)/rust-nightly-$env:TARGET/bin"
-
-$pythonLocation = Invoke-Expression "python -c `"import sys; print(sys.base_prefix)`""
-$env:LIBPATH = "$env:LIBPATH; $( Join-Path $pythonLocation "libs" )"


### PR DESCRIPTION
This commit adds a new gitattributes file to mark the documentation
and release note directories as containing documentation (and therefore
excluding them from language statistics on github). This is documented
here: https://github.com/github/linguist/blob/master/docs/overrides.md

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
