### PR TITLE
Add multigraph option to`PyDiGraph.to_undirected`

### DIFF
--- a/releasenotes/notes/multigraph-option-in-to-undirected-b56af4f26816be61.yaml
+++ b/releasenotes/notes/multigraph-option-in-to-undirected-b56af4f26816be61.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Two new kwargs, ``multigraph`` and ``weight_combo_fn``, was added to
+    :meth:`~retworkx.PyDiGraph.to_undirected`. This can be used to set
+    whether the generated :class:`~retworkx.PyGraph` object is a multi graph or not
+    (whether parallel edges can be added or not). By default this is set to ``True``.
+    If set to ``False`` an extra python callable object should be specified to combine
+    the weights/data of parallel edges.

--- a/releasenotes/notes/multigraph-option-in-to-undirected-b56af4f26816be61.yaml
+++ b/releasenotes/notes/multigraph-option-in-to-undirected-b56af4f26816be61.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+features:
   - |
     Two new kwargs, ``multigraph`` and ``weight_combo_fn``, was added to
     :meth:`~retworkx.PyDiGraph.to_undirected`. This can be used to set

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2347,9 +2347,13 @@ impl PyDiGraph {
                 let exists = new_graph.find_edge(source, target);
                 match exists {
                     Some(index) => {
-                        let old_weight = new_graph.edge_weight_mut(index).unwrap();
-                        match combine(old_weight, edge.weight(), &weight_combo_fn)?
-                        {
+                        let old_weight =
+                            new_graph.edge_weight_mut(index).unwrap();
+                        match combine(
+                            old_weight,
+                            edge.weight(),
+                            &weight_combo_fn,
+                        )? {
                             Some(value) => {
                                 *old_weight = value;
                             }
@@ -2357,7 +2361,7 @@ impl PyDiGraph {
                                 *old_weight = weight;
                             }
                         }
-                    },
+                    }
                     None => new_graph.add_edge(source, target, weight),
                 }
             }

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2304,7 +2304,7 @@ impl PyDiGraph {
     /// :returns: A new PyGraph object with an undirected edge for every
     ///     directed edge in this graph
     /// :rtype: PyGraph
-    #[text_signature = "(self)"]
+    #[text_signature = "(self, multigraph, weight_combo_fn, /)"]
     #[args(multigraph = "true", weight_combo_fn = "None")]
     pub fn to_undirected(
         &self,

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2305,7 +2305,7 @@ impl PyDiGraph {
     ///     directed edge in this graph
     /// :rtype: PyGraph
     #[text_signature = "(self)"]
-    #[args(multigraph = "true", weight_comb_fn = "None")]
+    #[args(multigraph = "true", weight_combo_fn = "None")]
     pub fn to_undirected(
         &self,
         py: Python,

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2362,7 +2362,9 @@ impl PyDiGraph {
                             }
                         }
                     }
-                    None => new_graph.add_edge(source, target, weight),
+                    None => {
+                        new_graph.add_edge(source, target, weight);
+                    }
                 }
             }
         }

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2338,20 +2338,21 @@ impl PyDiGraph {
             let &source = node_map.get(&edge.source()).unwrap();
             let &target = node_map.get(&edge.target()).unwrap();
             let weight = edge.weight().clone_ref(py);
-            if multigraph {
-                new_graph.add_edge(source, target, weight);
-            } else {
+            let mut processed = false;
+            if !multigraph {
                 let exists = new_graph.find_edge(source, target);
                 if let Some(index) = exists {
                     let old_weight = new_graph.edge_weight_mut(index).unwrap();
                     if let Some(value) =
                         combine(old_weight, edge.weight(), &weight_combo_fn)?
                     {
-                        *old_weight = value
+                        *old_weight = value;
+                        processed = true;
                     }
-                } else {
-                    new_graph.add_edge(source, target, weight);
                 }
+            }
+            if !processed {
+                new_graph.add_edge(source, target, weight);
             }
         }
         Ok(crate::graph::PyGraph {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2011,7 +2011,7 @@ pub fn digraph_dijkstra_shortest_paths(
             // TODO: Use petgraph undirected adapter after
             // https://github.com/petgraph/petgraph/pull/318 is available in
             // a petgraph release.
-            &graph.to_undirected(py),
+            &graph.to_undirected(py, true, None)?,
             start,
             goal_index,
             |e| weight_callable(py, &weight_fn, e.weight(), default_weight),

--- a/tests/digraph/test_to_undirected.py
+++ b/tests/digraph/test_to_undirected.py
@@ -37,6 +37,22 @@ class TestToUndirected(unittest.TestCase):
             digraph.weighted_edge_list(), graph.weighted_edge_list()
         )
 
+    def test_bidirectional_not_multigraph(self):
+        digraph = retworkx.generators.directed_path_graph(5)
+        for i in range(0, 4):
+            digraph.add_edge(i + 1, i, None)
+        graph = digraph.to_undirected(multigraph=False)
+        self.assertEqual(graph.edge_list(), [(0, 1), (1, 2), (2, 3), (3, 4)])
+
+    def test_multiple_edges_combo_weight_not_multigraph(self):
+        digraph = retworkx.PyDiGraph()
+        digraph.add_nodes_from([0, 1])
+        digraph.add_edges_from([(0, 1, "a"), (0, 1, "b")])
+        graph = digraph.to_undirected(
+            multigraph=False, weight_combo_fn=lambda x, y: x + y
+        )
+        self.assertEqual(graph.weighted_edge_list(), [(0, 1, "ab")])
+
     def test_shared_ref(self):
         digraph = retworkx.PyDiGraph()
         node_weight = {"a": 1}


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
Closes #369.

Instead of relying to the default graph api that would keep the *last* edge data among the parallel edges we see, i added an optional weight_combo_fn` argument that combines all edge data. Do note here that if `weight_combo_fn` is omitted, the behavior is the same as the default graph api.