### PR TITLE
Remove unnecessary borrows from code

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1797,7 +1797,7 @@ impl PyDiGraph {
         let dir = petgraph::Direction::Outgoing;
         let edges = self.graph.edges_directed(index, dir);
         for edge in edges {
-            let edge_predicate_raw = predicate_callable(&edge.weight())?;
+            let edge_predicate_raw = predicate_callable(edge.weight())?;
             let edge_predicate: bool = edge_predicate_raw.extract(py)?;
             if edge_predicate {
                 return Ok(self.graph.node_weight(edge.target()).unwrap());

--- a/src/dot_utils.rs
+++ b/src/dot_utils.rs
@@ -51,7 +51,7 @@ where
             file,
             "{} {};",
             graph.to_index(node.id()),
-            attr_map_to_string(py, node_attrs.as_ref(), &node.weight())?
+            attr_map_to_string(py, node_attrs.as_ref(), node.weight())?
         )?;
     }
     for edge in graph.edge_references() {
@@ -61,7 +61,7 @@ where
             graph.to_index(edge.source()),
             EDGE[graph.is_directed() as usize],
             graph.to_index(edge.target()),
-            attr_map_to_string(py, edge_attrs.as_ref(), &edge.weight())?
+            attr_map_to_string(py, edge_attrs.as_ref(), edge.weight())?
         )?;
     }
     writeln!(file, "}}")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,7 +635,7 @@ where
             let mut index = count;
             for child in &children[index..] {
                 index += 1;
-                if !visited.contains(&child) {
+                if !visited.contains(child) {
                     out_vec.push((parent.index(), child.index()));
                     visited.insert(*child);
                     let mut grandchildren: Vec<NodeIndex> =
@@ -3757,7 +3757,7 @@ pub fn minimum_spanning_edges(
         Vec::with_capacity(graph.graph.edge_count());
     for edge in graph.edge_references() {
         let weight =
-            weight_callable(py, &weight_fn, &edge.weight(), default_weight)?;
+            weight_callable(py, &weight_fn, edge.weight(), default_weight)?;
         if weight.is_nan() {
             return Err(PyValueError::new_err("NaN found as an edge weight"));
         }
@@ -3965,7 +3965,7 @@ where
     let mut weights: HashMap<(usize, usize), f64> =
         HashMap::with_capacity(2 * graph.edge_count());
     for e in graph.edge_references() {
-        let w = weight_callable(py, &weight_fn, &e.weight(), default_weight)?;
+        let w = weight_callable(py, &weight_fn, e.weight(), default_weight)?;
         let source = e.source().index();
         let target = e.target().index();
 

--- a/src/max_weight_matching.rs
+++ b/src/max_weight_matching.rs
@@ -108,7 +108,7 @@ fn assign_label(
     best_edge[b] = None;
     if t == 1 {
         // b became an S-vertex/blossom; add it(s verticies) to the queue
-        queue.append(&mut blossom_leaves(b, num_nodes, &blossom_children)?);
+        queue.append(&mut blossom_leaves(b, num_nodes, blossom_children)?);
     } else if t == 2 {
         // b became a T-vertex/blossom; assign label S to its mate.
         // (If b is a non-trivial blossom, its base is the only vertex
@@ -279,7 +279,7 @@ fn add_blossom(
     // Set dual variable to 0
     dual_var[blossom] = 0;
     // Relabel vertices
-    for node in blossom_leaves(blossom, num_nodes, &blossom_children)? {
+    for node in blossom_leaves(blossom, num_nodes, blossom_children)? {
         if labels[in_blossoms[node]] == Some(2) {
             // This T-vertex now turns into an S-vertex because it becomes
             // part of an S-blossom; add it to the queue
@@ -296,7 +296,7 @@ fn add_blossom(
         // get the information from the vertices.
         let nblists: Vec<Vec<usize>> = if blossom_best_edges[bv].is_empty() {
             let mut tmp: Vec<Vec<usize>> = Vec::new();
-            for node in blossom_leaves(bv, num_nodes, &blossom_children)? {
+            for node in blossom_leaves(bv, num_nodes, blossom_children)? {
                 tmp.push(
                     neighbor_endpoints[node].iter().map(|p| p / 2).collect(),
                 );
@@ -316,12 +316,8 @@ fn add_blossom(
                 if blossom_j != blossom
                     && labels[blossom_j] == Some(1)
                     && (best_edge_to.get(&blossom_j).is_none()
-                        || slack(edge_index, &dual_var, &edges)
-                            < slack(
-                                best_edge_to[&blossom_j],
-                                &dual_var,
-                                &edges,
-                            ))
+                        || slack(edge_index, dual_var, edges)
+                            < slack(best_edge_to[&blossom_j], dual_var, edges))
                 {
                     best_edge_to.insert(blossom_j, edge_index);
                 }
@@ -336,8 +332,8 @@ fn add_blossom(
     best_edge[blossom] = None;
     for edge_index in &blossom_best_edges[blossom] {
         if best_edge[blossom].is_none()
-            || slack(*edge_index, &dual_var, &edges)
-                < slack(best_edge[blossom].unwrap(), &dual_var, &edges)
+            || slack(*edge_index, dual_var, edges)
+                < slack(best_edge[blossom].unwrap(), dual_var, edges)
         {
             best_edge[blossom] = Some(*edge_index);
         }


### PR DESCRIPTION
In the current nightly version of rust's clippy a new check for finding
unnecessary borrows on variables was added. This check has identified
several places we're passing a borrowed references that wasn't
necessary. This commit just fixes those places identified by nightly
clippy so that when rust 1.55 is released we don't have any issues.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
