### PR TITLE
Add induced kwarg in `is_subgraph_isomorphic`

### DIFF
--- a/releasenotes/notes/non-induced-subgraph-isomorphism-710f5a21565abf06.yaml
+++ b/releasenotes/notes/non-induced-subgraph-isomorphism-710f5a21565abf06.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    A new kwarg, ``induced``, was added to :func:`~retworkx.is_subgraph_isomorphic`.
+    If set to ``True`` the function will check if the second graph is isomorphic to a
+    node-induced subgraph of the first. If set to ``False`` it will check if the second
+    graph is isomorphic to a subgraph of the first. By default this is set to ``True``.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -744,14 +744,23 @@ def _graph_is_isomorphic_node_match(first, second, matcher, id_order=True):
 
 @functools.singledispatch
 def is_subgraph_isomorphic(
-    first, second, node_matcher=None, edge_matcher=None, id_order=False
+    first,
+    second,
+    node_matcher=None,
+    edge_matcher=None,
+    id_order=False,
+    induced=True,
 ):
     """Determine if 2 graphs are subgraph isomorphic
 
     This checks if 2 graphs are subgraph isomorphic both structurally and also
     comparing the node and edge data using the provided matcher functions.
-    The matcher functions take in 2 data objects and will compare them. A
-    simple example that checks if they're just equal would be::
+    The matcher functions take in 2 data objects and will compare them.
+    Since there is an ambiguity in the term 'subgraph', do note that we check
+    for an node-induced subgraph if argument `induced` is set to `True`. If it is
+    set to `False`, we check for a non induced subgraph, meaning the second graph
+    can have fewer edges than the subgraph of the first. A simple example that checks
+    if they're just equal would be::
 
             graph_a = retworkx.PyGraph()
             graph_b = retworkx.PyGraph()
@@ -775,6 +784,8 @@ def is_subgraph_isomorphic(
     :param bool id_order: If set to ``True`` this function will match the nodes
         in order specified by their ids. Otherwise it will default to a heuristic
         matching order based on [VF2]_ paper.
+    :param bool induced: If set to ``True`` this function will check the existence
+        of a node-induced subgraph of first isomorphic to second graph. Default: ``True``.
 
     :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`
         , ``False`` if there is not.
@@ -785,19 +796,29 @@ def is_subgraph_isomorphic(
 
 @is_subgraph_isomorphic.register(PyDiGraph)
 def _digraph_is_subgraph_isomorphic(
-    first, second, node_matcher=None, edge_matcher=None, id_order=False
+    first,
+    second,
+    node_matcher=None,
+    edge_matcher=None,
+    id_order=False,
+    induced=True,
 ):
     return digraph_is_subgraph_isomorphic(
-        first, second, node_matcher, edge_matcher, id_order
+        first, second, node_matcher, edge_matcher, id_order, induced
     )
 
 
 @is_subgraph_isomorphic.register(PyGraph)
 def _graph_is_subgraph_isomorphic(
-    first, second, node_matcher=None, edge_matcher=None, id_order=False
+    first,
+    second,
+    node_matcher=None,
+    edge_matcher=None,
+    id_order=False,
+    induced=True,
 ):
     return graph_is_subgraph_isomorphic(
-        first, second, node_matcher, edge_matcher, id_order
+        first, second, node_matcher, edge_matcher, id_order, induced
     )
 
 

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -785,7 +785,8 @@ def is_subgraph_isomorphic(
         in order specified by their ids. Otherwise it will default to a heuristic
         matching order based on [VF2]_ paper.
     :param bool induced: If set to ``True`` this function will check the existence
-        of a node-induced subgraph of first isomorphic to second graph. Default: ``True``.
+        of a node-induced subgraph of first isomorphic to second graph.
+        Default: ``True``.
 
     :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`
         , ``False`` if there is not.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -759,8 +759,8 @@ def is_subgraph_isomorphic(
     Since there is an ambiguity in the term 'subgraph', do note that we check
     for an node-induced subgraph if argument `induced` is set to `True`. If it is
     set to `False`, we check for a non induced subgraph, meaning the second graph
-    can have fewer edges than the subgraph of the first. A simple example that checks
-    if they're just equal would be::
+    can have fewer edges than the subgraph of the first. By default it's `True`. A
+    simple example that checks if they're just equal would be::
 
             graph_a = retworkx.PyGraph()
             graph_b = retworkx.PyGraph()

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -706,12 +706,12 @@ where
                     return Ok(false);
                 }
             }
-            // semantic feasibility: compare associated data for nodes
-            if node_match.enabled()
-                && !node_match.eq(&g[0][nodes[0]], &g[1][nodes[1]])?
-            {
-                return Ok(false);
-            }
+        }
+        // semantic feasibility: compare associated data for nodes
+        if node_match.enabled()
+            && !node_match.eq(&g[0][nodes[0]], &g[1][nodes[1]])?
+        {
+            return Ok(false);
         }
         // semantic feasibility: compare associated data for edges
         if edge_match.enabled() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,8 +435,12 @@ fn graph_is_isomorphic(
 ///
 /// This checks if 2 graphs are subgraph isomorphic both structurally and also
 /// comparing the node data and edge data using the provided matcher functions.
-/// The matcher function takes in 2 data objects and will compare them. A simple
-/// example that checks if they're just equal would be::
+/// The matcher function takes in 2 data objects and will compare them.
+/// Since there is an ambiguity in the term 'subgraph', do note that we check
+/// for an node-induced subgraph if argument `induced` is set to `True`. If it is
+/// set to `False`, we check for a non induced subgraph, meaning the second graph
+/// can have fewer edges than the subgraph of the first. By default it's `True`. A
+/// simple example that checks if they're just equal would be::
 ///
 ///     graph_a = retworkx.PyDiGraph()
 ///     graph_b = retworkx.PyDiGraph()
@@ -506,8 +510,12 @@ fn digraph_is_subgraph_isomorphic(
 ///
 /// This checks if 2 graphs are subgraph isomorphic both structurally and also
 /// comparing the node data and edge data using the provided matcher functions.
-/// The matcher function takes in 2 data objects and will compare them. A simple
-/// example that checks if they're just equal would be::
+/// The matcher function takes in 2 data objects and will compare them.
+/// Since there is an ambiguity in the term 'subgraph', do note that we check
+/// for an node-induced subgraph if argument `induced` is set to `True`. If it is
+/// set to `False`, we check for a non induced subgraph, meaning the second graph
+/// can have fewer edges than the subgraph of the first. By default it's `True`. A
+/// simple example that checks if they're just equal would be::
 ///
 ///     graph_a = retworkx.PyGraph()
 ///     graph_b = retworkx.PyGraph()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@ fn graph_is_isomorphic(
 ///     ``False`` if there is not.
 /// :rtype: bool
 #[pyfunction(id_order = "false", induced = "true")]
-#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, induced=True, /)"]
+#[text_signature = "(first, second, /, node_matcher=None, edge_matcher=None, id_order=False, induced=True)"]
 fn digraph_is_subgraph_isomorphic(
     py: Python,
     first: &digraph::PyDiGraph,
@@ -536,7 +536,7 @@ fn digraph_is_subgraph_isomorphic(
 ///     ``False`` if there is not.
 /// :rtype: bool
 #[pyfunction(id_order = "false", induced = "true")]
-#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, induced=True, /)"]
+#[text_signature = "(first, second, /, node_matcher=None, edge_matcher=None, id_order=False, induced=True)"]
 fn graph_is_subgraph_isomorphic(
     py: Python,
     first: &graph::PyGraph,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,7 @@ fn digraph_is_isomorphic(
         compare_edges,
         id_order,
         Ordering::Equal,
+        true,
     )?;
     Ok(res)
 }
@@ -425,6 +426,7 @@ fn graph_is_isomorphic(
         compare_edges,
         id_order,
         Ordering::Equal,
+        true,
     )?;
     Ok(res)
 }
@@ -462,8 +464,8 @@ fn graph_is_isomorphic(
 /// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
 ///     ``False`` if there is not.
 /// :rtype: bool
-#[pyfunction(id_order = "false")]
-#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, /)"]
+#[pyfunction(id_order = "false", induced = "true")]
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, induced=True, /)"]
 fn digraph_is_subgraph_isomorphic(
     py: Python,
     first: &digraph::PyDiGraph,
@@ -471,6 +473,7 @@ fn digraph_is_subgraph_isomorphic(
     node_matcher: Option<PyObject>,
     edge_matcher: Option<PyObject>,
     id_order: bool,
+    induced: bool,
 ) -> PyResult<bool> {
     let compare_nodes = node_matcher.map(|f| {
         move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
@@ -494,6 +497,7 @@ fn digraph_is_subgraph_isomorphic(
         compare_edges,
         id_order,
         Ordering::Greater,
+        induced,
     )?;
     Ok(res)
 }
@@ -531,8 +535,8 @@ fn digraph_is_subgraph_isomorphic(
 /// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
 ///     ``False`` if there is not.
 /// :rtype: bool
-#[pyfunction(id_order = "false")]
-#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, /)"]
+#[pyfunction(id_order = "false", induced = "true")]
+#[text_signature = "(first, second, node_matcher=None, edge_matcher=None, id_order=False, induced=True, /)"]
 fn graph_is_subgraph_isomorphic(
     py: Python,
     first: &graph::PyGraph,
@@ -540,6 +544,7 @@ fn graph_is_subgraph_isomorphic(
     node_matcher: Option<PyObject>,
     edge_matcher: Option<PyObject>,
     id_order: bool,
+    induced: bool,
 ) -> PyResult<bool> {
     let compare_nodes = node_matcher.map(|f| {
         move |a: &PyObject, b: &PyObject| -> PyResult<bool> {
@@ -563,6 +568,7 @@ fn graph_is_subgraph_isomorphic(
         compare_edges,
         id_order,
         Ordering::Greater,
+        induced,
     )?;
     Ok(res)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,6 +464,9 @@ fn graph_is_isomorphic(
 /// :param bool id_order: If set to ``True`` this function will match the nodes
 ///     in order specified by their ids. Otherwise it will default to a heuristic
 ///     matching order based on [VF2]_ paper.
+/// :param bool induced: If set to ``True`` this function will check the existence
+///     of a node-induced subgraph of first isomorphic to second graph.
+///     Default: ``True``.
 ///
 /// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
 ///     ``False`` if there is not.
@@ -539,6 +542,9 @@ fn digraph_is_subgraph_isomorphic(
 /// :param bool id_order: If set to ``True`` this function will match the nodes
 ///     in order specified by their ids. Otherwise it will default to a heuristic
 ///     matching order based on [VF2]_ paper.
+/// :param bool induced: If set to ``True`` this function will check the existence
+///     of a node-induced subgraph of first isomorphic to second graph.
+///     Default: ``True``.
 ///
 /// :returns: ``True`` if there is a subgraph of `first` isomorphic to `second`,
 ///     ``False`` if there is not.

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -178,13 +178,13 @@ class TestSubgraphIsomorphic(unittest.TestCase):
             [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
         )
         for id_order in [False, True]:
-            with self.subTest(id_order=id_order):
+            with self.subTest(id_order=id_order, induced=True):
                 self.assertFalse(
                     retworkx.is_subgraph_isomorphic(
                         g_a, g_b, id_order=id_order, induced=True
                     )
                 )
-            with self.subTest(id_order=id_order):
+            with self.subTest(id_order=id_order, induced=False):
                 self.assertTrue(
                     retworkx.is_subgraph_isomorphic(
                         g_a, g_b, id_order=id_order, induced=False

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -180,5 +180,27 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, id_order=id_order, induced=True
+                    )
                 )
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, id_order=id_order, induced=False
+                    )
+                )
+
+    def test_non_induced_grid_subgraph_isomorphic(self):
+        g_a = retworkx.generators.directed_grid_graph(2, 2)
+        g_b = retworkx.PyDiGraph()
+        g_b.add_nodes_from([0, 1, 2, 3])
+        g_b.add_edges_from_no_data([(0, 1), (2, 3)])
+
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True)
+        )
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False)
+        )

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -178,13 +178,13 @@ class TestSubgraphIsomorphic(unittest.TestCase):
             [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
         )
         for id_order in [False, True]:
-            with self.subTest(id_order=id_order):
+            with self.subTest(id_order=id_order, induced=True):
                 self.assertFalse(
                     retworkx.is_subgraph_isomorphic(
                         g_a, g_b, id_order=id_order, induced=True
                     )
                 )
-            with self.subTest(id_order=id_order):
+            with self.subTest(id_order=id_order, induced=False):
                 self.assertTrue(
                     retworkx.is_subgraph_isomorphic(
                         g_a, g_b, id_order=id_order, induced=False

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -180,5 +180,27 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, id_order=id_order, induced=True
+                    )
                 )
+            with self.subTest(id_order=id_order):
+                self.assertTrue(
+                    retworkx.is_subgraph_isomorphic(
+                        g_a, g_b, id_order=id_order, induced=False
+                    )
+                )
+
+    def test_non_induced_grid_subgraph_isomorphic(self):
+        g_a = retworkx.generators.grid_graph(2, 2)
+        g_b = retworkx.PyGraph()
+        g_b.add_nodes_from([0, 1, 2, 3])
+        g_b.add_edges_from_no_data([(0, 1), (2, 3)])
+
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True)
+        )
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False)
+        )

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import random
 
 import retworkx
 
@@ -197,3 +198,31 @@ class TestGeometricRandomGraph(unittest.TestCase):
     def test_random_geometric_pos_num_nodes_incomp(self):
         with self.assertRaises(ValueError):
             retworkx.random_geometric_graph(3, 0.15, pos=[[0.5, 0.5]])
+
+
+class TestRandomSubGraphIsomorphism(unittest.TestCase):
+    def test_random_gnm_induced_subgraph_isomorphism(self):
+        graph = retworkx.undirected_gnm_random_graph(50, 150)
+        nodes = random.sample(range(50), 25)
+        subgraph = graph.subgraph(nodes)
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(
+                graph, subgraph, id_order=True, induced=True
+            )
+        )
+
+    def test_random_gnm_non_induced_subgraph_isomorphism(self):
+        graph = retworkx.undirected_gnm_random_graph(50, 150)
+        nodes = random.sample(range(50), 25)
+        subgraph = graph.subgraph(nodes)
+
+        indexes = list(subgraph.edge_indices())
+        for idx in random.sample(indexes, len(indexes) // 2):
+            subgraph.remove_edge_from_index(idx)
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(
+                graph, subgraph, id_order=True, induced=False
+            )
+        )


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This commit adds a kwarg `induced` in `is_subgraph_isomorphic` to determine if we should check for a *node-induced* subgraph or *not* induced. Previously, only node-induced case was supported.
In not induced case, the changes are minimal: we shouldn't  check `R_new` pruning rule and check neighbors in `R_suc` and `R_pred` rules only in the second graph. 