### PR TITLE
Handle non-existent files in edgelist cleanup

### DIFF
--- a/tests/digraph/test_edgelist.py
+++ b/tests/digraph/test_edgelist.py
@@ -169,6 +169,12 @@ class TestEdgeList(unittest.TestCase):
         def weight_fn(edge):
             raise KeyError
 
-        self.addCleanup(os.remove, path)
+        def cleanup_file(path):
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+        self.addCleanup(cleanup_file, path)
         with self.assertRaises(KeyError):
             graph.write_edge_list(path, weight_fn=weight_fn)

--- a/tests/graph/test_edgelist.py
+++ b/tests/graph/test_edgelist.py
@@ -169,6 +169,12 @@ class TestEdgeList(unittest.TestCase):
         def weight_fn(edge):
             raise KeyError
 
-        self.addCleanup(os.remove, path)
+        def cleanup_file(path):
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+        self.addCleanup(cleanup_file, path)
         with self.assertRaises(KeyError):
             graph.write_edge_list(path, weight_fn=weight_fn)


### PR DESCRIPTION
In the test_invalid_return_type_weight_fn edge list test methods we're
occasionally seeing CI failures caused by an error in cleanup. The test
method calls a write_edge_list() method of the graph objects that will
raise an exception, however to prevent leaking a temp file an addCleanup
call was added protectively. However, whether the file gets written or
not is not deterministic on every platform (apparently especially on
macOS). To avoid a spurious CI failure this commit adds a custom
function to handle any exceptions raised during cleanup and treat them
as non-fatal.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
