### PR TITLE
Really fix macOS CI failures

### DIFF
--- a/tests/digraph/test_edgelist.py
+++ b/tests/digraph/test_edgelist.py
@@ -158,7 +158,7 @@ class TestEdgeList(unittest.TestCase):
     def test_invalid_return_type_weight_fn(self):
         path = os.path.join(tempfile.gettempdir(), "fail.txt")
         graph = retworkx.directed_gnm_random_graph(5, 4)
-        self.addCleanup(os.remove, path)
+        self.addCleanup(cleanup_file, path)
         with self.assertRaises(TypeError):
             graph.write_edge_list(path, weight_fn=lambda _: 4.5)
 
@@ -169,12 +169,13 @@ class TestEdgeList(unittest.TestCase):
         def weight_fn(edge):
             raise KeyError
 
-        def cleanup_file(path):
-            try:
-                os.remove(path)
-            except Exception:
-                pass
-
         self.addCleanup(cleanup_file, path)
         with self.assertRaises(KeyError):
             graph.write_edge_list(path, weight_fn=weight_fn)
+
+
+def cleanup_file(path):
+    try:
+        os.remove(path)
+    except Exception:
+        pass

--- a/tests/graph/test_edgelist.py
+++ b/tests/graph/test_edgelist.py
@@ -158,7 +158,7 @@ class TestEdgeList(unittest.TestCase):
     def test_invalid_return_type_weight_fn(self):
         path = os.path.join(tempfile.gettempdir(), "fail.txt")
         graph = retworkx.undirected_gnm_random_graph(5, 4)
-        self.addCleanup(os.remove, path)
+        self.addCleanup(cleanup_file, path)
         with self.assertRaises(TypeError):
             graph.write_edge_list(path, weight_fn=lambda _: 4.5)
 
@@ -169,12 +169,13 @@ class TestEdgeList(unittest.TestCase):
         def weight_fn(edge):
             raise KeyError
 
-        def cleanup_file(path):
-            try:
-                os.remove(path)
-            except Exception:
-                pass
-
         self.addCleanup(cleanup_file, path)
         with self.assertRaises(KeyError):
             graph.write_edge_list(path, weight_fn=weight_fn)
+
+
+def cleanup_file(path):
+    try:
+        os.remove(path)
+    except Exception:
+        pass


### PR DESCRIPTION
In #380 we updated the tests to fix some tests when in macOS CI the
,write_edge_list() negative tests were not actually writing a file to
disk which was causing a failure in the cleanup phase. However, that PR
missed a test case which had the same bug and the issue isn't actually
fixed. This commit corrects that oversight and handles a non-existent
file in cleanup for the test cases which were missed.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
