### PR TITLE
Fix incorrect result with dijkstra path functions

### DIFF
--- a/releasenotes/notes/dijkstra-path-bugfix-2c3f8f16d40c47b9.yaml
+++ b/releasenotes/notes/dijkstra-path-bugfix-2c3f8f16d40c47b9.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fixed an issue with the Dijkstra path functions:
+
+      * :func:`retworkx.dijkstra_shortest_paths`
+      * :func:`retworkx.all_pairs_dijkstra_shortest_paths`
+      * :func:`retworkx.digraph_dijkstra_shortest_paths`
+      * :func:`retworkx.graph_dijkstra_shortest_paths`
+      * :func:`retworkx.digraph_all_pairs_dijkstra_shortest_paths`
+      * :func:`retworkx.graph_all_pairs_dijkstra_shortest_paths`
+
+    where the returned paths could be incorrect in cases where there were
+    multiple paths between nodes and an edge weight callback function was
+    specified.
+    Fixed `#387 <https://github.com/Qiskit/retworkx/issues/387>`__

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -138,6 +138,20 @@ where
                     if next_score < *ent.get() {
                         *ent.into_mut() = next_score;
                         visit_next.push(MinScored(next_score, next));
+                        if path.is_some() {
+                            let mut node_path = path
+                                .as_mut()
+                                .unwrap()
+                                .get(&node)
+                                .unwrap()
+                                .clone();
+                            node_path.push(next);
+                            path.as_mut().unwrap().entry(next).and_modify(
+                                |new_vec| {
+                                    *new_vec = node_path;
+                                },
+                            );
+                        }
                     }
                 }
                 Vacant(ent) => {
@@ -146,12 +160,8 @@ where
                     if path.is_some() {
                         let mut node_path =
                             path.as_mut().unwrap().get(&node).unwrap().clone();
-                        path.as_mut().unwrap().entry(next).or_insert({
-                            let mut new_vec: Vec<G::NodeId> = Vec::new();
-                            new_vec.append(&mut node_path);
-                            new_vec.push(next);
-                            new_vec
-                        });
+                        node_path.push(next);
+                        path.as_mut().unwrap().entry(next).or_insert(node_path);
                     }
                 }
             }

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -66,7 +66,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         )
         expected = {
             1: [0, 1],
-            2: [0, 1, 2],
+            2: [0, 3, 2],
             3: [0, 3],
             4: [0, 3, 4],
             5: [0, 1, 5],
@@ -111,9 +111,9 @@ class TestDijkstraDiGraph(unittest.TestCase):
         expected = {
             1: [0, 1],
             2: [0, 2],
-            3: [0, 3],
-            4: [0, 3, 4],
-            5: [0, 1, 5],
+            3: [0, 2, 3],
+            4: [0, 2, 3, 4],
+            5: [0, 2, 5],
         }
         self.assertEqual(expected, paths)
 
@@ -135,7 +135,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
             as_undirected=True,
         )
         expected = {
-            4: [0, 3, 4],
+            4: [0, 2, 3, 4],
         }
         self.assertEqual(expected, paths)
 
@@ -197,11 +197,12 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, lengths)
 
     def test_dijkstra_all_pair_paths(self):
-        lengths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(
+        paths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(
             self.graph, float
         )
+        print(paths)
         expected = {
-            0: {1: [0, 1], 2: [0, 1, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
+            0: {1: [0, 1], 2: [0, 3, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
             1: {
                 0: [1, 2, 0],
                 2: [1, 2],
@@ -226,7 +227,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
             4: {5: [4, 5]},
             5: {},
         }
-        self.assertEqual(expected, lengths)
+        self.assertEqual(expected, paths)
 
     def test_dijkstra_all_pair_path_lengths_with_node_removal(self):
         self.graph.remove_node(3)

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -45,7 +45,9 @@ class TestDijkstraGraph(unittest.TestCase):
         path = retworkx.graph_dijkstra_shortest_paths(
             self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
         )
-        expected = {4: [0, 3, 4]}
+        # a -> d -> e = 23
+        # a -> c -> d -> e = 20
+        expected = {4: [self.a, self.c, self.d, self.e]}
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_no_goal_set(self):
@@ -122,18 +124,30 @@ class TestDijkstraGraph(unittest.TestCase):
         self.assertEqual(expected, lengths)
 
     def test_dijkstra_all_pair_paths(self):
-        lengths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
+        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
             self.graph, float
         )
         expected = {
-            0: {1: [0, 1], 2: [0, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
-            1: {0: [1, 0], 2: [1, 2], 3: [1, 0, 3], 4: [1, 0, 3, 4], 5: [1, 5]},
+            0: {
+                1: [0, 1],
+                2: [0, 2],
+                3: [0, 2, 3],
+                4: [0, 2, 3, 4],
+                5: [0, 2, 5],
+            },
+            1: {0: [1, 0], 2: [1, 2], 3: [1, 2, 3], 4: [1, 2, 3, 4], 5: [1, 5]},
             2: {0: [2, 0], 1: [2, 1], 3: [2, 3], 4: [2, 3, 4], 5: [2, 5]},
-            3: {0: [3, 0], 1: [3, 2, 1], 2: [3, 2], 4: [3, 4], 5: [3, 2, 5]},
-            4: {0: [4, 3, 0], 1: [4, 5, 1], 2: [4, 5, 2], 3: [4, 3], 5: [4, 5]},
-            5: {0: [5, 2, 0], 1: [5, 1], 2: [5, 2], 3: [5, 4, 3], 4: [5, 4]},
+            3: {0: [3, 2, 0], 1: [3, 2, 1], 2: [3, 2], 4: [3, 4], 5: [3, 2, 5]},
+            4: {
+                0: [4, 3, 2, 0],
+                1: [4, 5, 1],
+                2: [4, 3, 2],
+                3: [4, 3],
+                5: [4, 5],
+            },
+            5: {0: [5, 2, 0], 1: [5, 1], 2: [5, 2], 3: [5, 2, 3], 4: [5, 4]},
         }
-        self.assertEqual(expected, lengths)
+        self.assertEqual(expected, paths)
 
     def test_dijkstra_all_pair_path_lengths_with_node_removal(self):
         self.graph.remove_node(3)
@@ -151,17 +165,17 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_paths_with_node_removal(self):
         self.graph.remove_node(3)
-        lengths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
+        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
             self.graph, float
         )
         expected = {
-            0: {1: [0, 1], 2: [0, 2], 4: [0, 1, 5, 4], 5: [0, 1, 5]},
+            0: {1: [0, 1], 2: [0, 2], 4: [0, 2, 5, 4], 5: [0, 2, 5]},
             1: {0: [1, 0], 2: [1, 2], 4: [1, 5, 4], 5: [1, 5]},
             2: {0: [2, 0], 1: [2, 1], 4: [2, 5, 4], 5: [2, 5]},
             4: {0: [4, 5, 2, 0], 1: [4, 5, 1], 2: [4, 5, 2], 5: [4, 5]},
             5: {0: [5, 2, 0], 1: [5, 1], 2: [5, 2], 4: [5, 4]},
         }
-        self.assertEqual(expected, lengths)
+        self.assertEqual(expected, paths)
 
     def test_dijkstra_all_pair_path_lengths_empty_graph(self):
         graph = retworkx.PyGraph()

--- a/tests/graph/test_num_shortest_path.py
+++ b/tests/graph/test_num_shortest_path.py
@@ -120,7 +120,6 @@ class TestNumShortestpath(unittest.TestCase):
             11: 1,
         }
         res = retworkx.num_shortest_paths_unweighted(graph, 0)
-        print(res)
         self.assertEqual(expected, res)
 
     def test_no_edges(self):


### PR DESCRIPTION
This commit fixes an issue with the dijkstra path functions where they
were returning the incorrect result in the case of multiple paths
between nodes in the graph. Previously, in cases of parallel paths the
inner rust dijkstra function was not updating the path if it had a
shorter weight than the already found path. This could result in an
incorrect shortest path being returned, depsite the shortest length
being correct. This fixes this by making sure we always update the path
when we set the distance. Additionally, after fixing this several of the
dijkstra path tests began to fail because they were not returning the
correct result.

Fixes #387

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
