### PR TITLE
Add weighted longest path functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "hashbrown 0.9.1",
  "ndarray",
  "num-bigint",
+ "num-traits",
  "numpy",
  "petgraph",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ numpy = "0.14.1"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1.5"
+num-traits = "0.2"
 num-bigint = "0.4"
 
 [dependencies.pyo3]

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -62,6 +62,7 @@ DAG Algorithms
 
    retworkx.dag_longest_path
    retworkx.dag_longest_path_length
+   retworkx.dag_weighted_longest_path_length
    retworkx.is_directed_acyclic_graph
    retworkx.layers
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -62,6 +62,7 @@ DAG Algorithms
 
    retworkx.dag_longest_path
    retworkx.dag_longest_path_length
+   retworkx.dag_weighted_longest_path
    retworkx.dag_weighted_longest_path_length
    retworkx.is_directed_acyclic_graph
    retworkx.layers

--- a/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
+++ b/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
@@ -1,0 +1,15 @@
+---
+features:
+  - |
+    Added a new algorithm function,
+    :func:`~retworkx.dag_weighted_longest_path_length`, to find the length
+    of the longest path in a:class:`~retworkx.PyDiGraph` object without any
+    cycles. This new function is basically equivalent to
+    :func:`~retworkx.dag_longest_path_length` except for two key differences,
+    the ``weight_fn`` parameter is required for
+    :func:`~retworkx.dag_weighted_longest_path_length` while it is optional
+    in :func:`~retworkx.dag_longest_path_length` and
+    :func:`~retworkx.dag_weighted_longest_path_length` works with ``float``
+    weights (the function returns a float and the ``weight_fn`` callback is
+    expected to return a ``float``) while
+    :func:`~retworkx.dag_longest_path_length` works with an unsigned ``int``.

--- a/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
+++ b/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added two new algorithm function,
+    Added two new algorithm functions,
     :func:`~retworkx.dag_weighted_longest_path_length` and
     :func:`~retworkx.dag_weighted_longest_path`, to find the longest path
     and the length of the longest path in a:class:`~retworkx.PyDiGraph` object

--- a/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
+++ b/releasenotes/notes/add-dag_weighted_longest_path_length-5c4e9a7d19c97d4d.yaml
@@ -1,15 +1,20 @@
 ---
 features:
   - |
-    Added a new algorithm function,
-    :func:`~retworkx.dag_weighted_longest_path_length`, to find the length
-    of the longest path in a:class:`~retworkx.PyDiGraph` object without any
-    cycles. This new function is basically equivalent to
+    Added two new algorithm function,
+    :func:`~retworkx.dag_weighted_longest_path_length` and
+    :func:`~retworkx.dag_weighted_longest_path`, to find the longest path
+    and the length of the longest path in a:class:`~retworkx.PyDiGraph` object
+    without any cycles. This new function is basically equivalent to
+    :func:`~retworkx.dag_longest_path` and
     :func:`~retworkx.dag_longest_path_length` except for two key differences,
     the ``weight_fn`` parameter is required for
+    :func:`~retworkx.dag_weighted_longest_path_length` and
     :func:`~retworkx.dag_weighted_longest_path_length` while it is optional
-    in :func:`~retworkx.dag_longest_path_length` and
-    :func:`~retworkx.dag_weighted_longest_path_length` works with ``float``
+    in :func:`~retworkx.dag_longest_path` and
+    :func:`~retworkx.dag_longest_path_length`. Also,
+    :func:`~retworkx.dag_weighted_longest_path` and
+    :func:`~retworkx.dag_weighted_longest_path_length` work with ``float``
     weights (the function returns a float and the ``weight_fn`` callback is
-    expected to return a ``float``) while
+    expected to return a ``float``) while :func:`~retworkx.dag_longest_path` and
     :func:`~retworkx.dag_longest_path_length` works with an unsigned ``int``.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,9 +225,9 @@ fn dag_longest_path_length(
 /// :param weight_fn: A python callable that will be passed the 3
 ///     positional arguments, the source node, the target node, and the edge
 ///     weight for each edge as the function traverses the graph. It is expected
-///     to return an float weight for that edge. For example,
+///     to return a float weight for that edge. For example,
 ///     ``dag_longest_path(graph, lambda: _, __, weight: weight)`` could be
-///     use to just use an float edge weight. It's also worth noting that this
+///     used to just use a float edge weight. It's also worth noting that this
 ///     function traverses in topological order and only checks incoming edges to
 ///     each node.
 ///
@@ -235,7 +235,7 @@ fn dag_longest_path_length(
 /// :rtype: NodeIndices
 ///
 /// :raises Exception: If an unexpected error occurs or a path can't be found
-/// :raises DAGHasCycle: If the input PyDiGraph has a cyc
+/// :raises DAGHasCycle: If the input PyDiGraph has a cycle
 #[pyfunction]
 #[pyo3(text_signature = "(graph, weight_fn, /)")]
 fn dag_weighted_longest_path(
@@ -270,9 +270,9 @@ fn dag_weighted_longest_path(
 /// :param weight_fn: A python callable that will be passed the 3
 ///     positional arguments, the source node, the target node, and the edge
 ///     weight for each edge as the function traverses the graph. It is expected
-///     to return an float weight for that edge. For example,
+///     to return a float weight for that edge. For example,
 ///     ``dag_longest_path(graph, lambda: _, __, weight: weight)`` could be
-///     use to just use an float edge weight. It's also worth noting that this
+///     used to just use a float edge weight. It's also worth noting that this
 ///     function traverses in topological order and only checks incoming edges to
 ///     each node.
 ///
@@ -280,7 +280,7 @@ fn dag_weighted_longest_path(
 /// :rtype: float
 ///
 /// :raises Exception: If an unexpected error occurs or a path can't be found
-/// :raises DAGHasCycle: If the input PyDiGraph has a cyc
+/// :raises DAGHasCycle: If the input PyDiGraph has a cycle
 #[pyfunction]
 #[pyo3(text_signature = "(graph, weight_fn, /)")]
 fn dag_weighted_longest_path_length(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,17 +116,10 @@ where
         };
         dist.insert(node, maxu);
     }
-    let first = match dist
+    let first = dist
         .keys()
         .max_by(|a, b| dist[a].partial_cmp(&dist[b]).unwrap())
-    {
-        Some(first) => first,
-        None => {
-            return Err(PyException::new_err(
-                "Encountered something unexpected",
-            ))
-        }
-    };
+        .unwrap();
     let mut v = *first;
     let mut u: Option<NodeIndex> = None;
     while match u {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,13 @@ fn dag_weighted_longest_path_length(
     let edge_weight_callable =
         |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
             let res = weight_fn.call1(py, (source, target, weight))?;
-            res.extract(py)
+            let float_res: f64 = res.extract(py)?;
+            if float_res.is_nan() {
+                return Err(PyValueError::new_err(
+                    "NaN is not a valid edge weight",
+                ));
+            }
+            Ok(float_res)
         };
     let (_, path_weight) = longest_path(graph, edge_weight_callable)?;
     Ok(path_weight)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ use petgraph::EdgeType;
 
 use ndarray::prelude::*;
 use num_bigint::{BigUint, ToBigUint};
+use num_traits::{Num, Zero};
 use numpy::IntoPyArray;
 use rand::distributions::{Distribution, Uniform};
 use rand::prelude::*;
@@ -69,21 +70,14 @@ trait NodesRemoved {
     fn nodes_removed(&self) -> bool;
 }
 
-fn longest_path(
-    py: Python,
+fn longest_path<F, T>(
     graph: &digraph::PyDiGraph,
-    weight_fn: Option<PyObject>,
-) -> PyResult<(Vec<usize>, usize)> {
-    let edge_weight_callable =
-        |source: usize, target: usize, weight: &PyObject| -> PyResult<usize> {
-            match &weight_fn {
-                Some(weight_fn) => {
-                    let res = weight_fn.call1(py, (source, target, weight))?;
-                    res.extract(py)
-                }
-                None => Ok(1),
-            }
-        };
+    mut weight_fn: F,
+) -> PyResult<(Vec<usize>, T)>
+where
+    F: FnMut(usize, usize, &PyObject) -> PyResult<T>,
+    T: Num + Zero + PartialOrd + Copy,
+{
     let dag = &graph.graph;
     let mut path: Vec<usize> = Vec::new();
     let nodes = match algo::toposort(graph, None) {
@@ -93,15 +87,15 @@ fn longest_path(
         }
     };
     if nodes.is_empty() {
-        return Ok((path, 0));
+        return Ok((path, T::zero()));
     }
-    let mut dist: HashMap<NodeIndex, (usize, NodeIndex)> = HashMap::new();
+    let mut dist: HashMap<NodeIndex, (T, NodeIndex)> = HashMap::new();
     for node in nodes {
         let parents = dag.edges_directed(node, petgraph::Direction::Incoming);
-        let mut us: Vec<(usize, NodeIndex)> = Vec::new();
+        let mut us: Vec<(T, NodeIndex)> = Vec::new();
         for p_edge in parents {
             let p_node = p_edge.source();
-            let weight: usize = edge_weight_callable(
+            let weight: T = weight_fn(
                 p_node.index(),
                 p_edge.target().index(),
                 p_edge.weight(),
@@ -109,15 +103,23 @@ fn longest_path(
             let length = dist[&p_node].0 + weight;
             us.push((length, p_node));
         }
-        let maxu: (usize, NodeIndex);
-        if !us.is_empty() {
-            maxu = *us.iter().max_by_key(|x| x.0).unwrap();
+        let maxu: (T, NodeIndex) = if !us.is_empty() {
+            *us.iter()
+                .max_by(|a, b| {
+                    let weight_a = a.0;
+                    let weight_b = b.0;
+                    weight_a.partial_cmp(&weight_b).unwrap()
+                })
+                .unwrap()
         } else {
-            maxu = (0, node);
+            (T::zero(), node)
         };
         dist.insert(node, maxu);
     }
-    let first = match dist.keys().max_by_key(|index| dist[index]) {
+    let first = match dist
+        .keys()
+        .max_by(|a, b| dist[a].partial_cmp(&dist[b]).unwrap())
+    {
         Some(first) => first,
         None => {
             return Err(PyException::new_err(
@@ -165,8 +167,18 @@ fn dag_longest_path(
     graph: &digraph::PyDiGraph,
     weight_fn: Option<PyObject>,
 ) -> PyResult<NodeIndices> {
+    let edge_weight_callable =
+        |source: usize, target: usize, weight: &PyObject| -> PyResult<usize> {
+            match &weight_fn {
+                Some(weight_fn) => {
+                    let res = weight_fn.call1(py, (source, target, weight))?;
+                    res.extract(py)
+                }
+                None => Ok(1),
+            }
+        };
     Ok(NodeIndices {
-        nodes: longest_path(py, graph, weight_fn)?.0,
+        nodes: longest_path(graph, edge_weight_callable)?.0,
     })
 }
 
@@ -195,7 +207,56 @@ fn dag_longest_path_length(
     graph: &digraph::PyDiGraph,
     weight_fn: Option<PyObject>,
 ) -> PyResult<usize> {
-    let (_, path_weight) = longest_path(py, graph, weight_fn)?;
+    let edge_weight_callable =
+        |source: usize, target: usize, weight: &PyObject| -> PyResult<usize> {
+            match &weight_fn {
+                Some(weight_fn) => {
+                    let res = weight_fn.call1(py, (source, target, weight))?;
+                    res.extract(py)
+                }
+                None => Ok(1),
+            }
+        };
+    let (_, path_weight) = longest_path(graph, edge_weight_callable)?;
+    Ok(path_weight)
+}
+
+/// Find the length of the weighted longest path in a DAG
+///
+/// This function differs from :func:`retworkx.dag_longest_path_length` in that
+/// this function requires a ``weight_fn`` parameter, and the ``weight_fn`` is
+/// expected to return a ``float`` not an ``int``.
+///
+/// :param PyDiGraph graph: The graph to find the longest path on. The input
+///     object must be a DAG without a cycle.
+/// :param weight_fn: A python callable that if set will be passed the 3
+///     positional arguments, the source node, the target node, and the edge
+///     weight for each edge as the function traverses the graph. It is expected
+///     to return an float weight for that edge. For example,
+///     ``dag_longest_path(graph, lambda: _, __, weight: weight)`` could be
+///     use to just use an float edge weight. It's also worth noting that this
+///     function traverses in topological order and only checks incoming edges to
+///     each node.
+///
+/// :returns: The longest path length on the DAG
+/// :rtype: float
+///
+/// :raises Exception: If an unexpected error occurs or a path can't be found
+/// :raises DAGHasCycle: If the input PyDiGraph has a cyc
+
+#[pyfunction]
+#[pyo3(text_signature = "(graph, weight_fn, /)")]
+fn dag_weighted_longest_path_length(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    weight_fn: PyObject,
+) -> PyResult<f64> {
+    let edge_weight_callable =
+        |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
+            let res = weight_fn.call1(py, (source, target, weight))?;
+            res.extract(py)
+        };
+    let (_, path_weight) = longest_path(graph, edge_weight_callable)?;
     Ok(path_weight)
 }
 
@@ -4806,6 +4867,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(bfs_successors))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path))?;
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
+    m.add_wrapped(wrap_pyfunction!(dag_weighted_longest_path_length))?;
     m.add_wrapped(wrap_pyfunction!(number_weakly_connected_components))?;
     m.add_wrapped(wrap_pyfunction!(weakly_connected_components))?;
     m.add_wrapped(wrap_pyfunction!(is_weakly_connected))?;

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -185,3 +185,88 @@ class TestLongestPath(unittest.TestCase):
 
 def weight_fn(_, __, weight):
     return int(weight)
+
+
+class TestWeightedLongestPath(unittest.TestCase):
+    def test_linear_with_weight(self):
+        """Longest depth for a simple dag.
+
+        a
+        |
+        b
+        |\
+        c d
+        |\
+        e |
+        | |
+        f g
+        """
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", 4)
+        node_c = dag.add_child(node_b, "c", 4)
+        dag.add_child(node_b, "d", 5)
+        node_e = dag.add_child(node_c, "e", 2)
+        dag.add_child(node_e, "f", 2)
+        dag.add_child(node_c, "g", 15)
+        self.assertEqual(
+            23,
+            retworkx.dag_weighted_longest_path_length(
+                dag, lambda _, __, weight: float(weight)
+            ),
+        )
+
+    def test_parallel_edges_with_weights(self):
+        dag = retworkx.PyDiGraph()
+        dag.extend_from_weighted_edge_list(
+            [
+                (0, 1, 1),
+                (0, 3, 1),
+                (3, 4, 1),
+                (4, 5, 1),
+                (1, 2, 1),
+                (0, 1, 3),
+            ]
+        )
+        self.assertEqual(
+            4.0,
+            retworkx.dag_weighted_longest_path_length(
+                dag, weight_fn=lambda _, __, weight: float(weight)
+            ),
+        )
+
+    def test_less_linear_with_weight(self):
+        dag = retworkx.PyDAG()
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", 1)
+        node_c = dag.add_child(node_b, "c", 1)
+        node_d = dag.add_child(node_c, "d", 1)
+        node_e = dag.add_child(node_d, "e", 1)
+        dag.add_edge(node_a, node_c, 3)
+        dag.add_edge(node_a, node_e, 3)
+        dag.add_edge(node_c, node_e, 3)
+        self.assertEqual(
+            6.0,
+            retworkx.dag_weighted_longest_path_length(
+                dag, weight_fn=lambda _, __, weight: float(weight)
+            ),
+        )
+
+    def test_degenerate_graph_with_weight(self):
+        dag = retworkx.PyDAG()
+        dag.add_node(0)
+        self.assertEqual(
+            0.0,
+            retworkx.dag_weighted_longest_path_length(
+                dag, lambda x: float(weight_fn(x))
+            ),
+        )
+
+    def test_empty_graph_with_weights(self):
+        dag = retworkx.PyDAG()
+        self.assertEqual(
+            0.0,
+            retworkx.dag_weighted_longest_path_length(
+                dag, lambda x: float(weight_fn(x))
+            ),
+        )

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -215,10 +215,16 @@ class TestWeightedLongestPath(unittest.TestCase):
         dag.add_child(node_b, "d", 5)
         node_e = dag.add_child(node_c, "e", 2)
         dag.add_child(node_e, "f", 2)
-        dag.add_child(node_c, "g", 15)
+        node_g = dag.add_child(node_c, "g", 15)
         self.assertEqual(
-            23,
+            23.0,
             retworkx.dag_weighted_longest_path_length(
+                dag, lambda _, __, weight: float(weight)
+            ),
+        )
+        self.assertEqual(
+            [node_a, node_b, node_c, node_g],
+            retworkx.dag_weighted_longest_path(
                 dag, lambda _, __, weight: float(weight)
             ),
         )
@@ -241,6 +247,12 @@ class TestWeightedLongestPath(unittest.TestCase):
                 dag, weight_fn=lambda _, __, weight: float(weight)
             ),
         )
+        self.assertEqual(
+            [0, 1, 2],
+            retworkx.dag_weighted_longest_path(
+                dag, lambda _, __, weight: float(weight)
+            ),
+        )
 
     def test_less_linear_with_weight(self):
         dag = retworkx.PyDAG()
@@ -258,6 +270,12 @@ class TestWeightedLongestPath(unittest.TestCase):
                 dag, weight_fn=lambda _, __, weight: float(weight)
             ),
         )
+        self.assertEqual(
+            [node_a, node_c, node_e],
+            retworkx.dag_weighted_longest_path(
+                dag, weight_fn=lambda _, __, weight: float(weight)
+            ),
+        )
 
     def test_degenerate_graph_with_weight(self):
         dag = retworkx.PyDAG()
@@ -265,6 +283,12 @@ class TestWeightedLongestPath(unittest.TestCase):
         self.assertEqual(
             0.0,
             retworkx.dag_weighted_longest_path_length(
+                dag, lambda x: float(weight_fn(x))
+            ),
+        )
+        self.assertEqual(
+            [0],
+            retworkx.dag_weighted_longest_path(
                 dag, lambda x: float(weight_fn(x))
             ),
         )
@@ -277,6 +301,12 @@ class TestWeightedLongestPath(unittest.TestCase):
                 dag, lambda x: float(weight_fn(x))
             ),
         )
+        self.assertEqual(
+            [],
+            retworkx.dag_weighted_longest_path(
+                dag, lambda x: float(weight_fn(x))
+            ),
+        )
 
     def test_nan_not_valid_weight(self):
         dag = retworkx.generators.directed_path_graph(526)
@@ -286,8 +316,12 @@ class TestWeightedLongestPath(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             retworkx.dag_weighted_longest_path_length(dag, weight_fn)
+        with self.assertRaises(ValueError):
+            retworkx.dag_weighted_longest_path(dag, weight_fn)
 
     def test_cycle(self):
         not_a_dag = retworkx.generators.directed_cycle_graph(250)
         with self.assertRaises(retworkx.DAGHasCycle):
             retworkx.dag_weighted_longest_path_length(not_a_dag, lambda *_: 1.0)
+        with self.assertRaises(retworkx.DAGHasCycle):
+            retworkx.dag_weighted_longest_path(not_a_dag, lambda *_: 1.0)

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -182,6 +182,13 @@ class TestLongestPath(unittest.TestCase):
             0, retworkx.dag_longest_path_length(dag, weight_fn=weight_fn)
         )
 
+    def test_cycle(self):
+        not_a_dag = retworkx.generators.directed_cycle_graph(250)
+        with self.assertRaises(retworkx.DAGHasCycle):
+            retworkx.dag_longest_path_length(not_a_dag, lambda *_: 1.0)
+        with self.assertRaises(retworkx.DAGHasCycle):
+            retworkx.dag_longest_path(not_a_dag, lambda *_: 1.0)
+
 
 def weight_fn(_, __, weight):
     return int(weight)
@@ -279,3 +286,8 @@ class TestWeightedLongestPath(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             retworkx.dag_weighted_longest_path_length(dag, weight_fn)
+
+    def test_cycle(self):
+        not_a_dag = retworkx.generators.directed_cycle_graph(250)
+        with self.assertRaises(retworkx.DAGHasCycle):
+            retworkx.dag_weighted_longest_path_length(not_a_dag, lambda *_: 1.0)

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -270,3 +270,12 @@ class TestWeightedLongestPath(unittest.TestCase):
                 dag, lambda x: float(weight_fn(x))
             ),
         )
+
+    def test_nan_not_valid_weight(self):
+        dag = retworkx.generators.directed_path_graph(526)
+
+        def weight_fn(*_):
+            return float("nan")
+
+        with self.assertRaises(ValueError):
+            retworkx.dag_weighted_longest_path_length(dag, weight_fn)


### PR DESCRIPTION
As a follow up to #383 what the underlying Qiskit user case for #381
would like is to use floats for the edge weighting. However for the
existing `dag_longest_path_length()` function our hands are tied with the
return type being an unsigned integer for backwards compatibility. To
workaround that limitation this commit adds a new function
`dag_weighted_longest_path_length()` which requires a weight function and
works with `f64` weights. To accomplish this, the inner `longest_path()` rust
function is made generic for any numeric type returned by the callback
function, which required leveraging the num-traits crate. The new
pyfunction is then just a thin wrapper that works with `f64` instead of
`usize`.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
