### PR TITLE
Remove unnecessary .collect() from _floyd_warshall()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1215,10 +1215,8 @@ fn _floyd_warshall<Ty: EdgeType>(
     }
 
     // Convert to return format
-    let node_indices: Vec<NodeIndex> = graph.node_indices().collect();
-
-    let out_map: HashMap<usize, PathLengthMapping> = node_indices
-        .into_iter()
+    let out_map: HashMap<usize, PathLengthMapping> = graph
+        .node_indices()
         .map(|i| {
             let out_map = PathLengthMapping {
                 path_lengths: mat[i.index()]


### PR DESCRIPTION
This commit removes an unnecessary `.collect()` on the node indices from
being used in `_floyd_warshall()`. To build the output container the
function was looping over the node indices. Previously it was building a
`Vec` by iterating over the contents of `graph.node_indices()` and then
proceeding to iterate over the vec. Instead we can remove the
intermediate `Vec` and directly iterate over the `NodeIndices` iterator
returned by `graph.node_indices()`.

This was caught by clippy on rust nightly which will save us from having
to fix this at a future date when a new rust version is released.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
