### PR TITLE
Leverage concurrency groups to auto cancel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,21 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 jobs:
   build_lint:
     name: Build, rustfmt, and python lint
     runs-on: ubuntu-latest
     steps:
+      - name: Print Concurrency Group
+        env:
+          CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+        run: |
+          echo -e "\033[31;1;4mConcurrency Group\033[0m"
+          echo -e "$CONCURRENCY_GROUP\n"
+        shell: bash
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
This commit leverages a new beta feature in github actions, concurrency
groups [1], to enable job auto cancellation when there is a PR update.
Basically we define a unique concurrency group for each PR and limit
the group to only run a single workflow at once and cancel any existing
jobs when a new one is launched. This should hopefully improve CI
throughput by not running duplicate jobs on PR updates and only running
CI on the latest commit of a PR branch if there are multiple workflows
queued.

[1] https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
