### PR TITLE
Fix handling of null value in from_adjacency_matrix

### DIFF
--- a/releasenotes/notes/adjacency_matrix_fixes-6e8c937398346c44.yaml
+++ b/releasenotes/notes/adjacency_matrix_fixes-6e8c937398346c44.yaml
@@ -4,7 +4,7 @@ features:
     Added a new kwarg, ``null_value`` to the
     :meth:`retworkx.PyDiGraph.from_adjacency_matrix` and
     :meth:`retworkx.PyGraph.from_adjacency_matrix` which is used to optionally
-    change the null value in the matrix treated as the absense of an edge. By
+    change the null value in the matrix treated as the absence of an edge. By
     default ``0.0`` is used. For example:
 
     .. jupyter-execute::

--- a/releasenotes/notes/adjacency_matrix_fixes-6e8c937398346c44.yaml
+++ b/releasenotes/notes/adjacency_matrix_fixes-6e8c937398346c44.yaml
@@ -1,0 +1,40 @@
+---
+features:
+  - |
+    Added a new kwarg, ``null_value`` to the
+    :meth:`retworkx.PyDiGraph.from_adjacency_matrix` and
+    :meth:`retworkx.PyGraph.from_adjacency_matrix` which is used to optionally
+    change the null value in the matrix treated as the absense of an edge. By
+    default ``0.0`` is used. For example:
+
+    .. jupyter-execute::
+
+      import numpy as np
+      import retworkx
+      from retworkx.visualization import mpl_draw
+
+      matrix = np.array([[np.nan, 1, 1], [1, np.nan, 1], [1, 1, 0]], dtype=np.float64)
+      graph = retworkx.PyDiGraph.from_adjacency_matrix(matrix, null_value=np.nan)
+      mpl_draw(graph, with_labels=True, edge_labels=str)
+
+fixes:
+  - |
+    Support for negative weights in the
+    :meth:`retworkx.PyDiGraph.from_adjacency_matrix` and
+    :meth:`retworkx.PyGraph.from_adjacency_matrix` methods has been fixed.
+    Previously, if a negative weight were used it would be incorrectly treated
+    as a null value and no edge was added to the graph. This has been corrected
+    so that a negative value in the input matrix is now treated as an edge with
+    a negative weight. For example:
+
+    .. jupyter-execute::
+
+      import numpy as np
+      import retworkx
+      from retworkx.visualization import mpl_draw
+
+      matrix = np.array([[0, -1, -1], [1, 0, -1], [1, 1, 0]], dtype=np.float64)
+      graph = retworkx.PyDiGraph.from_adjacency_matrix(matrix)
+      mpl_draw(graph, with_labels=True, edge_labels=str)
+
+    Fixed `#408 <https://github.com/Qiskit/retworkx/issues/408>`__

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2130,16 +2130,21 @@ impl PyDiGraph {
     /// :param ndarray matrix: The input numpy array adjacency matrix to create
     ///     a new :class:`~retworkx.PyDiGraph` object from. It must be a 2
     ///     dimensional array and be a ``float``/``np.float64`` data type.
-    ///
+    /// :param float null_value: An optional float that will treated as a null
+    ///     value. If any element in the input matrix is this value it will be
+    ///     treated as not an edge. By default this is ``0.0``
     ///
     /// :returns: A new graph object generated from the adjacency matrix
     /// :rtype: PyDiGraph
     #[staticmethod]
+    #[args(null_value = "0.0")]
     #[pyo3(text_signature = "(matrix, /)")]
     pub fn from_adjacency_matrix<'p>(
         py: Python<'p>,
         matrix: PyReadonlyArray2<'p, f64>,
+        null_value: f64,
     ) -> PyDiGraph {
+        let null_nan = null_value.is_nan();
         let array = matrix.as_array();
         let shape = array.shape();
         let mut out_graph = StableDiGraph::<PyObject, PyObject>::new();
@@ -2152,7 +2157,7 @@ impl PyDiGraph {
             .for_each(|(index, row)| {
                 let source_index = NodeIndex::new(index);
                 for target_index in 0..row.len() {
-                    if row[[target_index]] > 0.0 {
+                    if row[[target_index]] != null_value {
                         out_graph.add_edge(
                             source_index,
                             NodeIndex::new(target_index),

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2144,7 +2144,6 @@ impl PyDiGraph {
         matrix: PyReadonlyArray2<'p, f64>,
         null_value: f64,
     ) -> PyDiGraph {
-        let null_nan = null_value.is_nan();
         let array = matrix.as_array();
         let shape = array.shape();
         let mut out_graph = StableDiGraph::<PyObject, PyObject>::new();
@@ -2157,7 +2156,15 @@ impl PyDiGraph {
             .for_each(|(index, row)| {
                 let source_index = NodeIndex::new(index);
                 for target_index in 0..row.len() {
-                    if row[[target_index]] != null_value {
+                    if null_value.is_nan() {
+                        if !row[[target_index]].is_nan() {
+                            out_graph.add_edge(
+                                source_index,
+                                NodeIndex::new(target_index),
+                                row[[target_index]].to_object(py),
+                            );
+                        }
+                    } else if row[[target_index]] != null_value {
                         out_graph.add_edge(
                             source_index,
                             NodeIndex::new(target_index),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1407,7 +1407,15 @@ impl PyGraph {
                     if target_index < index {
                         continue;
                     }
-                    if row[[target_index]] != null_value {
+                    if null_value.is_nan() {
+                        if !row[[target_index]].is_nan() {
+                            out_graph.add_edge(
+                                source_index,
+                                NodeIndex::new(target_index),
+                                row[[target_index]].to_object(py),
+                            );
+                        }
+                    } else if row[[target_index]] != null_value {
                         out_graph.add_edge(
                             source_index,
                             NodeIndex::new(target_index),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1378,14 +1378,19 @@ impl PyGraph {
     /// :param ndarray matrix: The input numpy array adjacency matrix to create
     ///     a new :class:`~retworkx.PyGraph` object from. It must be a 2
     ///     dimensional array and be a ``float``/``np.float64`` data type.
+    /// :param float null_value: An optional float that will treated as a null
+    ///     value. If any element in the input matrix is this value it will be
+    ///     treated as not an edge. By default this is ``0.0``.
     ///
     /// :returns: A new graph object generated from the adjacency matrix
     /// :rtype: PyGraph
     #[staticmethod]
+    #[args(null_value = "0.0")]
     #[pyo3(text_signature = "(matrix, /)")]
     pub fn from_adjacency_matrix<'p>(
         py: Python<'p>,
         matrix: PyReadonlyArray2<'p, f64>,
+        null_value: f64,
     ) -> PyGraph {
         let array = matrix.as_array();
         let shape = array.shape();
@@ -1402,7 +1407,7 @@ impl PyGraph {
                     if target_index < index {
                         continue;
                     }
-                    if row[[target_index]] > 0.0 {
+                    if row[[target_index]] != null_value {
                         out_graph.add_edge(
                             source_index,
                             NodeIndex::new(target_index),

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -144,3 +144,30 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
+
+    def test_non_zero_null(self):
+        input_matrix = np.array(
+            [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
+            dtype=np.float64,
+        )
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(
+            input_matrix, null_value=np.Inf
+        )
+        adj_matrix = retworkx.adjacency_matrix(graph, float)
+        expected_matrix = np.array(
+            [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+            dtype=np.float64,
+        )
+        self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
+
+    def test_negative_weight(self):
+        input_matrix = np.array(
+            [[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=float
+        )
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
+        adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))
+        self.assertEqual(
+            [(0, 1, 1), (1, 0, -1), (1, 2, -1), (2, 1, 1)],
+            graph.weighted_edge_list(),
+        )

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -171,3 +171,17 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
             [(0, 1, 1), (1, 0, -1), (1, 2, -1), (2, 1, 1)],
             graph.weighted_edge_list(),
         )
+
+    def test_nan_null(self):
+        input_matrix = np.array(
+            [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
+            dtype=np.float64,
+        )
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(
+            input_matrix, null_value=np.nan
+        )
+        adj_matrix = retworkx.adjacency_matrix(graph, float)
+        expected_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
+        )
+        self.assertTrue(np.array_equal(adj_matrix, expected_matrix))

--- a/tests/graph/test_adjencency_matrix.py
+++ b/tests/graph/test_adjencency_matrix.py
@@ -181,3 +181,17 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
         self.assertEqual([(0, 1, -1), (1, 2, -1)], graph.weighted_edge_list())
+
+    def test_nan_null(self):
+        input_matrix = np.array(
+            [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
+            dtype=np.float64,
+        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(
+            input_matrix, null_value=np.nan
+        )
+        adj_matrix = retworkx.adjacency_matrix(graph, float)
+        expected_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
+        )
+        self.assertTrue(np.array_equal(adj_matrix, expected_matrix))

--- a/tests/graph/test_adjencency_matrix.py
+++ b/tests/graph/test_adjencency_matrix.py
@@ -158,3 +158,26 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
     def test_graph_to_digraph_adjacency_matrix(self):
         graph = retworkx.PyGraph()
         self.assertRaises(TypeError, retworkx.digraph_adjacency_matrix, graph)
+
+    def test_non_zero_null(self):
+        input_matrix = np.array(
+            [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
+            dtype=np.float64,
+        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(
+            input_matrix, null_value=np.Inf
+        )
+        adj_matrix = retworkx.adjacency_matrix(graph, float)
+        expected_matrix = np.array(
+            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
+        )
+        self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
+
+    def test_negative_weight(self):
+        input_matrix = np.array(
+            [[0, -1, 0], [-1, 0, -1], [0, -1, 0]], dtype=float
+        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
+        adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
+        self.assertTrue(np.array_equal(adj_matrix, input_matrix))
+        self.assertEqual([(0, 1, -1), (1, 2, -1)], graph.weighted_edge_list())


### PR DESCRIPTION
This commit fixes an issue with the handling of null values in the
from_adjacency_matrix for PyDiGraph and PyGraph. Previously, the
function incorrectly treated any value <= 0 as a null value and didn't
add an edge for that. But the behavior should have been != instead of
less than or equal to. Additionally, the null value of 0.0 was hard
coded into the constructor methods which precluded using different
values. This commit fixes both issues by adding a new kwarg, null_value,
that lets users specify the null value they'd like to use. Additionally,
the behavior is changed to just use a not equals comparison to enable
using negative values (assuming null_value is zero).

Fixes #408

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
