### PR TITLE
Fix `number_weakly_connected_components` if holes in node indices.

### DIFF
--- a/releasenotes/notes/fix-node-holes-bug-in-number-weakly-connected-components-addafef7d39f5471.yaml
+++ b/releasenotes/notes/fix-node-holes-bug-in-number-weakly-connected-components-addafef7d39f5471.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the output of :func:`~retworkx.number_weakly_connected_components`
+    in case of holes in the graph node indices.

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -27,7 +27,9 @@ use pyo3::Python;
 
 use petgraph::algo;
 use petgraph::graph::NodeIndex;
+use petgraph::unionfind::UnionFind;
 use petgraph::visit::NodeCount;
+use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
 
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
@@ -225,17 +227,41 @@ pub fn digraph_find_cycle(
     EdgeList { edges: cycle }
 }
 
-/// Find the number of weakly connected components in a DAG.
+/// Find the number of weakly connected components in a directed graph
 ///
 /// :param PyDiGraph graph: The graph to find the number of weakly connected
 ///     components on
 ///
-/// :returns: The number of weakly connected components in the DAG
+/// :returns: The number of weakly connected components in the graph
 /// :rtype: int
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 fn number_weakly_connected_components(graph: &digraph::PyDiGraph) -> usize {
-    algo::connected_components(graph)
+    if graph.graph.node_count() == 0 {
+        return 0;
+    }
+    let mut vertex_sets = UnionFind::new(graph.node_bound());
+    let first = graph
+        .graph
+        .node_indices()
+        .next()
+        .map(|a| graph.graph.to_index(a))
+        .unwrap();
+    for ix in 0..graph.node_bound() {
+        if !graph.graph.contains_node(NodeIndex::new(ix)) {
+            vertex_sets.union(first, ix);
+        }
+    }
+    for edge in graph.graph.edge_references() {
+        let (a, b) = (edge.source(), edge.target());
+
+        // union the two vertices of the edge
+        vertex_sets.union(graph.graph.to_index(a), graph.graph.to_index(b));
+    }
+    let mut labels = vertex_sets.into_labeling();
+    labels.sort_unstable();
+    labels.dedup();
+    labels.len()
 }
 
 /// Find the weakly connected components in a directed graph

--- a/tests/digraph/test_weakly_connected.py
+++ b/tests/digraph/test_weakly_connected.py
@@ -37,6 +37,12 @@ class TestWeaklyConnected(unittest.TestCase):
             G.add_child(node, str(i), {})
         self.assertEqual(retworkx.number_weakly_connected_components(G), 100000)
 
+    def test_number_weakly_connected_node_holes(self):
+        graph = retworkx.PyDiGraph()
+        graph.add_nodes_from([0, 1, 2])
+        graph.remove_node(1)
+        self.assertEqual(retworkx.number_weakly_connected_components(graph), 2)
+
     def test_weakly_connected_components(self):
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(


### PR DESCRIPTION

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
`number_weakly_connected_components`  returns wrong answer if the graph has holes in the node indices. This commit modifies the source code of `petgraph::algo::connected_components` to handle this case.