### PR TITLE
Bump version strings post release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retworkx"
 description = "A python graph library implemented in Rust"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2021, retworkx Contributors'
 
 
 # The short X.Y version.
-version = '0.10.0'
+version = '0.11.0'
 # The full version, including alpha/beta/rc tags.
-release = '0.10.0'
+release = '0.11.0'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ graphviz_extras = ['pydot>=1.4', 'pillow>=5.4']
 
 setup(
     name="retworkx",
-    version="0.10.1",
+    version="0.11.0",
     description="A python graph library implemented in Rust",
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Now that the 0.10.x release is out the door we should bump the version
string on main to show the source version we're installing is newer
than what's been released. This bumps the version strings to 0.11.0. If
we decide to do another bugfix release in the 0.10.x series we can
create a banch from 0.10.1 and go from there.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
