### PR TITLE
Pin importlib-metadata in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 decorator==4.4.2
+importlib-metadata==4.7.1


### PR DESCRIPTION
The recent release of importlib-metadata has broken an interface that
stevedore uses when looking for entrypoints (see:
https://github.com/python/importlib_metadata/issues/348 ). Several of
our test/ci dependecies use stevedore for their plugin interfaces
including stestr which is causing CI failures. To unblock CI this commit
pins the importlib metadata version in our constraints file while the
upstream issue is resolved.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
