### PR TITLE
Fix `is_subgraph_isomorphic` with parallel edges.

### DIFF
--- a/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
+++ b/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
@@ -3,3 +3,7 @@ fixes:
   - |
     Fixes the output of :func:`~retworkx.is_subgraph_isomorphic`
     if the input graphs have parallel edges.
+  - |
+    Fixes the output of :func:`~retworkx.is_isomorphic`
+    if the input graphs have parallel edges and an `edge_matcher`
+    is specified.

--- a/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
+++ b/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the output of :func:`~retworkx.is_subgraph_isomorphic`
+    if the input graphs have parallel edges.

--- a/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
+++ b/releasenotes/notes/bugfix-vf2-parallel-edges-f8be125e255753f7.yaml
@@ -7,3 +7,8 @@ fixes:
     Fixes the output of :func:`~retworkx.is_isomorphic`
     if the input graphs have parallel edges and an `edge_matcher`
     is specified.
+  - |
+    Reduces the memory requirements of VF2 graph isomorphism algorithm
+    by making use of a hash map with number of entries scaling
+    as the number of edges in the graph rather than building the
+    full adjacency matrix.

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -99,7 +99,7 @@ fn edge_multiplicity<Ty: EdgeType>(
     if !graph.is_directed() {
         sorted(&mut item);
     }
-    matrix.get(&item).cloned().unwrap_or(0)
+    *matrix.get(&item).unwrap_or(&0)
 }
 
 /// Nodes `a`, `b` are adjacent if the number of edges
@@ -115,7 +115,7 @@ fn is_adjacent<Ty: EdgeType>(
     if !graph.is_directed() {
         sorted(&mut item);
     }
-    matrix.get(&item).cloned().unwrap_or(0) >= val
+    *matrix.get(&item).unwrap_or(&0) >= val
 }
 
 trait NodeSorter<Ty>

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -111,11 +111,7 @@ fn is_adjacent<Ty: EdgeType>(
     b: NodeIndex,
     val: usize,
 ) -> bool {
-    let mut item = (a, b);
-    if !graph.is_directed() {
-        sorted(&mut item);
-    }
-    *matrix.get(&item).unwrap_or(&0) >= val
+    edge_multiplicity(&graph, &matrix, a, b) >= val
 }
 
 trait NodeSorter<Ty>

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -111,7 +111,7 @@ fn is_adjacent<Ty: EdgeType>(
     b: NodeIndex,
     val: usize,
 ) -> bool {
-    edge_multiplicity(&graph, &matrix, a, b) >= val
+    edge_multiplicity(graph, matrix, a, b) >= val
 }
 
 trait NodeSorter<Ty>

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -299,13 +299,9 @@ class TestIsomorphic(unittest.TestCase):
 
     def test_isomorphic_parallel_edges(self):
         first = retworkx.PyDiGraph()
-        first.extend_from_edge_list([
-            (0, 1), (0, 1), (1, 2), (2, 3)
-        ])
+        first.extend_from_edge_list([(0, 1), (0, 1), (1, 2), (2, 3)])
         second = retworkx.PyDiGraph()
-        second.extend_from_edge_list([
-            (0, 1), (1, 2), (1, 2), (2, 3)
-        ])
+        second.extend_from_edge_list([(0, 1), (1, 2), (1, 2), (2, 3)])
         self.assertFalse(retworkx.is_isomorphic(first, second))
 
     def test_digraph_isomorphic_insufficient_call_limit(self):

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -245,6 +245,17 @@ class TestIsomorphic(unittest.TestCase):
                     )
                 )
 
+    def test_digraph_isomorphic_parallel_edges_with_edge_matcher(self):
+        graph = retworkx.PyDiGraph()
+        graph.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "b"), (1, 2, "c")]
+        )
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                graph, graph, edge_matcher=lambda x, y: x == y
+            )
+        )
+
     def test_digraph_isomorphic_self_loop(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from([0])

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -297,6 +297,17 @@ class TestIsomorphic(unittest.TestCase):
             retworkx.is_isomorphic(graph, second_graph, id_order=True)
         )
 
+    def test_isomorphic_parallel_edges(self):
+        first = retworkx.PyDiGraph()
+        first.extend_from_edge_list([
+            (0, 1), (0, 1), (1, 2), (2, 3)
+        ])
+        second = retworkx.PyDiGraph()
+        second.extend_from_edge_list([
+            (0, 1), (1, 2), (1, 2), (2, 3)
+        ])
+        self.assertFalse(retworkx.is_isomorphic(first, second))
+
     def test_digraph_isomorphic_insufficient_call_limit(self):
         graph = retworkx.generators.directed_path_graph(5)
         self.assertFalse(retworkx.is_isomorphic(graph, graph, call_limit=2))

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -188,6 +188,36 @@ class TestSubgraphIsomorphic(unittest.TestCase):
                     retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
                 )
 
+    def test_subgraph_isomorphic_edge_matcher(self):
+        first = retworkx.PyDiGraph()
+        first.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (1, 2, "b"), (2, 0, "c")]
+        )
+        second = retworkx.PyDiGraph()
+        second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(
+                first, second, induced=False, edge_matcher=lambda x, y: x == y
+            )
+        )
+
+    def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
+        first = retworkx.PyDiGraph()
+        first.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")]
+        )
+        second = retworkx.PyDiGraph()
+        second.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "a"), (1, 2, "b")]
+        )
+
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(
+                first, second, id_order=True, edge_matcher=lambda x, y: x == y
+            )
+        )
+
     def test_non_induced_subgraph_isomorphic(self):
         g_a = retworkx.PyDiGraph()
         g_b = retworkx.PyDiGraph()

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -266,13 +266,9 @@ class TestIsomorphic(unittest.TestCase):
 
     def test_isomorphic_parallel_edges(self):
         first = retworkx.PyGraph()
-        first.extend_from_edge_list([
-            (0, 1), (0, 1), (1, 2), (2, 3)
-        ])
+        first.extend_from_edge_list([(0, 1), (0, 1), (1, 2), (2, 3)])
         second = retworkx.PyGraph()
-        second.extend_from_edge_list([
-            (0, 1), (1, 2), (1, 2), (2, 3)
-        ])
+        second.extend_from_edge_list([(0, 1), (1, 2), (1, 2), (2, 3)])
         self.assertFalse(retworkx.is_isomorphic(first, second))
 
     def test_graph_isomorphic_insufficient_call_limit(self):

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -271,6 +271,17 @@ class TestIsomorphic(unittest.TestCase):
         second.extend_from_edge_list([(0, 1), (1, 2), (1, 2), (2, 3)])
         self.assertFalse(retworkx.is_isomorphic(first, second))
 
+    def test_isomorphic_parallel_edges_with_edge_matcher(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "b"), (1, 2, "c")]
+        )
+        self.assertTrue(
+            retworkx.is_isomorphic(
+                graph, graph, edge_matcher=lambda x, y: x == y
+            )
+        )
+
     def test_graph_isomorphic_insufficient_call_limit(self):
         graph = retworkx.generators.path_graph(5)
         self.assertFalse(retworkx.is_isomorphic(graph, graph, call_limit=2))

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -264,6 +264,17 @@ class TestIsomorphic(unittest.TestCase):
         graph.add_edges_from_no_data([(0, 0), (0, 1)])
         self.assertTrue(retworkx.is_isomorphic(graph, graph))
 
+    def test_isomorphic_parallel_edges(self):
+        first = retworkx.PyGraph()
+        first.extend_from_edge_list([
+            (0, 1), (0, 1), (1, 2), (2, 3)
+        ])
+        second = retworkx.PyGraph()
+        second.extend_from_edge_list([
+            (0, 1), (1, 2), (1, 2), (2, 3)
+        ])
+        self.assertFalse(retworkx.is_isomorphic(first, second))
+
     def test_graph_isomorphic_insufficient_call_limit(self):
         graph = retworkx.generators.path_graph(5)
         self.assertFalse(retworkx.is_isomorphic(graph, graph, call_limit=2))

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -219,6 +219,22 @@ class TestSubgraphIsomorphic(unittest.TestCase):
                     )
                 )
 
+    def test_subgraph_isomorphic_parallel_edges(self):
+        first = retworkx.PyGraph()
+        first.extend_from_edge_list([
+            (0, 1), (1, 2), (2, 3)
+        ])
+        second = retworkx.PyGraph()
+        second.extend_from_edge_list([
+            (0, 1), (0, 1)
+        ])
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(first, second, induced=True)
+        )
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(first, second, induced=False)
+        )
+
     def test_non_induced_grid_subgraph_isomorphic(self):
         g_a = retworkx.generators.grid_graph(2, 2)
         g_b = retworkx.PyGraph()
@@ -231,6 +247,22 @@ class TestSubgraphIsomorphic(unittest.TestCase):
 
         self.assertTrue(
             retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False)
+        )
+
+    def test_non_induced_subgraph_isomorphic_parallel_edges(self):
+        first = retworkx.PyGraph()
+        first.extend_from_edge_list([
+            (0, 1), (0, 1), (1, 2), (1, 2)
+        ])
+        second = retworkx.PyGraph()
+        second.extend_from_edge_list([
+            (0, 1), (1, 2), (1, 2)
+        ])
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(first, second, induced=True)
+        )
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(first, second, induced=False)
         )
 
     def test_subgraph_vf2_mapping(self):

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -221,13 +221,9 @@ class TestSubgraphIsomorphic(unittest.TestCase):
 
     def test_subgraph_isomorphic_parallel_edges(self):
         first = retworkx.PyGraph()
-        first.extend_from_edge_list([
-            (0, 1), (1, 2), (2, 3)
-        ])
+        first.extend_from_edge_list([(0, 1), (1, 2), (2, 3)])
         second = retworkx.PyGraph()
-        second.extend_from_edge_list([
-            (0, 1), (0, 1)
-        ])
+        second.extend_from_edge_list([(0, 1), (0, 1)])
         self.assertFalse(
             retworkx.is_subgraph_isomorphic(first, second, induced=True)
         )
@@ -251,13 +247,9 @@ class TestSubgraphIsomorphic(unittest.TestCase):
 
     def test_non_induced_subgraph_isomorphic_parallel_edges(self):
         first = retworkx.PyGraph()
-        first.extend_from_edge_list([
-            (0, 1), (0, 1), (1, 2), (1, 2)
-        ])
+        first.extend_from_edge_list([(0, 1), (0, 1), (1, 2), (1, 2)])
         second = retworkx.PyGraph()
-        second.extend_from_edge_list([
-            (0, 1), (1, 2), (1, 2)
-        ])
+        second.extend_from_edge_list([(0, 1), (1, 2), (1, 2)])
         self.assertFalse(
             retworkx.is_subgraph_isomorphic(first, second, induced=True)
         )

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -219,6 +219,36 @@ class TestSubgraphIsomorphic(unittest.TestCase):
                     )
                 )
 
+    def test_subgraph_isomorphic_edge_matcher(self):
+        first = retworkx.PyGraph()
+        first.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (1, 2, "b"), (2, 0, "c")]
+        )
+        second = retworkx.PyGraph()
+        second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
+
+        self.assertTrue(
+            retworkx.is_subgraph_isomorphic(
+                first, second, induced=False, edge_matcher=lambda x, y: x == y
+            )
+        )
+
+    def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
+        first = retworkx.PyGraph()
+        first.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")]
+        )
+        second = retworkx.PyGraph()
+        second.extend_from_weighted_edge_list(
+            [(0, 1, "a"), (0, 1, "a"), (1, 2, "b")]
+        )
+
+        self.assertFalse(
+            retworkx.is_subgraph_isomorphic(
+                first, second, id_order=True, edge_matcher=lambda x, y: x == y
+            )
+        )
+
     def test_subgraph_isomorphic_parallel_edges(self):
         first = retworkx.PyGraph()
         first.extend_from_edge_list([(0, 1), (1, 2), (2, 3)])


### PR DESCRIPTION
Closes #429.
The solution is to build an adjacency matrix with entries equal
to the number of edges connecting a pair of nodes instead of
0/1 values.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
