### PR TITLE
Pin nightly version in coverage job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-08-31
           override: true
           profile: default
           components: llvm-tools-preview


### PR DESCRIPTION
The coverage ci job uses the rust nightly channel to enable the coverage
collection. However, building with nightly has recently stopped working
because of a change breaking num-bigint (see
https://github.com/rust-num/num-bigint/issues/218 for more details).
Until the rustc nightly behavior is reverted or a new num-bigint version
is released that is compatible with the new nightly behavior this commit
pins the nightly version used in the coverage job to a version prior to
the failure.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
