### PR TITLE
Fixes `digraph_union` if `merge_edges` is set to true.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -146,6 +146,7 @@ Other Algorithm Functions
    retworkx.core_number
    retworkx.graph_greedy_color
    retworkx.digraph_union
+   retworkx.graph_union
    retworkx.metric_closure
 
 Generators

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -145,8 +145,7 @@ Other Algorithm Functions
    retworkx.transitivity
    retworkx.core_number
    retworkx.graph_greedy_color
-   retworkx.digraph_union
-   retworkx.graph_union
+   retworkx.union
    retworkx.metric_closure
 
 Generators
@@ -243,6 +242,7 @@ the functions from the explicitly typed based on the data type.
    retworkx.digraph_transitivity
    retworkx.digraph_core_number
    retworkx.digraph_complement
+   retworkx.digraph_union
    retworkx.digraph_random_layout
    retworkx.digraph_bipartite_layout
    retworkx.digraph_circular_layout
@@ -284,6 +284,7 @@ typed API based on the data type.
    retworkx.graph_transitivity
    retworkx.graph_core_number
    retworkx.graph_complement
+   retworkx.graph_union
    retworkx.graph_random_layout
    retworkx.graph_bipartite_layout
    retworkx.graph_circular_layout

--- a/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
+++ b/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Previously, :func:`~retworkx.digraph_union` would falsely keep or delete edges
+    Previously, :func:`~retworkx.digraph_union` would incorrectly keep or delete edges
     if argument `merge_edges` is set to true. This has been fixed and an edge from
     the second graph will be skipped if both its endpoints were merged to nodes from
     the first graph and these nodes already share an edge with equal weight data.
@@ -9,7 +9,9 @@ fixes:
 features:
   - |
     Adds a new function :func:`~retworkx.graph_union` that returns the union
-    of two :class:`~retworkx.PyGraph` objects.
+    of two :class:`~retworkx.PyGraph` objects. This is the equivalent to 
+    :func:`~retworkx.digraph_union` but for a :class:`~retworkx.PyGraph`
+    instead of for a :class:`~retworkx.PyDiGraph`.
     For example:
 
     .. jupyter-execute::
@@ -21,4 +23,3 @@ features:
       second = retworkx.generators.cycle_graph(3, weights=["node", "b_0", "b_1"])
       graph = retworkx.graph_union(first, second, merge_nodes=True)
       mpl_draw(graph)
-    

--- a/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
+++ b/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
@@ -1,0 +1,24 @@
+---
+fixes:
+  - |
+    Previously, :func:`~retworkx.digraph_union` would falsely keep or delete edges
+    if argument `merge_edges` is set to true. This has been fixed and an edge from
+    the second graph will be skipped if both its endpoints were merged to nodes from
+    the first graph and these nodes already share an edge with equal weight data.
+    Fixed `#432 <https://github.com/Qiskit/retworkx/issues/432>`__
+features:
+  - |
+    Adds a new function :func:`~retworkx.graph_union` that returns the union
+    of two :class:`~retworkx.PyGraph` objects.
+    For example:
+
+    .. jupyter-execute::
+
+      import retworkx
+      from retworkx.visualization import mpl_draw
+
+      first = retworkx.generators.path_graph(3, weights=["a_0", "node", "a_1"])
+      second = retworkx.generators.cycle_graph(3, weights=["node", "b_0", "b_1"])
+      graph = retworkx.graph_union(first, second, merge_nodes=True)
+      mpl_draw(graph)
+    

--- a/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
+++ b/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Previously, :func:`~retworkx.digraph_union` would incorrectly keep or delete edges
-    if argument `merge_edges` is set to true. This has been fixed and an edge from
+    if argument ``merge_edges`` is set to true. This has been fixed and an edge from
     the second graph will be skipped if both its endpoints were merged to nodes from
     the first graph and these nodes already share an edge with equal weight data.
     Fixed `#432 <https://github.com/Qiskit/retworkx/issues/432>`__
@@ -26,7 +26,7 @@ features:
       graph = retworkx.graph_union(first, second, merge_nodes=True)
       mpl_draw(graph)
   - |
-    The kwargs `merge_nodes` and `merge_edges` of :func:`~retworkx.union` are
+    The kwargs ``merge_nodes`` and ``merge_edges`` of :func:`~retworkx.digraph_union` are
     now optional and by default are set `False`.
   - |
     Add a new :meth:`~retworkx.PyGraph.find_node_by_weight` that finds the index

--- a/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
+++ b/releasenotes/notes/bugfix-union-7da79789134a3028.yaml
@@ -8,10 +8,12 @@ fixes:
     Fixed `#432 <https://github.com/Qiskit/retworkx/issues/432>`__
 features:
   - |
-    Adds a new function :func:`~retworkx.graph_union` that returns the union
+    Add a new function :func:`~retworkx.graph_union` that returns the union
     of two :class:`~retworkx.PyGraph` objects. This is the equivalent to 
     :func:`~retworkx.digraph_union` but for a :class:`~retworkx.PyGraph`
-    instead of for a :class:`~retworkx.PyDiGraph`.
+    instead of for a :class:`~retworkx.PyDiGraph`. A new unified function
+    :func:`~retworkx.union` was also added that supports both
+    :class:`~retworkx.PyDiGraph` and :class:`~retworkx.PyGraph`.
     For example:
 
     .. jupyter-execute::
@@ -23,3 +25,9 @@ features:
       second = retworkx.generators.cycle_graph(3, weights=["node", "b_0", "b_1"])
       graph = retworkx.graph_union(first, second, merge_nodes=True)
       mpl_draw(graph)
+  - |
+    The kwargs `merge_nodes` and `merge_edges` of :func:`~retworkx.union` are
+    now optional and by default are set `False`.
+  - |
+    Add a new :meth:`~retworkx.PyGraph.find_node_by_weight` that finds the index
+    of a node given a specific weight.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -1633,3 +1633,63 @@ def _graph_vf2_mapping(
         induced=induced,
         call_limit=call_limit,
     )
+
+
+@functools.singledispatch
+def union(
+    first,
+    second,
+    merge_nodes=False,
+    merge_edges=False,
+):
+    """Return a new graph by forming a union from two input graph objects
+
+    The algorithm in this function operates in three phases:
+
+    1. Add all the nodes from  ``second`` into ``first``. operates in :math:`\mathcal{O}(n_2)`,
+       with :math:`n_2` being number of nodes in ``second``.
+    2. Merge nodes from ``second`` over ``first`` given that:
+
+       - The ``merge_nodes`` is ``True``. operates in :math:`\mathcal{O}(n_1 n_2)`,
+         with :math:`n_1` being the number of nodes in ``first`` and :math:`n_2`
+         the number of nodes in ``second``
+       - The respective node in ``second`` and ``first`` share the same
+         weight/data payload.
+
+    3. Adds all the edges from ``second`` to ``first``. If the ``merge_edges``
+       parameter is ``True`` and the respective edge in ``second`` and
+       ``first`` share the same weight/data payload they will be merged together.
+
+    :param first: The first graph object
+    :param second: The second graph object
+    :param bool merge_nodes: If set to ``True`` nodes will be merged between
+        ``second`` and ``first`` if the weights are equal. Default: ``False``.
+    :param bool merge_edges: If set to ``True`` edges will be merged between
+        ``second`` and ``first`` if the weights are equal. Default: ``False``.
+
+    :returns: A new graph object that is the union of ``second`` and
+        ``first``. It's worth noting the weight/data payload objects are
+        passed by reference from ``first`` and ``second`` to this new object.
+    :rtype: :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(first))
+
+
+@union.register(PyDiGraph)
+def _digraph_union(
+    first,
+    second,
+    merge_nodes=False,
+    merge_edges=False,
+):
+    return digraph_union(first, second, merge_nodes=False, merge_edges=False)
+
+
+@union.register(PyGraph)
+def _graph_union(
+    first,
+    second,
+    merge_nodes=False,
+    merge_edges=False,
+):
+    return graph_union(first, second, merge_nodes=False, merge_edges=False)

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -1646,11 +1646,12 @@ def union(
 
     The algorithm in this function operates in three phases:
 
-    1. Add all the nodes from  ``second`` into ``first``. operates in :math:`\mathcal{O}(n_2)`,
-       with :math:`n_2` being number of nodes in ``second``.
+    1. Add all the nodes from  ``second`` into ``first``. operates in
+    :math:`\\mathcal{O}(n_2)`, with :math:`n_2` being number of nodes in
+    ``second``.
     2. Merge nodes from ``second`` over ``first`` given that:
 
-       - The ``merge_nodes`` is ``True``. operates in :math:`\mathcal{O}(n_1 n_2)`,
+       - The ``merge_nodes`` is ``True``. operates in :math:`\\mathcal{O}(n_1 n_2)`,
          with :math:`n_1` being the number of nodes in ``first`` and :math:`n_2`
          the number of nodes in ``second``
        - The respective node in ``second`` and ``first`` share the same

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -50,8 +50,8 @@ use super::iterators::{
     EdgeIndexMap, EdgeIndices, EdgeList, NodeIndices, NodeMap, WeightedEdgeList,
 };
 use super::{
-    DAGHasCycle, DAGWouldCycle, NoEdgeBetweenNodes, NoSuitableNeighbors,
-    NodesRemoved,
+    find_node_by_weight, DAGHasCycle, DAGWouldCycle, NoEdgeBetweenNodes,
+    NoSuitableNeighbors, NodesRemoved,
 };
 
 use super::dag_algo::is_directed_acyclic_graph;
@@ -1401,21 +1401,9 @@ impl PyDiGraph {
         &self,
         py: Python,
         obj: PyObject,
-    ) -> Option<usize> {
-        let mut index = None;
-        for node in self.graph.node_indices() {
-            let weight = self.graph.node_weight(node).unwrap();
-            let weight_compare = |a: &PyAny, b: &PyAny| -> PyResult<bool> {
-                let res = a.compare(b)?;
-                Ok(res == Ordering::Equal)
-            };
-
-            if weight_compare(obj.as_ref(py), weight.as_ref(py)).unwrap() {
-                index = Some(node.index());
-                break;
-            }
-        }
-        index
+    ) -> PyResult<Option<usize>> {
+        find_node_by_weight(py, &self.graph, &obj)
+            .map(|node| node.map(|x| x.index()))
     }
 
     /// Merge two nodes in the graph.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -35,7 +35,7 @@ use super::dot_utils::build_dot;
 use super::iterators::{
     EdgeIndexMap, EdgeIndices, EdgeList, NodeIndices, WeightedEdgeList,
 };
-use super::{NoEdgeBetweenNodes, NodesRemoved};
+use super::{find_node_by_weight, NoEdgeBetweenNodes, NodesRemoved};
 
 use petgraph::algo;
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -1018,6 +1018,26 @@ impl PyGraph {
             self.graph.remove_node(node);
         }
         Ok(())
+    }
+
+    /// Find node within this graph given a specific weight
+    ///
+    /// This algorithm has a worst case of O(n) since it searches the node
+    /// indices in order. If there is more than one node in the graph with the
+    /// same weight only the first match (by node index) will be returned.
+    ///
+    /// :param obj: The weight to look for in the graph.
+    ///
+    /// :returns: the index of the first node in the graph that is equal to the
+    ///     weight. If no match is found ``None`` will be returned.
+    /// :rtype: int
+    pub fn find_node_by_weight(
+        &self,
+        py: Python,
+        obj: PyObject,
+    ) -> PyResult<Option<usize>> {
+        find_node_by_weight(py, &self.graph, &obj)
+            .map(|node| node.map(|x| x.index()))
     }
 
     /// Get the index and data for the neighbors of a node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_vf2_mapping))?;
     m.add_wrapped(wrap_pyfunction!(graph_vf2_mapping))?;
     m.add_wrapped(wrap_pyfunction!(digraph_union))?;
+    m.add_wrapped(wrap_pyfunction!(graph_union))?;
     m.add_wrapped(wrap_pyfunction!(topological_sort))?;
     m.add_wrapped(wrap_pyfunction!(descendants))?;
     m.add_wrapped(wrap_pyfunction!(ancestors))?;

--- a/src/union.rs
+++ b/src/union.rs
@@ -105,8 +105,9 @@ fn union<Ty: EdgeType>(
 ///
 /// The algorithm in this function operates in three phases:
 ///
-/// 1. Add all the nodes from  ``second`` into ``first``. operates in :math:`\mathcal{O}(n_2)`,
-///    with :math:`n_2` being number of nodes in ``second``.
+/// 1. Add all the nodes from  ``second`` into ``first``. operates in
+///    :math:`\mathcal{O}(n_2)`, with :math:`n_2` being number of nodes in
+///    ``second``.
 /// 2. Merge nodes from ``second`` over ``first`` given that:
 ///
 ///    - The ``merge_nodes`` is ``True``. operates in :math:`\mathcal{O}(n_1 n_2)`,
@@ -155,8 +156,9 @@ fn graph_union(
 ///
 /// The algorithm in this function operates in three phases:
 ///
-/// 1. Add all the nodes from  ``second`` into ``first``. operates in :math:`\mathcal{O}(n_2)`,
-///    with :math:`n_2` being number of nodes in ``second``.
+/// 1. Add all the nodes from  ``second`` into ``first``. operates in
+///    :math:`\mathcal{O}(n_2)`, with :math:`n_2` being number of nodes in
+///    ``second``.
 /// 2. Merge nodes from ``second`` over ``first`` given that:
 ///
 ///    - The ``merge_nodes`` is ``True``. operates in :math:`\mathcal{O}(n_1 n_2)`,

--- a/src/union.rs
+++ b/src/union.rs
@@ -52,7 +52,7 @@ fn extract<T>(x: Entry<T>) -> T {
     match x {
         Entry::Merged(val) => val,
         Entry::Added(val) => val,
-        Entry::None => panic!("called `Entry::extract()` on a `None` value"),
+        Entry::None => panic!("Unexpected internal error: called `Entry::extract()` on a `None` value. Please file an issue at https://github.com/Qiskit/retworkx/issues/new/choose with the details on how you encountered this."),
     }
 }
 

--- a/tests/digraph/test_union.py
+++ b/tests/digraph/test_union.py
@@ -31,23 +31,6 @@ class TestUnion(unittest.TestCase):
 
         self.assertTrue(retworkx.is_isomorphic(dag_a, dag_c))
 
-    def test_union_basic_merge_edges_only(self):
-        dag_a = retworkx.PyDiGraph()
-        dag_b = retworkx.PyDiGraph()
-
-        node_a = dag_a.add_node("a_1")
-        dag_a.add_child(node_a, "a_2", "e_1")
-        dag_a.add_child(node_a, "a_3", "e_2")
-
-        node_b = dag_b.add_node("a_1")
-        dag_b.add_child(node_b, "a_2", "e_1")
-        dag_b.add_child(node_b, "a_3", "e_2")
-
-        dag_c = retworkx.digraph_union(dag_a, dag_b, False, True)
-
-        self.assertTrue(len(dag_c.edge_list()) == 2)
-        self.assertTrue(len(dag_c.nodes()) == 6)
-
     def test_union_basic_merge_nodes_only(self):
         dag_a = retworkx.PyDiGraph()
         dag_b = retworkx.PyDiGraph()
@@ -82,3 +65,33 @@ class TestUnion(unittest.TestCase):
 
         self.assertTrue(len(dag_c.nodes()) == 6)
         self.assertTrue(len(dag_c.edge_list()) == 4)
+
+    def test_union_mismatch_edge_weight(self):
+        first = retworkx.PyDiGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyDiGraph()
+        nodes = second.add_nodes_from([0, 1])
+        second.add_edges_from([(nodes[0], nodes[1], "b")])
+
+        final = retworkx.digraph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 1, "b")])
+
+    def test_union_node_hole(self):
+        first = retworkx.PyDiGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyDiGraph()
+        dummy = second.add_node("dummy")
+        nodes = second.add_nodes_from([0, 1])
+        second.add_edges_from([(nodes[0], nodes[1], "a")])
+        second.remove_node(dummy)
+
+        final = retworkx.digraph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])

--- a/tests/digraph/test_union.py
+++ b/tests/digraph/test_union.py
@@ -95,3 +95,17 @@ class TestUnion(unittest.TestCase):
             first, second, merge_nodes=True, merge_edges=True
         )
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])
+
+    def test_union_edge_between_merged_and_unmerged_nodes(self):
+        first = retworkx.PyDiGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyDiGraph()
+        nodes = second.add_nodes_from([0, 2])
+        second.add_edges_from([(nodes[0], nodes[1], "b")])
+
+        final = retworkx.digraph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 2, "b")])

--- a/tests/graph/test_union.py
+++ b/tests/graph/test_union.py
@@ -18,8 +18,10 @@ class TestUnion(unittest.TestCase):
     def setUp(self):
         self.graph = retworkx.PyGraph()
         self.graph.add_nodes_from(["a_1", "a_2", "a_3"])
-        self.graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
-    
+        self.graph.extend_from_weighted_edge_list(
+            [(0, 1, "e_1"), (1, 2, "e_2")]
+        )
+
     def test_union_basic_merge_none(self):
         final = retworkx.graph_union(
             self.graph, self.graph, merge_nodes=False, merge_edges=False

--- a/tests/graph/test_union.py
+++ b/tests/graph/test_union.py
@@ -1,0 +1,76 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+import retworkx
+
+
+class TestUnion(unittest.TestCase):
+    def test_union_basic_merge_none(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(["a_1", "a_2", "a_3"])
+        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
+        final = retworkx.graph_union(
+            graph, graph, merge_nodes=False, merge_edges=False
+        )
+        self.assertTrue(len(final.nodes()) == 6)
+        self.assertTrue(len(final.edge_list()) == 4)
+
+    def test_union_merge_all(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(["a_1", "a_2", "a_3"])
+        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
+        final = retworkx.graph_union(
+            graph, graph, merge_nodes=True, merge_edges=True
+        )
+        self.assertTrue(retworkx.is_isomorphic(final, graph))
+
+    def test_union_basic_merge_nodes_only(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(["a_1", "a_2", "a_3"])
+        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
+        final = retworkx.graph_union(
+            graph, graph, merge_nodes=True, merge_edges=False
+        )
+        self.assertTrue(len(final.edge_list()) == 4)
+        self.assertTrue(len(final.get_all_edge_data(0, 1)) == 2)
+        self.assertTrue(len(final.nodes()) == 3)
+
+    def test_union_mismatch_edge_weight(self):
+        first = retworkx.PyGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyGraph()
+        nodes = second.add_nodes_from([0, 1])
+        second.add_edges_from([(nodes[0], nodes[1], "b")])
+
+        final = retworkx.graph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 1, "b")])
+
+    def test_union_node_hole(self):
+        first = retworkx.PyGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyGraph()
+        dummy = second.add_node("dummy")
+        nodes = second.add_nodes_from([0, 1])
+        second.add_edges_from([(nodes[0], nodes[1], "a")])
+        second.remove_node(dummy)
+
+        final = retworkx.graph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])

--- a/tests/graph/test_union.py
+++ b/tests/graph/test_union.py
@@ -15,31 +15,27 @@ import retworkx
 
 
 class TestUnion(unittest.TestCase):
+    def setUp(self):
+        self.graph = retworkx.PyGraph()
+        self.graph.add_nodes_from(["a_1", "a_2", "a_3"])
+        self.graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
+    
     def test_union_basic_merge_none(self):
-        graph = retworkx.PyGraph()
-        graph.add_nodes_from(["a_1", "a_2", "a_3"])
-        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
         final = retworkx.graph_union(
-            graph, graph, merge_nodes=False, merge_edges=False
+            self.graph, self.graph, merge_nodes=False, merge_edges=False
         )
         self.assertTrue(len(final.nodes()) == 6)
         self.assertTrue(len(final.edge_list()) == 4)
 
     def test_union_merge_all(self):
-        graph = retworkx.PyGraph()
-        graph.add_nodes_from(["a_1", "a_2", "a_3"])
-        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
         final = retworkx.graph_union(
-            graph, graph, merge_nodes=True, merge_edges=True
+            self.graph, self.graph, merge_nodes=True, merge_edges=True
         )
-        self.assertTrue(retworkx.is_isomorphic(final, graph))
+        self.assertTrue(retworkx.is_isomorphic(final, self.graph))
 
     def test_union_basic_merge_nodes_only(self):
-        graph = retworkx.PyGraph()
-        graph.add_nodes_from(["a_1", "a_2", "a_3"])
-        graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
         final = retworkx.graph_union(
-            graph, graph, merge_nodes=True, merge_edges=False
+            self.graph, self.graph, merge_nodes=True, merge_edges=False
         )
         self.assertTrue(len(final.edge_list()) == 4)
         self.assertTrue(len(final.get_all_edge_data(0, 1)) == 2)
@@ -74,3 +70,17 @@ class TestUnion(unittest.TestCase):
             first, second, merge_nodes=True, merge_edges=True
         )
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])
+
+    def test_union_edge_between_merged_and_unmerged_nodes(self):
+        first = retworkx.PyGraph()
+        nodes = first.add_nodes_from([0, 1])
+        first.add_edges_from([(nodes[0], nodes[1], "a")])
+
+        second = retworkx.PyGraph()
+        nodes = second.add_nodes_from([0, 2])
+        second.add_edges_from([(nodes[0], nodes[1], "b")])
+
+        final = retworkx.graph_union(
+            first, second, merge_nodes=True, merge_edges=True
+        )
+        self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 2, "b")])


### PR DESCRIPTION
Previously, `digraph_union` would falsely keep or delete
edges if `merge_edges` is set to true. This commit fixes
the logic of `digraph_union` to skip an edge from the second
graph if both its endpoints were merged to nodes from the
first graph and these nodes already share an edge with equal
weight data. At the same time, a new function `graph_union`
was added that returns the union of two `PyGraph`s.
Closes #432.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
