### PR TITLE
Add `chain_decomposition` function.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -130,6 +130,7 @@ Connectivity and Cycles
    retworkx.is_weakly_connected
    retworkx.cycle_basis
    retworkx.digraph_find_cycle
+   retworkx.chain_decomposition
 
 .. _other-algorithms:
 

--- a/releasenotes/notes/chain-decomposition-3fdf4b283b5b9ad1.yaml
+++ b/releasenotes/notes/chain-decomposition-3fdf4b283b5b9ad1.yaml
@@ -1,0 +1,40 @@
+---
+features:
+  - |
+    Added a new function :func:`~retworkx.chain_decomposition` that finds
+    a chain decomposition of an undirected :class:`~retworkx.PyGraph`.
+    A chain decomposition is a set of cycles or paths derived from the
+    set of fundamental cycles of a depth-first tree. It's defined in
+    https://doi.org/10.1016/j.ipl.2013.01.016
+    For example:
+
+    .. jupyter-execute::
+
+      import retworkx
+      from retworkx.visualization import mpl_draw
+
+      graph = retworkx.PyGraph()
+      graph.extend_from_edge_list([
+          (0, 1), (0, 2), (1, 2), (2, 3),
+          (3, 4), (3, 5), (4, 5),
+      ])
+      chains = retworkx.chain_decomposition(graph)
+
+      def color_edges(graph, chains): 
+          COLORS = ['blue', 'red']
+
+          edges_in_chain = {}
+          for idx, chain in enumerate(chains):
+              for edge in chain:
+                  edge = tuple(sorted(edge))
+                  edges_in_chain[edge] = COLORS[idx]
+              
+          edge_colors = []
+          for edge in graph.edge_list():
+              edge = tuple(sorted(edge))
+              edge_colors += [edges_in_chain.get(edge, 'black')]
+
+          return edge_colors
+
+      mpl_draw(graph, node_color='black', node_size=150,
+              edge_color=color_edges(graph, chains))

--- a/src/connectivity/chain.rs
+++ b/src/connectivity/chain.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use pyo3::prelude::*;
+
+use hashbrown::HashMap;
+
+use petgraph::prelude::*;
+use petgraph::stable_graph::NodeIndex;
+use petgraph::visit::VisitMap;
+use petgraph::visit::{depth_first_search, DfsEvent, NodeIndexable, Visitable};
+
+fn _build_chain<VM: VisitMap<NodeIndex>>(
+    parent: &[NodeIndex],
+    u: NodeIndex,
+    v: NodeIndex,
+    visited: &mut VM,
+) -> Vec<(usize, usize)> {
+    let mut u = u.index();
+    let mut v = v.index();
+
+    let mut chain = Vec::new();
+    while visited.visit(NodeIndex::new(v)) {
+        chain.push((u, v));
+        u = v;
+        v = parent[u].index();
+    }
+    chain.push((u, v));
+
+    chain
+}
+
+pub fn chain_decomposition(
+    graph: &StableUnGraph<PyObject, PyObject>,
+    source: Option<usize>,
+) -> Vec<Vec<(usize, usize)>> {
+    let roots = match source {
+        Some(node) => vec![NodeIndex::new(node)],
+        None => graph.node_indices().collect(),
+    };
+
+    let mut parent = vec![NodeIndex::end(); graph.node_bound()];
+    let mut back_edges: HashMap<NodeIndex, Vec<NodeIndex>> = HashMap::new();
+
+    // depth-first-index (DFI) ordered nodes.
+    let mut nodes = Vec::with_capacity(graph.node_count());
+    depth_first_search(graph, roots, |event| match event {
+        DfsEvent::Discover(u, _) => {
+            nodes.push(u);
+        }
+        DfsEvent::TreeEdge(u, v) => {
+            let v = v.index();
+            parent[v] = u;
+        }
+        DfsEvent::BackEdge(u, v) => {
+            // do *not* consider (u, v) as a back edge if (v, u) is a tree edge.
+            if parent[u.index()] != v {
+                back_edges
+                    .entry(v)
+                    .and_modify(|v_edges| v_edges.push(u))
+                    .or_insert(vec![u]);
+            }
+        }
+        _ => {}
+    });
+
+    let visited = &mut graph.visit_map();
+    let mut chains = Vec::new();
+
+    for u in nodes {
+        visited.visit(u);
+        if let Some(vs) = back_edges.get_mut(&u) {
+            for v in vs.drain(..) {
+                let chain = _build_chain(&parent, u, v, visited);
+                chains.push(chain);
+            }
+        }
+    }
+    chains
+}

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -12,6 +12,7 @@
 
 #![allow(clippy::float_cmp)]
 
+mod chain;
 mod core_number;
 
 use super::{
@@ -661,4 +662,46 @@ pub fn digraph_core_number(
     graph: &digraph::PyDiGraph,
 ) -> PyResult<PyObject> {
     core_number::core_number(py, &graph.graph)
+}
+
+/// Returns the chain decomposition of a graph.
+///
+/// The *chain decomposition* of a graph with respect to a depth-first
+/// search tree is a set of cycles or paths derived from the set of
+/// fundamental cycles of the tree in the following manner. Consider
+/// each fundamental cycle with respect to the given tree, represented
+/// as a list of edges beginning with the nontree edge oriented away
+/// from the root of the tree. For each fundamental cycle, if it
+/// overlaps with any previous fundamental cycle, just take the initial
+/// non-overlapping segment, which is a path instead of a cycle. Each
+/// cycle or path is called a *chain*. For more information, see [Jens]_.
+///
+/// .. note::
+///
+///     It's a recursive implementation and might run out of memory
+///     in large graphs.
+///
+/// :param PyGraph: The undirected graph to be used
+/// :param int source: An optional node index in the graph. If specified,
+///     only the chain decomposition for the connected component containing
+///     this node will be returned. This node indicates the root of the depth-first
+///     search tree. If this is not specified then a source will be chosen
+///     arbitrarly and repeated until all components of the graph are searched.
+/// :returns: A list of list of edges where each inner list is a chain.
+/// :rtype: list of EdgeList
+///
+/// .. [Jens] Jens M. Schmidt (2013). "A simple test on 2-vertex-
+///       and 2-edge-connectivity." *Information Processing Letters*,
+///       113, 241–244. Elsevier. <https://doi.org/10.1016/j.ipl.2013.01.016>
+#[pyfunction]
+#[pyo3(text_signature = "(graph, /, source=None)")]
+pub fn chain_decomposition(
+    graph: graph::PyGraph,
+    source: Option<usize>,
+) -> Vec<EdgeList> {
+    let chains = chain::chain_decomposition(&graph.graph, source);
+    chains
+        .into_iter()
+        .map(|chain| EdgeList { edges: chain })
+        .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     ))?;
     m.add_wrapped(wrap_pyfunction!(metric_closure))?;
     m.add_wrapped(wrap_pyfunction!(steiner_tree))?;
+    m.add_wrapped(wrap_pyfunction!(chain_decomposition))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
     m.add_class::<iterators::BFSSuccessors>()?;

--- a/tests/graph/test_chain_decomposition.py
+++ b/tests/graph/test_chain_decomposition.py
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestChainDecomposition(unittest.TestCase):
+    def setUp(self):
+        self.graph = retworkx.PyGraph()
+        self.graph.extend_from_edge_list(
+            [
+                (0, 1),
+                (0, 2),
+                (1, 2),
+                (3, 4),
+                (3, 5),
+                (4, 5),
+                (2, 3),
+            ]
+        )
+        return super().setUp()
+
+    def test_graph(self):
+        edges = [
+            # back edges
+            (0, 2),
+            (0, 3),
+            (1, 4),
+            (4, 9),
+            (5, 7),
+            # tree edges
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (2, 4),
+            (4, 5),
+            (4, 8),
+            (5, 6),
+            (6, 7),
+            (8, 9),
+        ]
+
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(edges)
+        chains = retworkx.chain_decomposition(graph, source=0)
+        expected = [
+            [(0, 3), (3, 2), (2, 1), (1, 0)],
+            [(0, 2)],
+            [(1, 4), (4, 2)],
+            [(4, 9), (9, 8), (8, 4)],
+            [(5, 7), (7, 6), (6, 5)],
+        ]
+        self.assertEqual(expected, chains)
+
+    def test_barbell_graph(self):
+        chains = retworkx.chain_decomposition(self.graph, source=0)
+        expected = [[(0, 1), (1, 2), (2, 0)], [(3, 4), (4, 5), (5, 3)]]
+        self.assertEqual(expected, chains)
+
+    def test_disconnected_graph(self):
+        graph = retworkx.union(self.graph, self.graph)
+        chains = retworkx.chain_decomposition(graph)
+        expected = [
+            [(0, 1), (1, 2), (2, 0)],
+            [(3, 4), (4, 5), (5, 3)],
+            [(6, 7), (7, 8), (8, 6)],
+            [(9, 10), (10, 11), (11, 9)],
+        ]
+        self.assertEqual(expected, chains)
+
+    def test_disconnected_graph_root_node(self):
+        graph = retworkx.union(self.graph, self.graph)
+        chains = retworkx.chain_decomposition(graph, source=0)
+        expected = [
+            [(0, 1), (1, 2), (2, 0)],
+            [(3, 4), (4, 5), (5, 3)],
+        ]
+        self.assertEqual(expected, chains)


### PR DESCRIPTION
This commit adds a new function that finds a
chain decomposition of an undirected `PyGraph` .
It's defined in https://doi.org/10.1016/j.ipl.2013.01.016
and can be used to compute all bridges and cut
vertices of the input graph.

One current limitation is that it's a recursive implementation
since it's based on the `petgraph::depth_first_search`.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
