### PR TITLE
Fix `distance_matrix` and `k_shortest_path_lengths` if node holes.

### DIFF
--- a/releasenotes/notes/bugfix-node-holes-210d1b4d329df6dc.yaml
+++ b/releasenotes/notes/bugfix-node-holes-210d1b4d329df6dc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug where :func:`~retworkx.distance_matrix` and
+    :func:`~retworkx.k_shortest_path` would panic if the input graph
+    contains holes in node indices.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,15 @@ pub trait NodesRemoved {
     fn nodes_removed(&self) -> bool;
 }
 
+impl<'a, Ty> NodesRemoved for &'a StableGraph<PyObject, PyObject, Ty>
+where
+    Ty: EdgeType,
+{
+    fn nodes_removed(&self) -> bool {
+        self.node_bound() != self.node_count()
+    }
+}
+
 pub fn get_edge_iter_with_weights<G>(
     graph: G,
 ) -> impl Iterator<Item = (usize, usize, PyObject)>

--- a/src/shortest_path/distance_matrix.rs
+++ b/src/shortest_path/distance_matrix.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use std::ops::Index;
+
 use hashbrown::{HashMap, HashSet};
 
 use ndarray::prelude::*;
@@ -18,24 +20,53 @@ use petgraph::EdgeType;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::NodesRemoved;
+
+#[inline]
+fn apply<I, M>(
+    map_fn: &Option<M>,
+    x: I,
+    default: <M as Index<I>>::Output,
+) -> <M as Index<I>>::Output
+where
+    M: Index<I>,
+    <M as Index<I>>::Output: Sized + Copy,
+{
+    match map_fn {
+        Some(map) => map[x],
+        None => default,
+    }
+}
+
 pub fn compute_distance_matrix<Ty: EdgeType + Sync>(
     graph: &StableGraph<PyObject, PyObject, Ty>,
     parallel_threshold: usize,
     as_undirected: bool,
     null_value: f64,
 ) -> Array2<f64> {
-    let node_map: HashMap<NodeIndex, usize> = graph
-        .node_indices()
-        .enumerate()
-        .map(|(i, v)| (v, i))
-        .collect();
-    let node_map_inv: Vec<NodeIndex> = graph.node_indices().collect();
+    let node_map: Option<HashMap<NodeIndex, usize>> = if graph.nodes_removed() {
+        Some(
+            graph
+                .node_indices()
+                .enumerate()
+                .map(|(i, v)| (v, i))
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    let node_map_inv: Option<Vec<NodeIndex>> = if graph.nodes_removed() {
+        Some(graph.node_indices().collect())
+    } else {
+        None
+    };
 
     let n = graph.node_count();
     let mut matrix = Array2::<f64>::from_elem((n, n), null_value);
     let bfs_traversal = |index: usize, mut row: ArrayViewMut1<f64>| {
         let mut seen: HashMap<NodeIndex, usize> = HashMap::with_capacity(n);
-        let start_index = node_map_inv[index];
+        let start_index = apply(&node_map_inv, index, NodeIndex::new(index));
         let mut level = 0;
         let mut next_level: HashSet<NodeIndex> = HashSet::new();
         next_level.insert(start_index);
@@ -47,7 +78,7 @@ pub fn compute_distance_matrix<Ty: EdgeType + Sync>(
                 if !seen.contains_key(&v) {
                     seen.insert(v, level);
                     found.push(v);
-                    row[[node_map[&v]]] = level as f64;
+                    row[[apply(&node_map, &v, v.index())]] = level as f64;
                 }
             }
             if seen.len() == n {

--- a/src/shortest_path/floyd_warshall.rs
+++ b/src/shortest_path/floyd_warshall.rs
@@ -29,16 +29,6 @@ use ndarray::prelude::*;
 use rayon::prelude::*;
 
 use crate::iterators::{AllPairsPathLengthMapping, PathLengthMapping};
-use crate::NodesRemoved;
-
-impl<'a, Ty> NodesRemoved for &'a StableGraph<PyObject, PyObject, Ty>
-where
-    Ty: EdgeType,
-{
-    fn nodes_removed(&self) -> bool {
-        self.node_bound() != self.node_count()
-    }
-}
 
 pub fn floyd_warshall<Ty: EdgeType>(
     py: Python,

--- a/src/shortest_path/k_shortest_path.rs
+++ b/src/shortest_path/k_shortest_path.rs
@@ -58,7 +58,7 @@ where
     G::NodeId: Eq + Hash,
     F: FnMut(&PyObject) -> PyResult<f64>,
 {
-    let mut counter: Vec<usize> = vec![0; graph.node_count()];
+    let mut counter: Vec<usize> = vec![0; graph.node_bound()];
     let mut scores = DictMap::with_capacity(graph.node_count());
     let mut visit_next = BinaryHeap::new();
     let zero_score = 0.0;

--- a/tests/digraph/test_dist_matrix.py
+++ b/tests/digraph/test_dist_matrix.py
@@ -147,3 +147,10 @@ class TestDistanceMatrix(unittest.TestCase):
             ]
         )
         self.assertTrue(np.array_equal(dist, expected, equal_nan=True))
+
+    def test_digraph_distance_matrix_node_hole(self):
+        graph = retworkx.generators.directed_path_graph(4)
+        graph.remove_node(0)
+        dist = retworkx.digraph_distance_matrix(graph)
+        expected = np.array([[0.0, 1.0, 2.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
+        self.assertTrue(np.array_equal(dist, expected))

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -65,3 +65,11 @@ class TestKShortestpath(unittest.TestCase):
             graph, 1, 2, lambda _: 1, 3
         )
         self.assertEqual(res, {3: 6})
+
+    def test_digraph_k_shortest_path_with_goal_node_hole(self):
+        graph = retworkx.generators.directed_path_graph(4)
+        graph.remove_node(0)
+        res = retworkx.digraph_k_shortest_path_lengths(
+            graph, start=1, k=1, edge_cost=lambda _: 1, goal=3
+        )
+        self.assertEqual({3: 2}, res)

--- a/tests/graph/test_dist_matrix.py
+++ b/tests/graph/test_dist_matrix.py
@@ -103,3 +103,10 @@ class TestDistanceMatrix(unittest.TestCase):
             ],
         )
         self.assertTrue(np.array_equal(dist, expected, equal_nan=True))
+
+    def test_graph_distance_matrix_node_hole(self):
+        graph = retworkx.generators.path_graph(4)
+        graph.remove_node(0)
+        dist = retworkx.graph_distance_matrix(graph)
+        expected = np.array([[0.0, 1.0, 2.0], [1.0, 0.0, 1.0], [2.0, 1.0, 0.0]])
+        self.assertTrue(np.array_equal(dist, expected))

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -46,3 +46,11 @@ class TestKShortestpath(unittest.TestCase):
             graph, 0, 2, lambda _: 1, 3
         )
         self.assertEqual({3: 4}, res)
+
+    def test_k_graph_shortest_path_with_goal_node_hole(self):
+        graph = retworkx.generators.path_graph(4)
+        graph.remove_node(0)
+        res = retworkx.graph_k_shortest_path_lengths(
+            graph, start=1, k=1, edge_cost=lambda _: 1, goal=3
+        )
+        self.assertEqual({3: 2}, res)


### PR DESCRIPTION
Previously, `distance_matrix` and `k_shortest_path` would panic
if the input graph contained holes in node indices. This commit
fixes this in `distance_matrix` by mapping nodes to a compact interval
`0..n` where `n` is the number of nodes in the graph.
In `k_shortest_path` we should initialize a vector of `node_bound` size.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
