### PR TITLE
Handle d=1 edge case in heavy graph functions

### DIFF
--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1144,6 +1144,15 @@ pub fn heavy_square_graph(
         return Err(PyIndexError::new_err("d must be odd"));
     }
 
+    if d == 1 {
+        graph.add_node(py.None());
+        return Ok(graph::PyGraph {
+            graph,
+            node_removed: false,
+            multigraph,
+        });
+    }
+
     let num_data = d * d;
     let num_syndrome = d * (d - 1);
     let num_flag = d * (d - 1);
@@ -1300,6 +1309,17 @@ pub fn directed_heavy_square_graph(
 
     if d % 2 == 0 {
         return Err(PyIndexError::new_err("d must be odd"));
+    }
+
+    if d == 1 {
+        graph.add_node(py.None());
+        return Ok(digraph::PyDiGraph {
+            graph,
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+        });
     }
 
     let num_data = d * d;
@@ -1520,6 +1540,15 @@ pub fn heavy_hex_graph(
         return Err(PyIndexError::new_err("d must be odd"));
     }
 
+    if d == 1 {
+        graph.add_node(py.None());
+        return Ok(graph::PyGraph {
+            graph,
+            node_removed: false,
+            multigraph,
+        });
+    }
+
     let num_data = d * d;
     let num_syndrome = (d - 1) * (d + 1) / 2;
     let num_flag = d * (d - 1);
@@ -1687,6 +1716,17 @@ pub fn directed_heavy_hex_graph(
 
     if d % 2 == 0 {
         return Err(PyIndexError::new_err("d must be odd"));
+    }
+
+    if d == 1 {
+        graph.add_node(py.None());
+        return Ok(digraph::PyDiGraph {
+            graph,
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+        });
     }
 
     let num_data = d * d;

--- a/tests/generators/releasenotes/notes/d-1-heavy-hex-e2e44861dc75009a.yaml
+++ b/tests/generators/releasenotes/notes/d-1-heavy-hex-e2e44861dc75009a.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~retworkx.generators.heavy_hex_graph`,
+    :func:`~retworkx.generators.directed_heavy_hex_graph`,
+    :func:`~retworkx.generators.heavy_square_graph`,
+    and :func:`~retworkx.generators.directed_heavy_square_graph` generator
+    functions. When the input parameter ``d`` was set to 1 these functions
+    would previously raise a ``pyo3_runtime.PanicException`` instead of
+    returning the expected graph (a single node). 
+    Fixed `#452 <https://github.com/Qiskit/retworkx/issues/452>`__

--- a/tests/generators/test_heavy_hex.py
+++ b/tests/generators/test_heavy_hex.py
@@ -16,6 +16,18 @@ import retworkx
 
 
 class TestHeavyHexGraph(unittest.TestCase):
+    def test_directed_heavy_hex_graph_1(self):
+        d = 1
+        graph = retworkx.generators.directed_heavy_hex_graph(d)
+        self.assertEqual(1, len(graph))
+        self.assertEqual(graph.edge_list(), [])
+
+    def test_heavy_hex_graph_1(self):
+        d = 1
+        graph = retworkx.generators.heavy_hex_graph(d)
+        self.assertEqual(1, len(graph))
+        self.assertEqual(graph.edge_list(), [])
+
     def test_directed_heavy_hex_graph_3(self):
         d = 3
         graph = retworkx.generators.directed_heavy_hex_graph(d)

--- a/tests/generators/test_heavy_square.py
+++ b/tests/generators/test_heavy_square.py
@@ -16,6 +16,18 @@ import retworkx
 
 
 class TestHeavyHexGraph(unittest.TestCase):
+    def test_directed_heavy_hex_graph_1(self):
+        d = 1
+        graph = retworkx.generators.directed_heavy_square_graph(d)
+        self.assertEqual(1, len(graph))
+        self.assertEqual(graph.edge_list(), [])
+
+    def test_heavy_hex_graph_1(self):
+        d = 1
+        graph = retworkx.generators.heavy_square_graph(d)
+        self.assertEqual(1, len(graph))
+        self.assertEqual(graph.edge_list(), [])
+
     def test_directed_heavy_square_graph_5(self):
         d = 5
         graph = retworkx.generators.directed_heavy_square_graph(d)


### PR DESCRIPTION
The *heavy_hex_graph and *heavy_square_graph generator functions all
previously had an issue where they would panic when d=1 was passed as
the input to the functions. The d=1 is just a single node, so to avoid a
panic a special case is added to return a graph with a single node which
avoids the panic.

Fixes #452

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
