### PR TITLE
Upgrade to PyO3 and Numpy 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c15af63aa0c74e0f7230d4e95d9a3d71a23449905f30f50b055df9a6a6a3e6"
+checksum = "e590538dba8432d54d3587b06df73d7c044e83cfa4b200cbc7d0567f924ac0a7"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
+checksum = "64664505ce285a59b8b7e940fbe54ad65b1758a0810eddc5bc26df6f6ec8c557"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
@@ -395,18 +395,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12961738cacbd7f91b7c43bc25cfeeaa2698ad07a04b3be0aa88b950865738f"
+checksum = "5f1e4a72de84cdcd69f62211b62f62753d0c11b7b5715f3467f3754dab22a7ca"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0bc5215d704824dfddddc03f93cb572e1155c68b6761c37005e1c288808ea8"
+checksum = "244f21d0a3887a9c02018b94e3b78d693dc7eca5c56839b7796a499cc364deb4"
 dependencies = [
  "pyo3-macros-backend",
  "quote",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71623fc593224afaab918aa3afcaf86ed2f43d34f6afde7f3922608f253240df"
+checksum = "b3d3d18ac41d05199bb82645d56e39f8c8b4909a0137c6f2640f03685b29f672"
 dependencies = [
  "proc-macro2",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 ahash = { version = "0.7.6", default-features = false }
 petgraph = "0.6.0"
 fixedbitset = "0.4.0"
-numpy = "0.14.1"
+numpy = "0.15.0"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1.5"
@@ -32,7 +32,7 @@ num-complex = "0.4"
 retworkx-core = { path = "./retworkx-core" }
 
 [dependencies.pyo3]
-version = "0.14.5"
+version = "0.15.0"
 features = ["extension-module", "hashbrown", "num-bigint", "num-complex", "indexmap"]
 
 [dependencies.hashbrown]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -352,11 +352,11 @@ impl PyDiGraph {
         }
         for raw_edge in edges_list.iter() {
             let edge = raw_edge.downcast::<PyTuple>()?;
-            let raw_p_index = edge.get_item(0).downcast::<PyLong>()?;
+            let raw_p_index = edge.get_item(0)?.downcast::<PyLong>()?;
             let p_index: usize = raw_p_index.extract()?;
-            let raw_c_index = edge.get_item(1).downcast::<PyLong>()?;
+            let raw_c_index = edge.get_item(1)?.downcast::<PyLong>()?;
             let c_index: usize = raw_c_index.extract()?;
-            let edge_data = edge.get_item(2);
+            let edge_data = edge.get_item(2)?;
             self.graph.add_edge(
                 NodeIndex::new(p_index),
                 NodeIndex::new(c_index),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -225,13 +225,13 @@ impl PyGraph {
         }
         for raw_edge in edges_list.iter() {
             let edge = raw_edge.downcast::<PyTuple>()?;
-            let raw_p_index = edge.get_item(0).downcast::<PyLong>()?;
+            let raw_p_index = edge.get_item(0)?.downcast::<PyLong>()?;
             let parent: usize = raw_p_index.extract()?;
             let p_index = NodeIndex::new(parent);
-            let raw_c_index = edge.get_item(1).downcast::<PyLong>()?;
+            let raw_c_index = edge.get_item(1)?.downcast::<PyLong>()?;
             let child: usize = raw_c_index.extract()?;
             let c_index = NodeIndex::new(child);
-            let edge_data = edge.get_item(2);
+            let edge_data = edge.get_item(2)?;
 
             self.graph.add_edge(p_index, c_index, edge_data.into());
         }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -305,7 +305,7 @@ where
         }
 
         for (i, item) in self.iter().enumerate() {
-            let other_raw = other.get_item(i.try_into().unwrap())?;
+            let other_raw = other.get_item(i)?;
             if !PyEq::eq(item, other_raw, py)? {
                 return Ok(false);
             }


### PR DESCRIPTION
Both PyO3 and rust-numpy released their 0.15.0 versions which added a
bunch of new feature (mainly on pyo3) and fixes. This commit upgrades
both to the latest release and fixes compatibility issues with the new
version.

Fixes #465

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
