### PR TITLE
Add Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -27,5 +27,8 @@
        "graph-theory",
        "rust",
        "python"
+    ],
+    "communities": [
+        {"identifier": "qiskit"}
     ]
  }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,31 @@
+{
+    "title":"retworkx",
+    "description":"retworkx is a general-purpose graph theory library focused on performance. It wraps low-level Rust code into a flexible Python API, providing fast implementations for popular graph algorithms.",
+    "license":"Apache-2.0",
+    "upload_type":"software",
+    "access_right":"open",
+    "creators":[
+       {
+          "name":"Matthew Treinish",
+          "orcid":"0000-0001-9713-2875"
+       },
+       {
+          "name":"Ivan Carvalho",
+          "orcid":"0000-0002-8257-2103"
+       },
+       {
+          "name":"Georgios Tsilimigkounakis",
+          "orcid":"0000-0001-6174-0801"
+       },
+       {
+          "name":"Nahum Sá",
+          "orcid":"0000-0002-3234-8154"
+       }
+    ],
+    "notes":"retworkx is the work of many people who contribute to the project at different levels. See the full list of contributors on Github: https://github.com/Qiskit/retworkx/graphs/contributors",
+    "keywords":[
+       "graph-theory",
+       "rust",
+       "python"
+    ]
+ }


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Related to #481 

Adds a `.zenodo.json` file with the metadata for the Zenodo releases, as specified in [their API](https://developers.zenodo.org/#github).

Thanks to [cbjuan](https://github.com/cbjuan), we have a webhook for Zenodo that will deposit the code on every release. This file contains the data cbjuan had to manually enter such that we will no longer need to worry about manually editing those fields.