### PR TITLE
Set max line length to 100 characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - run: pip install -U flake8 black==21.5b0
+      - run: pip install -U flake8 black~=22.0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-line-length = 80
-target-version = ['py36', 'py37', 'py38', 'py39']
+line-length = 100
+target-version = ['py37', 'py38', 'py39', 'py310']

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -127,9 +127,7 @@ class PyDAG(PyDiGraph):
 
 
 @functools.singledispatch
-def distance_matrix(
-    graph, parallel_threshold=300, as_undirected=False, null_value=0.0
-):
+def distance_matrix(graph, parallel_threshold=300, as_undirected=False, null_value=0.0):
     """Get the distance matrix for a graph
 
     This differs from functions like :func:`~retworkx.floyd_warshall_numpy` in
@@ -161,9 +159,7 @@ def distance_matrix(
 
 
 @distance_matrix.register(PyDiGraph)
-def _digraph_distance_matrix(
-    graph, parallel_threshold=300, as_undirected=False, null_value=0.0
-):
+def _digraph_distance_matrix(graph, parallel_threshold=300, as_undirected=False, null_value=0.0):
     return digraph_distance_matrix(
         graph,
         parallel_threshold=parallel_threshold,
@@ -180,9 +176,7 @@ def _graph_distance_matrix(graph, parallel_threshold=300, null_value=0.0):
 
 
 @functools.singledispatch
-def unweighted_average_shortest_path_length(
-    graph, parallel_threshold=300, disconnected=False
-):
+def unweighted_average_shortest_path_length(graph, parallel_threshold=300, disconnected=False):
     r"""Return the average shortest path length with unweighted edges.
 
     The average shortest path length is calculated as
@@ -236,9 +230,7 @@ def _digraph_unweighted_average_shortest_path_length(
 
 
 @unweighted_average_shortest_path_length.register(PyGraph)
-def _graph_unweighted_shortest_path_length(
-    graph, parallel_threshold=300, disconnected=False
-):
+def _graph_unweighted_shortest_path_length(graph, parallel_threshold=300, disconnected=False):
     return graph_unweighted_average_shortest_path_length(
         graph, parallel_threshold=parallel_threshold, disconnected=disconnected
     )
@@ -281,9 +273,7 @@ def adjacency_matrix(graph, weight_fn=None, default_weight=1.0, null_value=0.0):
 
 
 @adjacency_matrix.register(PyDiGraph)
-def _digraph_adjacency_matrix(
-    graph, weight_fn=None, default_weight=1.0, null_value=0.0
-):
+def _digraph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0, null_value=0.0):
     return digraph_adjacency_matrix(
         graph,
         weight_fn=weight_fn,
@@ -293,9 +283,7 @@ def _digraph_adjacency_matrix(
 
 
 @adjacency_matrix.register(PyGraph)
-def _graph_adjacency_matrix(
-    graph, weight_fn=None, default_weight=1.0, null_value=0.0
-):
+def _graph_adjacency_matrix(graph, weight_fn=None, default_weight=1.0, null_value=0.0):
     return graph_adjacency_matrix(
         graph,
         weight_fn=weight_fn,
@@ -329,16 +317,12 @@ def all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
 
 @all_simple_paths.register(PyDiGraph)
 def _digraph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return digraph_all_simple_paths(
-        graph, from_, to, min_depth=min_depth, cutoff=cutoff
-    )
+    return digraph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
 
 
 @all_simple_paths.register(PyGraph)
 def _graph_all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
-    return graph_all_simple_paths(
-        graph, from_, to, min_depth=min_depth, cutoff=cutoff
-    )
+    return graph_all_simple_paths(graph, from_, to, min_depth=min_depth, cutoff=cutoff)
 
 
 @functools.singledispatch
@@ -489,9 +473,7 @@ def _digraph_floyd_warshall_numpy(
 
 
 @floyd_warshall_numpy.register(PyGraph)
-def _graph_floyd_warshall_numpy(
-    graph, weight_fn=None, default_weight=1.0, parallel_threshold=300
-):
+def _graph_floyd_warshall_numpy(graph, weight_fn=None, default_weight=1.0, parallel_threshold=300):
     return graph_floyd_warshall_numpy(
         graph,
         weight_fn=weight_fn,
@@ -528,21 +510,13 @@ def astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
 
 
 @astar_shortest_path.register(PyDiGraph)
-def _digraph_astar_shortest_path(
-    graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
-):
-    return digraph_astar_shortest_path(
-        graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
-    )
+def _digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+    return digraph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
 
 
 @astar_shortest_path.register(PyGraph)
-def _graph_astar_shortest_path(
-    graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
-):
-    return graph_astar_shortest_path(
-        graph, node, goal_fn, edge_cost_fn, estimate_cost_fn
-    )
+def _graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn):
+    return graph_astar_shortest_path(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn)
 
 
 @functools.singledispatch
@@ -599,9 +573,7 @@ def _digraph_dijkstra_shortest_path(
 
 
 @dijkstra_shortest_paths.register(PyGraph)
-def _graph_dijkstra_shortest_path(
-    graph, source, target=None, weight_fn=None, default_weight=1.0
-):
+def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None, default_weight=1.0):
     return graph_dijkstra_shortest_paths(
         graph,
         source,
@@ -723,19 +695,13 @@ def dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
 
 
 @dijkstra_shortest_path_lengths.register(PyDiGraph)
-def _digraph_dijkstra_shortest_path_lengths(
-    graph, node, edge_cost_fn, goal=None
-):
-    return digraph_dijkstra_shortest_path_lengths(
-        graph, node, edge_cost_fn, goal=goal
-    )
+def _digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
+    return digraph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
 
 
 @dijkstra_shortest_path_lengths.register(PyGraph)
 def _graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=None):
-    return graph_dijkstra_shortest_path_lengths(
-        graph, node, edge_cost_fn, goal=goal
-    )
+    return graph_dijkstra_shortest_path_lengths(graph, node, edge_cost_fn, goal=goal)
 
 
 @functools.singledispatch
@@ -765,9 +731,7 @@ def k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
 
 @k_shortest_path_lengths.register(PyDiGraph)
 def _digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
-    return digraph_k_shortest_path_lengths(
-        graph, start, k, edge_cost, goal=goal
-    )
+    return digraph_k_shortest_path_lengths(graph, start, k, edge_cost, goal=goal)
 
 
 @k_shortest_path_lengths.register(PyGraph)
@@ -894,9 +858,7 @@ def _digraph_is_isomorphic(
     id_order=True,
     call_limit=None,
 ):
-    return digraph_is_isomorphic(
-        first, second, node_matcher, edge_matcher, id_order, call_limit
-    )
+    return digraph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order, call_limit)
 
 
 @is_isomorphic.register(PyGraph)
@@ -908,9 +870,7 @@ def _graph_is_isomorphic(
     id_order=True,
     call_limit=None,
 ):
-    return graph_is_isomorphic(
-        first, second, node_matcher, edge_matcher, id_order, call_limit
-    )
+    return graph_is_isomorphic(first, second, node_matcher, edge_matcher, id_order, call_limit)
 
 
 @functools.singledispatch
@@ -1330,10 +1290,7 @@ def networkx_converter(graph, keep_attributes: bool = False):
     nodes = list(graph.nodes)
     node_indices = dict(zip(nodes, new_graph.add_nodes_from(nodes)))
     new_graph.add_edges_from(
-        [
-            (node_indices[x[0]], node_indices[x[1]], x[2])
-            for x in graph.edges(data=True)
-        ]
+        [(node_indices[x[0]], node_indices[x[1]], x[2]) for x in graph.edges(data=True)]
     )
 
     if keep_attributes:
@@ -1461,22 +1418,16 @@ def shell_layout(graph, nlist=None, rotate=None, scale=1, center=None):
 
 @shell_layout.register(PyDiGraph)
 def _digraph_shell_layout(graph, nlist=None, rotate=None, scale=1, center=None):
-    return digraph_shell_layout(
-        graph, nlist=nlist, rotate=rotate, scale=scale, center=center
-    )
+    return digraph_shell_layout(graph, nlist=nlist, rotate=rotate, scale=scale, center=center)
 
 
 @shell_layout.register(PyGraph)
 def _graph_shell_layout(graph, nlist=None, rotate=None, scale=1, center=None):
-    return graph_shell_layout(
-        graph, nlist=nlist, rotate=rotate, scale=scale, center=center
-    )
+    return graph_shell_layout(graph, nlist=nlist, rotate=rotate, scale=scale, center=center)
 
 
 @functools.singledispatch
-def spiral_layout(
-    graph, scale=1, center=None, resolution=0.35, equidistant=False
-):
+def spiral_layout(graph, scale=1, center=None, resolution=0.35, equidistant=False):
     """
     Generate a spiral layout of the graph
 
@@ -1497,9 +1448,7 @@ def spiral_layout(
 
 
 @spiral_layout.register(PyDiGraph)
-def _digraph_spiral_layout(
-    graph, scale=1, center=None, resolution=0.35, equidistant=False
-):
+def _digraph_spiral_layout(graph, scale=1, center=None, resolution=0.35, equidistant=False):
     return digraph_spiral_layout(
         graph,
         scale=scale,
@@ -1510,9 +1459,7 @@ def _digraph_spiral_layout(
 
 
 @spiral_layout.register(PyGraph)
-def _graph_spiral_layout(
-    graph, scale=1, center=None, resolution=0.35, equidistant=False
-):
+def _graph_spiral_layout(graph, scale=1, center=None, resolution=0.35, equidistant=False):
     return graph_spiral_layout(
         graph,
         scale=scale,
@@ -1548,9 +1495,7 @@ def _graph_num_shortest_paths_unweighted(graph, source):
 
 
 @functools.singledispatch
-def betweenness_centrality(
-    graph, normalized=True, endpoints=False, parallel_threshold=50
-):
+def betweenness_centrality(graph, normalized=True, endpoints=False, parallel_threshold=50):
     r"""Returns the betweenness centrality of each node in the graph.
 
     Betweenness centrality of a node :math:`v` is the sum of the
@@ -1593,9 +1538,7 @@ def betweenness_centrality(
 
 
 @betweenness_centrality.register(PyDiGraph)
-def _digraph_betweenness_centrality(
-    graph, normalized=True, endpoints=False, parallel_threshold=50
-):
+def _digraph_betweenness_centrality(graph, normalized=True, endpoints=False, parallel_threshold=50):
     return digraph_betweenness_centrality(
         graph,
         normalized=normalized,
@@ -1605,9 +1548,7 @@ def _digraph_betweenness_centrality(
 
 
 @betweenness_centrality.register(PyGraph)
-def _graph_betweenness_centrality(
-    graph, normalized=True, endpoints=False, parallel_threshold=50
-):
+def _graph_betweenness_centrality(graph, normalized=True, endpoints=False, parallel_threshold=50):
     return graph_betweenness_centrality(
         graph,
         normalized=normalized,
@@ -1768,9 +1709,7 @@ def _digraph_union(
     merge_nodes=False,
     merge_edges=False,
 ):
-    return digraph_union(
-        first, second, merge_nodes=merge_nodes, merge_edges=merge_edges
-    )
+    return digraph_union(first, second, merge_nodes=merge_nodes, merge_edges=merge_edges)
 
 
 @union.register(PyGraph)
@@ -1780,9 +1719,7 @@ def _graph_union(
     merge_nodes=False,
     merge_edges=False,
 ):
-    return graph_union(
-        first, second, merge_nodes=merge_nodes, merge_edges=merge_edges
-    )
+    return graph_union(first, second, merge_nodes=merge_nodes, merge_edges=merge_edges)
 
 
 @functools.singledispatch

--- a/retworkx/visualization/matplotlib.py
+++ b/retworkx/visualization/matplotlib.py
@@ -214,9 +214,7 @@ def mpl_draw(graph, pos=None, ax=None, arrows=True, with_labels=False, **kwds):
         else:
             ax = cf.gca()
 
-    draw_graph(
-        graph, pos=pos, ax=ax, arrows=arrows, with_labels=with_labels, **kwds
-    )
+    draw_graph(graph, pos=pos, ax=ax, arrows=arrows, with_labels=with_labels, **kwds)
     ax.set_axis_off()
     plt.draw_if_interactive()
     if not plt.isinteractive() or ax is None:
@@ -320,12 +318,7 @@ def draw_graph(graph, pos=None, arrows=True, with_labels=False, **kwds):
         "verticalalignment",
     }
 
-    valid_kwds = (
-        valid_node_kwds
-        | valid_edge_kwds
-        | valid_label_kwds
-        | valid_edge_label_kwds
-    )
+    valid_kwds = valid_node_kwds | valid_edge_kwds | valid_label_kwds | valid_edge_label_kwds
 
     if any([k not in valid_kwds for k in kwds]):
         invalid_args = ", ".join([k for k in kwds if k not in valid_kwds])
@@ -337,8 +330,7 @@ def draw_graph(graph, pos=None, arrows=True, with_labels=False, **kwds):
     edge_label_fn = kwds.pop("edge_labels", None)
     if edge_label_fn:
         kwds["edge_labels"] = {
-            (x[0], x[1]): edge_label_fn(x[2])
-            for x in graph.weighted_edge_list()
+            (x[0], x[1]): edge_label_fn(x[2]) for x in graph.weighted_edge_list()
         }
 
     node_kwds = {k: v for k, v in kwds.items() if k in valid_node_kwds}
@@ -346,9 +338,7 @@ def draw_graph(graph, pos=None, arrows=True, with_labels=False, **kwds):
     if isinstance(edge_kwds.get("alpha"), list):
         del edge_kwds["alpha"]
     label_kwds = {k: v for k, v in kwds.items() if k in valid_label_kwds}
-    edge_label_kwds = {
-        k: v for k, v in kwds.items() if k in valid_edge_label_kwds
-    }
+    edge_label_kwds = {k: v for k, v in kwds.items() if k in valid_edge_label_kwds}
 
     if pos is None:
         pos = retworkx.spring_layout(graph)  # default to spring layout
@@ -720,9 +710,7 @@ def draw_edges(
                 data_loc + np.asarray([0, v_shift]),
             ]
 
-            ret = mpl.path.Path(
-                ax.transData.transform(path), [1, 4, 4, 4, 4, 4, 4]
-            )
+            ret = mpl.path.Path(ax.transData.transform(path), [1, 4, 4, 4, 4, 4, 4])
         # if not, fall back to the user specified behavior
         else:
             ret = base_connectionstyle(posA, posB, *args, **kwargs)
@@ -743,9 +731,7 @@ def draw_edges(
             shrink_source = to_marker_edge(source_node_size, node_shape)
             shrink_target = to_marker_edge(target_node_size, node_shape)
         else:
-            shrink_source = shrink_target = to_marker_edge(
-                node_size, node_shape
-            )
+            shrink_source = shrink_target = to_marker_edge(node_size, node_shape)
 
         if shrink_source < min_source_margin:
             shrink_source = min_source_margin
@@ -1026,16 +1012,12 @@ def draw_edge_labels(
                 angle += 180
             # transform data coordinate angle to screen coordinate angle
             xy = np.array((x, y))
-            trans_angle = ax.transData.transform_angles(
-                np.array((angle,)), xy.reshape((1, 2))
-            )[0]
+            trans_angle = ax.transData.transform_angles(np.array((angle,)), xy.reshape((1, 2)))[0]
         else:
             trans_angle = 0.0
         # use default box of white with white border
         if bbox is None:
-            bbox = dict(
-                boxstyle="round", ec=(1.0, 1.0, 1.0), fc=(1.0, 1.0, 1.0)
-            )
+            bbox = dict(boxstyle="round", ec=(1.0, 1.0, 1.0), fc=(1.0, 1.0, 1.0))
         if not isinstance(label, str):
             label = str(label)  # this makes "1" and 1 labeled the same
 
@@ -1131,9 +1113,7 @@ def apply_alpha(colors, alpha, elem_list, cmap=None, vmin=None, vmax=None):
         try:
             rgba_colors = np.array([mpl.colors.colorConverter.to_rgba(colors)])
         except ValueError:
-            rgba_colors = np.array(
-                [mpl.colors.colorConverter.to_rgba(color) for color in colors]
-            )
+            rgba_colors = np.array([mpl.colors.colorConverter.to_rgba(color) for color in colors])
     # Set the final column of the rgba_colors to have the relevant alpha values
     try:
         # If alpha is longer than the number of colors, resize to the number of

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-max_width = 80
+max_width = 100

--- a/src/cartesian_product.rs
+++ b/src/cartesian_product.rs
@@ -28,12 +28,10 @@ fn cartesian_product<Ty: EdgeType>(
 ) -> (StablePyGraph<Ty>, ProductNodeMap) {
     let mut final_graph = StablePyGraph::<Ty>::with_capacity(
         first.node_count() * second.node_count(),
-        first.node_count() * second.edge_count()
-            + first.edge_count() * second.node_count(),
+        first.node_count() * second.edge_count() + first.edge_count() * second.node_count(),
     );
 
-    let mut hash_nodes =
-        HashMap::with_capacity(first.node_count() * second.node_count());
+    let mut hash_nodes = HashMap::with_capacity(first.node_count() * second.node_count());
 
     for (x, weight_x) in first.node_references() {
         for (y, weight_y) in second.node_references() {
@@ -47,11 +45,7 @@ fn cartesian_product<Ty: EdgeType>(
             let source = hash_nodes[&(edge_first.source(), node_second)];
             let target = hash_nodes[&(edge_first.target(), node_second)];
 
-            final_graph.add_edge(
-                source,
-                target,
-                edge_first.weight().clone_ref(py),
-            );
+            final_graph.add_edge(source, target, edge_first.weight().clone_ref(py));
         }
     }
 
@@ -60,11 +54,7 @@ fn cartesian_product<Ty: EdgeType>(
             let source = hash_nodes[&(node_first, edge_second.source())];
             let target = hash_nodes[&(node_first, edge_second.target())];
 
-            final_graph.add_edge(
-                source,
-                target,
-                edge_second.weight().clone_ref(py),
-            );
+            final_graph.add_edge(source, target, edge_second.weight().clone_ref(py));
         }
     }
 
@@ -115,8 +105,7 @@ fn graph_cartesian_product(
     first: &graph::PyGraph,
     second: &graph::PyGraph,
 ) -> (graph::PyGraph, ProductNodeMap) {
-    let (out_graph, out_node_map) =
-        cartesian_product(py, &first.graph, &second.graph);
+    let (out_graph, out_node_map) = cartesian_product(py, &first.graph, &second.graph);
 
     (
         graph::PyGraph {
@@ -165,8 +154,7 @@ fn digraph_cartesian_product(
     first: &digraph::PyDiGraph,
     second: &digraph::PyDiGraph,
 ) -> (digraph::PyDiGraph, ProductNodeMap) {
-    let (out_graph, out_node_map) =
-        cartesian_product(py, &first.graph, &second.graph);
+    let (out_graph, out_node_map) = cartesian_product(py, &first.graph, &second.graph);
 
     (
         digraph::PyDiGraph {

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -57,26 +57,16 @@ use retworkx_core::centrality;
 /// :returns: a read-only dict-like object whose keys are the node indices and values are the
 ///      betweenness score for each node.
 /// :rtype: CentralityMapping
-#[pyfunction(
-    normalized = "true",
-    endpoints = "false",
-    parallel_threshold = "50"
-)]
-#[pyo3(
-    text_signature = "(graph, /, normalized=True, endpoints=False, parallel_threshold=50)"
-)]
+#[pyfunction(normalized = "true", endpoints = "false", parallel_threshold = "50")]
+#[pyo3(text_signature = "(graph, /, normalized=True, endpoints=False, parallel_threshold=50)")]
 pub fn graph_betweenness_centrality(
     graph: &graph::PyGraph,
     normalized: bool,
     endpoints: bool,
     parallel_threshold: usize,
 ) -> CentralityMapping {
-    let betweenness = centrality::betweenness_centrality(
-        &graph.graph,
-        endpoints,
-        normalized,
-        parallel_threshold,
-    );
+    let betweenness =
+        centrality::betweenness_centrality(&graph.graph, endpoints, normalized, parallel_threshold);
     CentralityMapping {
         centralities: betweenness
             .into_iter()
@@ -124,26 +114,16 @@ pub fn graph_betweenness_centrality(
 /// :returns: a read-only dict-like object whose keys are the node indices and values are the
 ///      betweenness score for each node.
 /// :rtype: CentralityMapping
-#[pyfunction(
-    normalized = "true",
-    endpoints = "false",
-    parallel_threshold = "50"
-)]
-#[pyo3(
-    text_signature = "(graph, /, normalized=True, endpoints=False, parallel_threshold=50)"
-)]
+#[pyfunction(normalized = "true", endpoints = "false", parallel_threshold = "50")]
+#[pyo3(text_signature = "(graph, /, normalized=True, endpoints=False, parallel_threshold=50)")]
 pub fn digraph_betweenness_centrality(
     graph: &digraph::PyDiGraph,
     normalized: bool,
     endpoints: bool,
     parallel_threshold: usize,
 ) -> CentralityMapping {
-    let betweenness = centrality::betweenness_centrality(
-        &graph.graph,
-        endpoints,
-        normalized,
-        parallel_threshold,
-    );
+    let betweenness =
+        centrality::betweenness_centrality(&graph.graph, endpoints, normalized, parallel_threshold);
     CentralityMapping {
         centralities: betweenness
             .into_iter()

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -35,14 +35,10 @@ use rayon::prelude::*;
 /// :rtype: dict
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-fn graph_greedy_color(
-    py: Python,
-    graph: &graph::PyGraph,
-) -> PyResult<PyObject> {
+fn graph_greedy_color(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
     let mut colors: DictMap<usize, usize> = DictMap::new();
     let mut node_vec: Vec<NodeIndex> = graph.graph.node_indices().collect();
-    let mut sort_map: HashMap<NodeIndex, usize> =
-        HashMap::with_capacity(graph.node_count());
+    let mut sort_map: HashMap<NodeIndex, usize> = HashMap::with_capacity(graph.node_count());
     for k in node_vec.iter() {
         sort_map.insert(*k, graph.graph.edges(*k).count());
     }

--- a/src/connectivity/connected_components.rs
+++ b/src/connectivity/connected_components.rs
@@ -40,9 +40,7 @@ pub fn bfs_undirected<Ty: EdgeType>(
     component
 }
 
-pub fn connected_components<Ty>(
-    graph: &StablePyGraph<Ty>,
-) -> Vec<HashSet<usize>>
+pub fn connected_components<Ty>(graph: &StablePyGraph<Ty>) -> Vec<HashSet<usize>>
 where
     Ty: EdgeType,
 {

--- a/src/connectivity/core_number.rs
+++ b/src/connectivity/core_number.rs
@@ -24,10 +24,7 @@ use rayon::prelude::*;
 
 use crate::StablePyGraph;
 
-pub fn core_number<Ty>(
-    py: Python,
-    graph: &StablePyGraph<Ty>,
-) -> PyResult<PyObject>
+pub fn core_number<Ty>(py: Python, graph: &StablePyGraph<Ty>) -> PyResult<PyObject>
 where
     Ty: EdgeType,
 {
@@ -38,16 +35,12 @@ where
 
     let mut cores: DictMap<NodeIndex, usize> = DictMap::with_capacity(node_num);
     let mut node_vec: Vec<NodeIndex> = graph.node_indices().collect();
-    let mut degree_map: HashMap<NodeIndex, usize> =
-        HashMap::with_capacity(node_num);
-    let mut nbrs: HashMap<NodeIndex, HashSet<NodeIndex>> =
-        HashMap::with_capacity(node_num);
-    let mut node_pos: HashMap<NodeIndex, usize> =
-        HashMap::with_capacity(node_num);
+    let mut degree_map: HashMap<NodeIndex, usize> = HashMap::with_capacity(node_num);
+    let mut nbrs: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::with_capacity(node_num);
+    let mut node_pos: HashMap<NodeIndex, usize> = HashMap::with_capacity(node_num);
 
     for k in node_vec.iter() {
-        let k_nbrs: HashSet<NodeIndex> =
-            graph.neighbors_undirected(*k).collect();
+        let k_nbrs: HashSet<NodeIndex> = graph.neighbors_undirected(*k).collect();
         let k_deg = k_nbrs.len();
 
         nbrs.insert(*k, k_nbrs);

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -15,10 +15,7 @@
 mod connected_components;
 mod core_number;
 
-use super::{
-    digraph, get_edge_iter_with_weights, graph, weight_callable, InvalidNode,
-    NullGraph,
-};
+use super::{digraph, get_edge_iter_with_weights, graph, weight_callable, InvalidNode, NullGraph};
 
 use hashbrown::{HashMap, HashSet};
 
@@ -28,9 +25,7 @@ use pyo3::Python;
 use petgraph::algo;
 use petgraph::graph::NodeIndex;
 use petgraph::unionfind::UnionFind;
-use petgraph::visit::{
-    EdgeRef, IntoEdgeReferences, NodeCount, NodeIndexable, Visitable,
-};
+use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeCount, NodeIndexable, Visitable};
 
 use ndarray::prelude::*;
 use numpy::IntoPyArray;
@@ -64,13 +59,9 @@ use retworkx_core::connectivity;
 ///    cycles of a graph. Comm. ACM 12, 9 (Sept 1969), 514-518.
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /, root=None)")]
-pub fn cycle_basis(
-    graph: &graph::PyGraph,
-    root: Option<usize>,
-) -> Vec<Vec<usize>> {
+pub fn cycle_basis(graph: &graph::PyGraph, root: Option<usize>) -> Vec<Vec<usize>> {
     let mut root_node = root;
-    let mut graph_nodes: HashSet<NodeIndex> =
-        graph.graph.node_indices().collect();
+    let mut graph_nodes: HashSet<NodeIndex> = graph.graph.node_indices().collect();
     let mut cycles: Vec<Vec<usize>> = Vec::new();
     while !graph_nodes.is_empty() {
         let temp_value: NodeIndex;
@@ -145,9 +136,7 @@ pub fn cycle_basis(
 /// :rtype: list
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn strongly_connected_components(
-    graph: &digraph::PyDiGraph,
-) -> Vec<Vec<usize>> {
+pub fn strongly_connected_components(graph: &digraph::PyDiGraph) -> Vec<Vec<usize>> {
     algo::kosaraju_scc(&graph.graph)
         .iter()
         .map(|x| x.iter().map(|id| id.index()).collect())
@@ -166,14 +155,9 @@ pub fn strongly_connected_components(
 /// :rtype: EdgeList
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /, source=None)")]
-pub fn digraph_find_cycle(
-    graph: &digraph::PyDiGraph,
-    source: Option<usize>,
-) -> EdgeList {
-    let mut graph_nodes: HashSet<NodeIndex> =
-        graph.graph.node_indices().collect();
-    let mut cycle: Vec<(usize, usize)> =
-        Vec::with_capacity(graph.graph.edge_count());
+pub fn digraph_find_cycle(graph: &digraph::PyDiGraph, source: Option<usize>) -> EdgeList {
+    let mut graph_nodes: HashSet<NodeIndex> = graph.graph.node_indices().collect();
+    let mut cycle: Vec<(usize, usize)> = Vec::with_capacity(graph.graph.edge_count());
     let temp_value: NodeIndex;
     // If source is not set get an arbitrary node from the set of graph
     // nodes we've not "examined"
@@ -272,10 +256,7 @@ pub fn connected_components(graph: &graph::PyGraph) -> Vec<HashSet<usize>> {
 /// :raises InvalidNode: When an invalid node index is provided.
 #[pyfunction]
 #[pyo3(text_signature = "(graph, node, /)")]
-pub fn node_connected_component(
-    graph: &graph::PyGraph,
-    node: usize,
-) -> PyResult<HashSet<usize>> {
+pub fn node_connected_component(graph: &graph::PyGraph, node: usize) -> PyResult<HashSet<usize>> {
     let node = NodeIndex::new(node);
 
     if !graph.graph.contains_node(node) {
@@ -343,9 +324,7 @@ fn number_weakly_connected_components(graph: &digraph::PyDiGraph) -> usize {
 /// :rtype: list
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn weakly_connected_components(
-    graph: &digraph::PyDiGraph,
-) -> Vec<HashSet<usize>> {
+pub fn weakly_connected_components(graph: &digraph::PyDiGraph) -> Vec<HashSet<usize>> {
     connected_components::connected_components(&graph.graph)
 }
 
@@ -397,9 +376,7 @@ pub fn is_weakly_connected(graph: &digraph::PyDiGraph) -> PyResult<bool> {
 ///  :return: The adjacency matrix for the input directed graph as a numpy array
 ///  :rtype: numpy.ndarray
 #[pyfunction(default_weight = "1.0", null_value = "0.0")]
-#[pyo3(
-    text_signature = "(graph, /, weight_fn=None, default_weight=1.0, null_value=0.0)"
-)]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, null_value=0.0)")]
 pub fn digraph_adjacency_matrix(
     py: Python,
     graph: &digraph::PyDiGraph,
@@ -410,11 +387,8 @@ pub fn digraph_adjacency_matrix(
     let n = graph.node_count();
     let mut matrix = Array2::<f64>::from_elem((n, n), null_value);
     for (i, j, weight) in get_edge_iter_with_weights(&graph.graph) {
-        let edge_weight =
-            weight_callable(py, &weight_fn, &weight, default_weight)?;
-        if matrix[[i, j]] == null_value
-            || (null_value.is_nan() && matrix[[i, j]].is_nan())
-        {
+        let edge_weight = weight_callable(py, &weight_fn, &weight, default_weight)?;
+        if matrix[[i, j]] == null_value || (null_value.is_nan() && matrix[[i, j]].is_nan()) {
             matrix[[i, j]] = edge_weight;
         } else {
             matrix[[i, j]] += edge_weight;
@@ -453,9 +427,7 @@ pub fn digraph_adjacency_matrix(
 /// :return: The adjacency matrix for the input graph as a numpy array
 /// :rtype: numpy.ndarray
 #[pyfunction(default_weight = "1.0", null_value = "0.0")]
-#[pyo3(
-    text_signature = "(graph, /, weight_fn=None, default_weight=1.0, null_value=0.0)"
-)]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, null_value=0.0)")]
 pub fn graph_adjacency_matrix(
     py: Python,
     graph: &graph::PyGraph,
@@ -466,11 +438,8 @@ pub fn graph_adjacency_matrix(
     let n = graph.node_count();
     let mut matrix = Array2::<f64>::from_elem((n, n), null_value);
     for (i, j, weight) in get_edge_iter_with_weights(&graph.graph) {
-        let edge_weight =
-            weight_callable(py, &weight_fn, &weight, default_weight)?;
-        if matrix[[i, j]] == null_value
-            || (null_value.is_nan() && matrix[[i, j]].is_nan())
-        {
+        let edge_weight = weight_callable(py, &weight_fn, &weight, default_weight)?;
+        if matrix[[i, j]] == null_value || (null_value.is_nan() && matrix[[i, j]].is_nan()) {
             matrix[[i, j]] = edge_weight;
             matrix[[j, i]] = edge_weight;
         } else {
@@ -495,29 +464,20 @@ pub fn graph_adjacency_matrix(
 ///     attribute is set to ``True``
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn graph_complement(
-    py: Python,
-    graph: &graph::PyGraph,
-) -> PyResult<graph::PyGraph> {
+pub fn graph_complement(py: Python, graph: &graph::PyGraph) -> PyResult<graph::PyGraph> {
     let mut complement_graph = graph.clone(); // keep same node indices
     complement_graph.graph.clear_edges();
 
     for node_a in graph.graph.node_indices() {
-        let old_neighbors: HashSet<NodeIndex> =
-            graph.graph.neighbors(node_a).collect();
+        let old_neighbors: HashSet<NodeIndex> = graph.graph.neighbors(node_a).collect();
         for node_b in graph.graph.node_indices() {
             if node_a != node_b
                 && !old_neighbors.contains(&node_b)
                 && (!complement_graph.multigraph
-                    || !complement_graph
-                        .has_edge(node_a.index(), node_b.index()))
+                    || !complement_graph.has_edge(node_a.index(), node_b.index()))
             {
                 // avoid creating parallel edges in multigraph
-                complement_graph.add_edge(
-                    node_a.index(),
-                    node_b.index(),
-                    py.None(),
-                )?;
+                complement_graph.add_edge(node_a.index(), node_b.index(), py.None())?;
             }
         }
     }
@@ -538,10 +498,7 @@ pub fn graph_complement(
 ///     attribute is set to ``True``
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn digraph_complement(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-) -> PyResult<digraph::PyDiGraph> {
+pub fn digraph_complement(py: Python, graph: &digraph::PyDiGraph) -> PyResult<digraph::PyDiGraph> {
     let mut complement_graph = graph.clone(); // keep same node indices
     complement_graph.graph.clear_edges();
 
@@ -552,11 +509,7 @@ pub fn digraph_complement(
             .collect();
         for node_b in graph.graph.node_indices() {
             if node_a != node_b && !old_neighbors.contains(&node_b) {
-                complement_graph.add_edge(
-                    node_a.index(),
-                    node_b.index(),
-                    py.None(),
-                )?;
+                complement_graph.add_edge(node_a.index(), node_b.index(), py.None())?;
             }
         }
     }
@@ -688,10 +641,7 @@ fn digraph_all_simple_paths(
 /// :rtype: dict
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn graph_core_number(
-    py: Python,
-    graph: &graph::PyGraph,
-) -> PyResult<PyObject> {
+pub fn graph_core_number(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
     core_number::core_number(py, &graph.graph)
 }
 
@@ -712,10 +662,7 @@ pub fn graph_core_number(
 /// :rtype: dict
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn digraph_core_number(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-) -> PyResult<PyObject> {
+pub fn digraph_core_number(py: Python, graph: &digraph::PyDiGraph) -> PyResult<PyObject> {
     core_number::core_number(py, &graph.graph)
 }
 
@@ -811,14 +758,8 @@ pub fn biconnected_components(graph: &graph::PyGraph) -> BiconnectedComponents {
 ///       113, 241–244. Elsevier. <https://doi.org/10.1016/j.ipl.2013.01.016>
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /, source=None)")]
-pub fn chain_decomposition(
-    graph: graph::PyGraph,
-    source: Option<usize>,
-) -> Chains {
-    let chains = connectivity::chain_decomposition(
-        &graph.graph,
-        source.map(NodeIndex::new),
-    );
+pub fn chain_decomposition(graph: graph::PyGraph, source: Option<usize>) -> Chains {
+    let chains = connectivity::chain_decomposition(&graph.graph, source.map(NodeIndex::new));
     Chains {
         chains: chains
             .into_iter()

--- a/src/dag_algo/longest_path.rs
+++ b/src/dag_algo/longest_path.rs
@@ -22,10 +22,7 @@ use petgraph::prelude::*;
 
 use num_traits::{Num, Zero};
 
-pub fn longest_path<F, T>(
-    graph: &digraph::PyDiGraph,
-    mut weight_fn: F,
-) -> PyResult<(Vec<usize>, T)>
+pub fn longest_path<F, T>(graph: &digraph::PyDiGraph, mut weight_fn: F) -> PyResult<(Vec<usize>, T)>
 where
     F: FnMut(usize, usize, &PyObject) -> PyResult<T>,
     T: Num + Zero + PartialOrd + Copy,
@@ -34,9 +31,7 @@ where
     let mut path: Vec<usize> = Vec::new();
     let nodes = match algo::toposort(&graph.graph, None) {
         Ok(nodes) => nodes,
-        Err(_err) => {
-            return Err(DAGHasCycle::new_err("Sort encountered a cycle"))
-        }
+        Err(_err) => return Err(DAGHasCycle::new_err("Sort encountered a cycle")),
     };
     if nodes.is_empty() {
         return Ok((path, T::zero()));
@@ -47,11 +42,7 @@ where
         let mut us: Vec<(T, NodeIndex)> = Vec::new();
         for p_edge in parents {
             let p_node = p_edge.source();
-            let weight: T = weight_fn(
-                p_node.index(),
-                p_edge.target().index(),
-                p_edge.weight(),
-            )?;
+            let weight: T = weight_fn(p_node.index(), p_edge.target().index(), p_edge.weight())?;
             let length = dist[&p_node].0 + weight;
             us.push((length, p_node));
         }

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -104,8 +104,7 @@ pub fn dag_longest_path_length(
                 None => Ok(1),
             }
         };
-    let (_, path_weight) =
-        longest_path::longest_path(graph, edge_weight_callable)?;
+    let (_, path_weight) = longest_path::longest_path(graph, edge_weight_callable)?;
     Ok(path_weight)
 }
 
@@ -138,17 +137,14 @@ pub fn dag_weighted_longest_path(
     graph: &digraph::PyDiGraph,
     weight_fn: PyObject,
 ) -> PyResult<NodeIndices> {
-    let edge_weight_callable =
-        |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
-            let res = weight_fn.call1(py, (source, target, weight))?;
-            let float_res: f64 = res.extract(py)?;
-            if float_res.is_nan() {
-                return Err(PyValueError::new_err(
-                    "NaN is not a valid edge weight",
-                ));
-            }
-            Ok(float_res)
-        };
+    let edge_weight_callable = |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
+        let res = weight_fn.call1(py, (source, target, weight))?;
+        let float_res: f64 = res.extract(py)?;
+        if float_res.is_nan() {
+            return Err(PyValueError::new_err("NaN is not a valid edge weight"));
+        }
+        Ok(float_res)
+    };
     Ok(NodeIndices {
         nodes: longest_path::longest_path(graph, edge_weight_callable)?.0,
     })
@@ -183,19 +179,15 @@ pub fn dag_weighted_longest_path_length(
     graph: &digraph::PyDiGraph,
     weight_fn: PyObject,
 ) -> PyResult<f64> {
-    let edge_weight_callable =
-        |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
-            let res = weight_fn.call1(py, (source, target, weight))?;
-            let float_res: f64 = res.extract(py)?;
-            if float_res.is_nan() {
-                return Err(PyValueError::new_err(
-                    "NaN is not a valid edge weight",
-                ));
-            }
-            Ok(float_res)
-        };
-    let (_, path_weight) =
-        longest_path::longest_path(graph, edge_weight_callable)?;
+    let edge_weight_callable = |source: usize, target: usize, weight: &PyObject| -> PyResult<f64> {
+        let res = weight_fn.call1(py, (source, target, weight))?;
+        let float_res: f64 = res.extract(py)?;
+        if float_res.is_nan() {
+            return Err(PyValueError::new_err("NaN is not a valid edge weight"));
+        }
+        Ok(float_res)
+    };
+    let (_, path_weight) = longest_path::longest_path(graph, edge_weight_callable)?;
     Ok(path_weight)
 }
 
@@ -230,11 +222,7 @@ pub fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
 /// :raises InvalidNode: If a node index in ``first_layer`` is not in the graph
 #[pyfunction]
 #[pyo3(text_signature = "(dag, first_layer, /)")]
-pub fn layers(
-    py: Python,
-    dag: &digraph::PyDiGraph,
-    first_layer: Vec<usize>,
-) -> PyResult<PyObject> {
+pub fn layers(py: Python, dag: &digraph::PyDiGraph, first_layer: Vec<usize>) -> PyResult<PyObject> {
     let mut output: Vec<Vec<&PyObject>> = Vec::new();
     // Convert usize to NodeIndex
     let mut first_layer_index: Vec<NodeIndex> = Vec::new();
@@ -253,8 +241,8 @@ pub fn layers(
             None => {
                 return Err(InvalidNode::new_err(format!(
                     "An index input in 'first_layer' {} is not a valid node index in the graph",
-                    layer_node.index()),
-                ))
+                    layer_node.index()
+                )))
             }
         };
         layer_node_data.push(node_data);
@@ -340,8 +328,7 @@ fn lexicographical_topological_sort(
     };
     // HashMap of node_index indegree
     let node_count = dag.node_count();
-    let mut in_degree_map: HashMap<NodeIndex, usize> =
-        HashMap::with_capacity(node_count);
+    let mut in_degree_map: HashMap<NodeIndex, usize> = HashMap::with_capacity(node_count);
     for node in dag.graph.node_indices() {
         in_degree_map.insert(node, dag.in_degree(node.index()));
     }
@@ -416,9 +403,7 @@ fn lexicographical_topological_sort(
 fn topological_sort(graph: &digraph::PyDiGraph) -> PyResult<NodeIndices> {
     let nodes = match algo::toposort(&graph.graph, None) {
         Ok(nodes) => nodes,
-        Err(_err) => {
-            return Err(DAGHasCycle::new_err("Sort encountered a cycle"))
-        }
+        Err(_err) => return Err(DAGHasCycle::new_err("Sort encountered a cycle")),
     };
     Ok(NodeIndices {
         nodes: nodes.iter().map(|node| node.index()).collect(),
@@ -448,8 +433,7 @@ fn collect_runs(
     filter_fn: PyObject,
 ) -> PyResult<Vec<Vec<PyObject>>> {
     let mut out_list: Vec<Vec<PyObject>> = Vec::new();
-    let mut seen: HashSet<NodeIndex> =
-        HashSet::with_capacity(graph.node_count());
+    let mut seen: HashSet<NodeIndex> = HashSet::with_capacity(graph.node_count());
 
     let filter_node = |node: &PyObject| -> PyResult<bool> {
         let res = filter_fn.call1(py, (node,))?;
@@ -458,9 +442,7 @@ fn collect_runs(
 
     let nodes = match algo::toposort(&graph.graph, None) {
         Ok(nodes) => nodes,
-        Err(_err) => {
-            return Err(DAGHasCycle::new_err("Sort encountered a cycle"))
-        }
+        Err(_err) => return Err(DAGHasCycle::new_err("Sort encountered a cycle")),
     };
     for node in nodes {
         if !filter_node(&graph.graph[node])? || seen.contains(&node) {
@@ -482,10 +464,7 @@ fn collect_runs(
             seen.insert(successors[0]);
             successors = graph
                 .graph
-                .neighbors_directed(
-                    successors[0],
-                    petgraph::Direction::Outgoing,
-                )
+                .neighbors_directed(successors[0], petgraph::Direction::Outgoing)
                 .collect();
             successors.dedup();
         }
@@ -542,9 +521,7 @@ fn collect_bicolor_runs(
 
     let nodes = match algo::toposort(&graph.graph, None) {
         Ok(nodes) => nodes,
-        Err(_err) => {
-            return Err(DAGHasCycle::new_err("Sort encountered a cycle"))
-        }
+        Err(_err) => return Err(DAGHasCycle::new_err("Sort encountered a cycle")),
     };
 
     // Utility for ensuring pending_list has the color index
@@ -579,8 +556,7 @@ fn collect_bicolor_runs(
                     let c0 = colors[0];
                     ensure_vector_has_index!(pending_list, block_id, c0);
                     if let Some(c0_block_id) = block_id[c0] {
-                        block_list[c0_block_id]
-                            .push(graph.graph[node].clone_ref(py));
+                        block_list[c0_block_id].push(graph.graph[node].clone_ref(py));
                     } else {
                         pending_list[c0].push(graph.graph[node].clone_ref(py));
                     }
@@ -597,9 +573,8 @@ fn collect_bicolor_runs(
                         block_list[block_id[c0].unwrap_or_default()]
                             .push(graph.graph[node].clone_ref(py));
                     } else {
-                        let mut new_block: Vec<PyObject> = Vec::with_capacity(
-                            pending_list[c0].len() + pending_list[c1].len() + 1,
-                        );
+                        let mut new_block: Vec<PyObject> =
+                            Vec::with_capacity(pending_list[c0].len() + pending_list[c1].len() + 1);
 
                         // Clears pending lits and add to new block
                         new_block.append(&mut pending_list[c0]);
@@ -618,8 +593,7 @@ fn collect_bicolor_runs(
                     let color = color;
                     ensure_vector_has_index!(pending_list, block_id, color);
                     if let Some(color_block_id) = block_id[color] {
-                        block_list[color_block_id]
-                            .append(&mut pending_list[color]);
+                        block_list[color_block_id].append(&mut pending_list[color]);
                     }
                     block_id[color] = None;
                     pending_list[color].clear();

--- a/src/dot_utils.rs
+++ b/src/dot_utils.rs
@@ -14,8 +14,8 @@ use std::collections::BTreeMap;
 use std::io::prelude::*;
 
 use petgraph::visit::{
-    Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences,
-    IntoNodeReferences, NodeIndexable, NodeRef,
+    Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable,
+    NodeRef,
 };
 use pyo3::prelude::*;
 
@@ -32,11 +32,7 @@ pub fn build_dot<G, T>(
 ) -> PyResult<()>
 where
     T: Write,
-    G: GraphBase
-        + IntoEdgeReferences
-        + IntoNodeReferences
-        + NodeIndexable
-        + GraphProp,
+    G: GraphBase + IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
     G: Data<NodeWeight = PyObject, EdgeWeight = PyObject>,
 {
     writeln!(file, "{} {{", TYPE[graph.is_directed() as usize])?;
@@ -77,11 +73,10 @@ fn attr_map_to_string<'a>(
     if attrs.is_none() {
         return Ok("".to_string());
     }
-    let attr_callable =
-        |node: &'a PyObject| -> PyResult<BTreeMap<String, String>> {
-            let res = attrs.unwrap().call1(py, (node,))?;
-            res.extract(py)
-        };
+    let attr_callable = |node: &'a PyObject| -> PyResult<BTreeMap<String, String>> {
+        let res = attrs.unwrap().call1(py, (node,))?;
+        res.extract(py)
+    };
 
     let attrs = attr_callable(weight)?;
     if attrs.is_empty() {

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -62,9 +62,7 @@ where
 ///   mpl_draw(graph)
 ///
 #[pyfunction(bidirectional = "false", multigraph = "true")]
-#[pyo3(
-    text_signature = "(/, num_nodes=None, weights=None, bidirectional=False, multigraph=True)"
-)]
+#[pyo3(text_signature = "(/, num_nodes=None, weights=None, bidirectional=False, multigraph=True)")]
 pub fn directed_cycle_graph(
     py: Python,
     num_nodes: Option<usize>,
@@ -223,9 +221,7 @@ pub fn cycle_graph(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(bidirectional = "false", multigraph = "true")]
-#[pyo3(
-    text_signature = "(/, num_nodes=None, weights=None, bidirectional=False, multigraph=True)"
-)]
+#[pyo3(text_signature = "(/, num_nodes=None, weights=None, bidirectional=False, multigraph=True)")]
 pub fn directed_path_graph(
     py: Python,
     num_nodes: Option<usize>,
@@ -653,9 +649,7 @@ pub fn directed_mesh_graph(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(multigraph = true)]
-#[pyo3(
-    text_signature = "(/, rows=None, cols=None, weights=None, multigraph=True)"
-)]
+#[pyo3(text_signature = "(/, rows=None, cols=None, weights=None, multigraph=True)")]
 pub fn grid_graph(
     py: Python,
     rows: Option<usize>,
@@ -712,11 +706,7 @@ pub fn grid_graph(
                 );
             }
             if j + 1 < collen {
-                graph.add_edge(
-                    nodes[i * collen + j],
-                    nodes[i * collen + j + 1],
-                    py.None(),
-                );
+                graph.add_edge(nodes[i * collen + j], nodes[i * collen + j + 1], py.None());
             }
         }
     }
@@ -831,17 +821,9 @@ pub fn directed_grid_graph(
             }
 
             if j + 1 < collen {
-                graph.add_edge(
-                    nodes[i * collen + j],
-                    nodes[i * collen + j + 1],
-                    py.None(),
-                );
+                graph.add_edge(nodes[i * collen + j], nodes[i * collen + j + 1], py.None());
                 if bidirectional {
-                    graph.add_edge(
-                        nodes[i * collen + j + 1],
-                        nodes[i * collen + j],
-                        py.None(),
-                    );
+                    graph.add_edge(nodes[i * collen + j + 1], nodes[i * collen + j], py.None());
                 }
             }
         }
@@ -904,15 +886,12 @@ pub fn binomial_tree_graph(
     }
     let num_nodes = usize::pow(2, order);
     let num_edges = usize::pow(2, order) - 1;
-    let mut graph =
-        StablePyGraph::<Undirected>::with_capacity(num_nodes, num_edges);
+    let mut graph = StablePyGraph::<Undirected>::with_capacity(num_nodes, num_edges);
     for i in 0..num_nodes {
         match weights {
             Some(ref weights) => {
                 if weights.len() > num_nodes {
-                    return Err(PyIndexError::new_err(
-                        "weights should be <= 2**order",
-                    ));
+                    return Err(PyIndexError::new_err("weights should be <= 2**order"));
                 }
                 if i < weights.len() {
                     graph.add_node(weights[i].clone_ref(py))
@@ -975,9 +954,7 @@ pub fn binomial_tree_graph(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(multigraph = true)]
-#[pyo3(
-    text_signature = "(branching_factor, num_nodes, /, weights=None, multigraph=True)"
-)]
+#[pyo3(text_signature = "(branching_factor, num_nodes, /, weights=None, multigraph=True)")]
 pub fn full_rary_tree(
     py: Python,
     branching_factor: u32,
@@ -991,9 +968,7 @@ pub fn full_rary_tree(
         Some(weights) => {
             let mut node_list: Vec<NodeIndex> = Vec::with_capacity(num_nodes);
             if weights.len() > num_nodes {
-                return Err(PyIndexError::new_err(
-                    "weights can't be greater than nodes",
-                ));
+                return Err(PyIndexError::new_err("weights can't be greater than nodes"));
             }
             let node_count = num_nodes - weights.len();
             for weight in weights {
@@ -1064,9 +1039,7 @@ pub fn full_rary_tree(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(bidirectional = "false", multigraph = "true")]
-#[pyo3(
-    text_signature = "(order, /,  weights=None, bidirectional=False, multigraph=True)"
-)]
+#[pyo3(text_signature = "(order, /,  weights=None, bidirectional=False, multigraph=True)")]
 pub fn directed_binomial_tree_graph(
     py: Python,
     order: u32,
@@ -1082,16 +1055,13 @@ pub fn directed_binomial_tree_graph(
     }
     let num_nodes = usize::pow(2, order);
     let num_edges = usize::pow(2, order) - 1;
-    let mut graph =
-        StablePyGraph::<Directed>::with_capacity(num_nodes, num_edges);
+    let mut graph = StablePyGraph::<Directed>::with_capacity(num_nodes, num_edges);
 
     for i in 0..num_nodes {
         match weights {
             Some(ref weights) => {
                 if weights.len() > num_nodes {
-                    return Err(PyIndexError::new_err(
-                        "weights should be <= 2**order",
-                    ));
+                    return Err(PyIndexError::new_err("weights should be <= 2**order"));
                 }
                 if i < weights.len() {
                     graph.add_node(weights[i].clone_ref(py))
@@ -1120,9 +1090,7 @@ pub fn directed_binomial_tree_graph(
                 graph.add_edge(source_index, target_index, py.None());
             }
 
-            if bidirectional
-                && graph.find_edge(target_index, source_index).is_none()
-            {
+            if bidirectional && graph.find_edge(target_index, source_index).is_none() {
                 graph.add_edge(target_index, source_index, py.None());
             }
         }
@@ -1213,11 +1181,7 @@ pub fn directed_binomial_tree_graph(
 ///
 #[pyfunction(multigraph = true)]
 #[pyo3(text_signature = "(d, /, multigraph=True)")]
-pub fn heavy_square_graph(
-    py: Python,
-    d: usize,
-    multigraph: bool,
-) -> PyResult<graph::PyGraph> {
+pub fn heavy_square_graph(py: Python, d: usize, multigraph: bool) -> PyResult<graph::PyGraph> {
     let mut graph = StablePyGraph::<Undirected>::default();
 
     if d % 2 == 0 {
@@ -1237,13 +1201,11 @@ pub fn heavy_square_graph(
     let num_syndrome = d * (d - 1);
     let num_flag = d * (d - 1);
 
-    let nodes_data: Vec<NodeIndex> =
-        (0..num_data).map(|_| graph.add_node(py.None())).collect();
+    let nodes_data: Vec<NodeIndex> = (0..num_data).map(|_| graph.add_node(py.None())).collect();
     let nodes_syndrome: Vec<NodeIndex> = (0..num_syndrome)
         .map(|_| graph.add_node(py.None()))
         .collect();
-    let nodes_flag: Vec<NodeIndex> =
-        (0..num_flag).map(|_| graph.add_node(py.None())).collect();
+    let nodes_flag: Vec<NodeIndex> = (0..num_flag).map(|_| graph.add_node(py.None())).collect();
 
     // connect data and flags
     for (i, flag_chunk) in nodes_flag.chunks(d - 1).enumerate() {
@@ -1268,11 +1230,7 @@ pub fn heavy_square_graph(
             );
         } else if i % 2 == 1 {
             graph.add_edge(nodes_data[i * d], syndrome_chunk[0], py.None());
-            graph.add_edge(
-                syndrome_chunk[0],
-                nodes_data[(i + 1) * d],
-                py.None(),
-            );
+            graph.add_edge(syndrome_chunk[0], nodes_data[(i + 1) * d], py.None());
         }
     }
 
@@ -1281,31 +1239,15 @@ pub fn heavy_square_graph(
         if i % 2 == 0 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != syndrome_chunk.len() - 1 {
-                    graph.add_edge(
-                        nodes_flag[i * (d - 1) + j],
-                        *syndrome,
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + j],
-                        py.None(),
-                    );
+                    graph.add_edge(nodes_flag[i * (d - 1) + j], *syndrome, py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + j], py.None());
                 }
             }
         } else if i % 2 == 1 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != 0 {
-                    graph.add_edge(
-                        nodes_flag[i * (d - 1) + j - 1],
-                        *syndrome,
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + j - 1],
-                        py.None(),
-                    );
+                    graph.add_edge(nodes_flag[i * (d - 1) + j - 1], *syndrome, py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + j - 1], py.None());
                 }
             }
         }
@@ -1407,13 +1349,11 @@ pub fn directed_heavy_square_graph(
     let num_syndrome = d * (d - 1);
     let num_flag = d * (d - 1);
 
-    let nodes_data: Vec<NodeIndex> =
-        (0..num_data).map(|_| graph.add_node(py.None())).collect();
+    let nodes_data: Vec<NodeIndex> = (0..num_data).map(|_| graph.add_node(py.None())).collect();
     let nodes_syndrome: Vec<NodeIndex> = (0..num_syndrome)
         .map(|_| graph.add_node(py.None()))
         .collect();
-    let nodes_flag: Vec<NodeIndex> =
-        (0..num_flag).map(|_| graph.add_node(py.None())).collect();
+    let nodes_flag: Vec<NodeIndex> = (0..num_flag).map(|_| graph.add_node(py.None())).collect();
 
     // connect data and flags
     for (i, flag_chunk) in nodes_flag.chunks(d - 1).enumerate() {
@@ -1454,18 +1394,10 @@ pub fn directed_heavy_square_graph(
             }
         } else if i % 2 == 1 {
             graph.add_edge(nodes_data[i * d], syndrome_chunk[0], py.None());
-            graph.add_edge(
-                nodes_data[(i + 1) * d],
-                syndrome_chunk[0],
-                py.None(),
-            );
+            graph.add_edge(nodes_data[(i + 1) * d], syndrome_chunk[0], py.None());
             if bidirectional {
                 graph.add_edge(syndrome_chunk[0], nodes_data[i * d], py.None());
-                graph.add_edge(
-                    syndrome_chunk[0],
-                    nodes_data[(i + 1) * d],
-                    py.None(),
-                );
+                graph.add_edge(syndrome_chunk[0], nodes_data[(i + 1) * d], py.None());
             }
         }
     }
@@ -1475,54 +1407,22 @@ pub fn directed_heavy_square_graph(
         if i % 2 == 0 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != syndrome_chunk.len() - 1 {
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[i * (d - 1) + j],
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + j],
-                        py.None(),
-                    );
+                    graph.add_edge(*syndrome, nodes_flag[i * (d - 1) + j], py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + j], py.None());
                     if bidirectional {
-                        graph.add_edge(
-                            nodes_flag[i * (d - 1) + j],
-                            *syndrome,
-                            py.None(),
-                        );
-                        graph.add_edge(
-                            nodes_flag[(i + 1) * (d - 1) + j],
-                            *syndrome,
-                            py.None(),
-                        );
+                        graph.add_edge(nodes_flag[i * (d - 1) + j], *syndrome, py.None());
+                        graph.add_edge(nodes_flag[(i + 1) * (d - 1) + j], *syndrome, py.None());
                     }
                 }
             }
         } else if i % 2 == 1 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != 0 {
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[i * (d - 1) + j - 1],
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + j - 1],
-                        py.None(),
-                    );
+                    graph.add_edge(*syndrome, nodes_flag[i * (d - 1) + j - 1], py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + j - 1], py.None());
                     if bidirectional {
-                        graph.add_edge(
-                            nodes_flag[i * (d - 1) + j - 1],
-                            *syndrome,
-                            py.None(),
-                        );
-                        graph.add_edge(
-                            nodes_flag[(i + 1) * (d - 1) + j - 1],
-                            *syndrome,
-                            py.None(),
-                        );
+                        graph.add_edge(nodes_flag[i * (d - 1) + j - 1], *syndrome, py.None());
+                        graph.add_edge(nodes_flag[(i + 1) * (d - 1) + j - 1], *syndrome, py.None());
                     }
                 }
             }
@@ -1611,11 +1511,7 @@ pub fn directed_heavy_square_graph(
 ///
 #[pyfunction(multigraph = true)]
 #[pyo3(text_signature = "(d, /, multigraph=True)")]
-pub fn heavy_hex_graph(
-    py: Python,
-    d: usize,
-    multigraph: bool,
-) -> PyResult<graph::PyGraph> {
+pub fn heavy_hex_graph(py: Python, d: usize, multigraph: bool) -> PyResult<graph::PyGraph> {
     let mut graph = StablePyGraph::<Undirected>::default();
 
     if d % 2 == 0 {
@@ -1635,13 +1531,11 @@ pub fn heavy_hex_graph(
     let num_syndrome = (d - 1) * (d + 1) / 2;
     let num_flag = d * (d - 1);
 
-    let nodes_data: Vec<NodeIndex> =
-        (0..num_data).map(|_| graph.add_node(py.None())).collect();
+    let nodes_data: Vec<NodeIndex> = (0..num_data).map(|_| graph.add_node(py.None())).collect();
     let nodes_syndrome: Vec<NodeIndex> = (0..num_syndrome)
         .map(|_| graph.add_node(py.None()))
         .collect();
-    let nodes_flag: Vec<NodeIndex> =
-        (0..num_flag).map(|_| graph.add_node(py.None())).collect();
+    let nodes_flag: Vec<NodeIndex> = (0..num_flag).map(|_| graph.add_node(py.None())).collect();
 
     // connect data and flags
     for (i, flag_chunk) in nodes_flag.chunks(d - 1).enumerate() {
@@ -1655,11 +1549,7 @@ pub fn heavy_hex_graph(
     for (i, syndrome_chunk) in nodes_syndrome.chunks((d + 1) / 2).enumerate() {
         if i % 2 == 0 {
             graph.add_edge(nodes_data[i * d], syndrome_chunk[0], py.None());
-            graph.add_edge(
-                syndrome_chunk[0],
-                nodes_data[(i + 1) * d],
-                py.None(),
-            );
+            graph.add_edge(syndrome_chunk[0], nodes_data[(i + 1) * d], py.None());
         } else if i % 2 == 1 {
             graph.add_edge(
                 nodes_data[i * d + (d - 1)],
@@ -1694,16 +1584,8 @@ pub fn heavy_hex_graph(
         } else if i % 2 == 1 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != syndrome_chunk.len() - 1 {
-                    graph.add_edge(
-                        nodes_flag[i * (d - 1) + 2 * j],
-                        *syndrome,
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + 2 * j],
-                        py.None(),
-                    );
+                    graph.add_edge(nodes_flag[i * (d - 1) + 2 * j], *syndrome, py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + 2 * j], py.None());
                 }
             }
         }
@@ -1816,13 +1698,11 @@ pub fn directed_heavy_hex_graph(
     let num_syndrome = (d - 1) * (d + 1) / 2;
     let num_flag = d * (d - 1);
 
-    let nodes_data: Vec<NodeIndex> =
-        (0..num_data).map(|_| graph.add_node(py.None())).collect();
+    let nodes_data: Vec<NodeIndex> = (0..num_data).map(|_| graph.add_node(py.None())).collect();
     let nodes_syndrome: Vec<NodeIndex> = (0..num_syndrome)
         .map(|_| graph.add_node(py.None()))
         .collect();
-    let nodes_flag: Vec<NodeIndex> =
-        (0..num_flag).map(|_| graph.add_node(py.None())).collect();
+    let nodes_flag: Vec<NodeIndex> = (0..num_flag).map(|_| graph.add_node(py.None())).collect();
 
     // connect data and flags
     for (i, flag_chunk) in nodes_flag.chunks(d - 1).enumerate() {
@@ -1840,18 +1720,10 @@ pub fn directed_heavy_hex_graph(
     for (i, syndrome_chunk) in nodes_syndrome.chunks((d + 1) / 2).enumerate() {
         if i % 2 == 0 {
             graph.add_edge(nodes_data[i * d], syndrome_chunk[0], py.None());
-            graph.add_edge(
-                nodes_data[(i + 1) * d],
-                syndrome_chunk[0],
-                py.None(),
-            );
+            graph.add_edge(nodes_data[(i + 1) * d], syndrome_chunk[0], py.None());
             if bidirectional {
                 graph.add_edge(syndrome_chunk[0], nodes_data[i * d], py.None());
-                graph.add_edge(
-                    syndrome_chunk[0],
-                    nodes_data[(i + 1) * d],
-                    py.None(),
-                );
+                graph.add_edge(syndrome_chunk[0], nodes_data[(i + 1) * d], py.None());
             }
         } else if i % 2 == 1 {
             graph.add_edge(
@@ -1911,27 +1783,11 @@ pub fn directed_heavy_hex_graph(
         } else if i % 2 == 1 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != syndrome_chunk.len() - 1 {
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[i * (d - 1) + 2 * j],
-                        py.None(),
-                    );
-                    graph.add_edge(
-                        *syndrome,
-                        nodes_flag[(i + 1) * (d - 1) + 2 * j],
-                        py.None(),
-                    );
+                    graph.add_edge(*syndrome, nodes_flag[i * (d - 1) + 2 * j], py.None());
+                    graph.add_edge(*syndrome, nodes_flag[(i + 1) * (d - 1) + 2 * j], py.None());
                     if bidirectional {
-                        graph.add_edge(
-                            nodes_flag[i * (d - 1) + 2 * j],
-                            *syndrome,
-                            py.None(),
-                        );
-                        graph.add_edge(
-                            nodes_flag[(i + 1) * (d - 1) + 2 * j],
-                            *syndrome,
-                            py.None(),
-                        );
+                        graph.add_edge(nodes_flag[i * (d - 1) + 2 * j], *syndrome, py.None());
+                        graph.add_edge(nodes_flag[(i + 1) * (d - 1) + 2 * j], *syndrome, py.None());
                     }
                 }
             }
@@ -1996,8 +1852,7 @@ pub fn hexagonal_lattice_graph(
     collen += 1;
     let num_nodes = rowlen * collen - 2;
 
-    let nodes: Vec<NodeIndex> =
-        (0..num_nodes).map(|_| graph.add_node(py.None())).collect();
+    let nodes: Vec<NodeIndex> = (0..num_nodes).map(|_| graph.add_node(py.None())).collect();
 
     // Add column edges
     // first column
@@ -2007,11 +1862,7 @@ pub fn hexagonal_lattice_graph(
 
     for i in 1..(collen - 1) {
         for j in 0..(rowlen - 1) {
-            graph.add_edge(
-                nodes[i * rowlen + j - 1],
-                nodes[i * rowlen + j],
-                py.None(),
-            );
+            graph.add_edge(nodes[i * rowlen + j - 1], nodes[i * rowlen + j], py.None());
         }
     }
 
@@ -2085,9 +1936,7 @@ pub fn hexagonal_lattice_graph(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(bidirectional = "false", multigraph = "true")]
-#[pyo3(
-    text_signature = "(rows, cols, /, bidirectional=False, multigraph=True)"
-)]
+#[pyo3(text_signature = "(rows, cols, /, bidirectional=False, multigraph=True)")]
 pub fn directed_hexagonal_lattice_graph(
     py: Python,
     rows: usize,
@@ -2115,8 +1964,7 @@ pub fn directed_hexagonal_lattice_graph(
     collen += 1;
     let num_nodes = rowlen * collen - 2;
 
-    let nodes: Vec<NodeIndex> =
-        (0..num_nodes).map(|_| graph.add_node(py.None())).collect();
+    let nodes: Vec<NodeIndex> = (0..num_nodes).map(|_| graph.add_node(py.None())).collect();
 
     // Add column edges
     // first column
@@ -2129,17 +1977,9 @@ pub fn directed_hexagonal_lattice_graph(
 
     for i in 1..(collen - 1) {
         for j in 0..(rowlen - 1) {
-            graph.add_edge(
-                nodes[i * rowlen + j - 1],
-                nodes[i * rowlen + j],
-                py.None(),
-            );
+            graph.add_edge(nodes[i * rowlen + j - 1], nodes[i * rowlen + j], py.None());
             if bidirectional {
-                graph.add_edge(
-                    nodes[i * rowlen + j],
-                    nodes[i * rowlen + j - 1],
-                    py.None(),
-                );
+                graph.add_edge(nodes[i * rowlen + j], nodes[i * rowlen + j - 1], py.None());
             }
         }
     }
@@ -2362,11 +2202,9 @@ pub fn generalized_petersen_graph(
 
     let mut graph = StablePyGraph::<Undirected>::with_capacity(2 * n, 3 * n);
 
-    let star_nodes: Vec<NodeIndex> =
-        (0..n).map(|_| graph.add_node(py.None())).collect();
+    let star_nodes: Vec<NodeIndex> = (0..n).map(|_| graph.add_node(py.None())).collect();
 
-    let polygon_nodes: Vec<NodeIndex> =
-        (0..n).map(|_| graph.add_node(py.None())).collect();
+    let polygon_nodes: Vec<NodeIndex> = (0..n).map(|_| graph.add_node(py.None())).collect();
 
     for i in 0..n {
         graph.add_edge(star_nodes[i], star_nodes[(i + k) % n], py.None());
@@ -2419,9 +2257,7 @@ pub fn generalized_petersen_graph(
 ///   mpl_draw(graph)
 ///
 #[pyfunction(multigraph = true)]
-#[pyo3(
-    text_signature = "(/, num_mesh_nodes=None, num_path_nodes=None, multigraph=True)"
-)]
+#[pyo3(text_signature = "(/, num_mesh_nodes=None, num_path_nodes=None, multigraph=True)")]
 pub fn barbell_graph(
     py: Python,
     num_mesh_nodes: Option<usize>,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -35,20 +35,17 @@ use num_traits::Zero;
 use numpy::PyReadonlyArray2;
 
 use super::dot_utils::build_dot;
-use super::iterators::{
-    EdgeIndexMap, EdgeIndices, EdgeList, NodeIndices, WeightedEdgeList,
-};
+use super::iterators::{EdgeIndexMap, EdgeIndices, EdgeList, NodeIndices, WeightedEdgeList};
 use super::{
-    find_node_by_weight, merge_duplicates, weight_callable, IsNan,
-    NoEdgeBetweenNodes, NodesRemoved, StablePyGraph,
+    find_node_by_weight, merge_duplicates, weight_callable, IsNan, NoEdgeBetweenNodes,
+    NodesRemoved, StablePyGraph,
 };
 
 use petgraph::algo;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::*;
 use petgraph::visit::{
-    GraphBase, IntoEdgeReferences, IntoNodeReferences, NodeCount, NodeFiltered,
-    NodeIndexable,
+    GraphBase, IntoEdgeReferences, IntoNodeReferences, NodeCount, NodeFiltered, NodeIndexable,
 };
 
 /// A class for creating undirected graphs
@@ -158,8 +155,7 @@ impl PyGraph {
     fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         let out_dict = PyDict::new(py);
         let node_dict = PyDict::new(py);
-        let mut out_list: Vec<PyObject> =
-            Vec::with_capacity(self.graph.edge_count());
+        let mut out_list: Vec<PyObject> = Vec::with_capacity(self.graph.edge_count());
         out_dict.set_item("nodes", node_dict)?;
         out_dict.set_item("nodes_removed", self.node_removed)?;
         out_dict.set_item("multigraph", self.multigraph)?;
@@ -171,8 +167,7 @@ impl PyGraph {
             let edge_w = self.graph.edge_weight(edge);
             let endpoints = self.graph.edge_endpoints(edge).unwrap();
 
-            let triplet = (endpoints.0.index(), endpoints.1.index(), edge_w)
-                .to_object(py);
+            let triplet = (endpoints.0.index(), endpoints.1.index(), edge_w).to_object(py);
             out_list.push(triplet);
         }
         let py_out_list: PyObject = PyList::new(py, out_list).into();
@@ -183,10 +178,8 @@ impl PyGraph {
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         self.graph = StablePyGraph::<Undirected>::default();
         let dict_state = state.cast_as::<PyDict>(py)?;
-        let nodes_dict =
-            dict_state.get_item("nodes").unwrap().downcast::<PyDict>()?;
-        let edges_list =
-            dict_state.get_item("edges").unwrap().downcast::<PyList>()?;
+        let nodes_dict = dict_state.get_item("nodes").unwrap().downcast::<PyDict>()?;
+        let edges_list = dict_state.get_item("edges").unwrap().downcast::<PyList>()?;
         let nodes_removed_raw = dict_state
             .get_item("nodes_removed")
             .unwrap()
@@ -373,20 +366,12 @@ impl PyGraph {
     /// :raises NoEdgeBetweenNodes: when there is no edge between the provided
     ///     nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
-    pub fn get_edge_data(
-        &self,
-        node_a: usize,
-        node_b: usize,
-    ) -> PyResult<&PyObject> {
+    pub fn get_edge_data(&self, node_a: usize, node_b: usize) -> PyResult<&PyObject> {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
         let edge_index = match self.graph.find_edge(index_a, index_b) {
             Some(edge_index) => edge_index,
-            None => {
-                return Err(NoEdgeBetweenNodes::new_err(
-                    "No edge found between nodes",
-                ))
-            }
+            None => return Err(NoEdgeBetweenNodes::new_err("No edge found between nodes")),
         };
 
         let data = self.graph.edge_weight(edge_index).unwrap();
@@ -429,11 +414,7 @@ impl PyGraph {
     ///     tuple for a given edge index.
     /// :rtype: EdgeIndexMap
     #[pyo3(text_signature = "(self, node, /)")]
-    pub fn incident_edge_index_map(
-        &self,
-        py: Python,
-        node: usize,
-    ) -> EdgeIndexMap {
+    pub fn incident_edge_index_map(&self, py: Python, node: usize) -> EdgeIndexMap {
         let node_index = NodeIndex::new(node);
         EdgeIndexMap {
             edge_map: self
@@ -507,10 +488,7 @@ impl PyGraph {
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
-    pub fn get_edge_data_by_index(
-        &self,
-        edge_index: usize,
-    ) -> PyResult<&PyObject> {
+    pub fn get_edge_data_by_index(&self, edge_index: usize) -> PyResult<&PyObject> {
         let data = match self.graph.edge_weight(EdgeIndex::new(edge_index)) {
             Some(data) => data,
             None => {
@@ -532,20 +510,16 @@ impl PyGraph {
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
-    pub fn get_edge_endpoints_by_index(
-        &self,
-        edge_index: usize,
-    ) -> PyResult<(usize, usize)> {
-        let endpoints =
-            match self.graph.edge_endpoints(EdgeIndex::new(edge_index)) {
-                Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
-                None => {
-                    return Err(PyIndexError::new_err(format!(
-                        "Provided edge index {} is not present in the graph",
-                        edge_index
-                    )));
-                }
-            };
+    pub fn get_edge_endpoints_by_index(&self, edge_index: usize) -> PyResult<(usize, usize)> {
+        let endpoints = match self.graph.edge_endpoints(EdgeIndex::new(edge_index)) {
+            Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
+            None => {
+                return Err(PyIndexError::new_err(format!(
+                    "Provided edge index {} is not present in the graph",
+                    edge_index
+                )));
+            }
+        };
         Ok(endpoints)
     }
 
@@ -561,21 +535,12 @@ impl PyGraph {
     ///
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
     #[pyo3(text_signature = "(self, source, target, edge /)")]
-    pub fn update_edge(
-        &mut self,
-        source: usize,
-        target: usize,
-        edge: PyObject,
-    ) -> PyResult<()> {
+    pub fn update_edge(&mut self, source: usize, target: usize, edge: PyObject) -> PyResult<()> {
         let index_a = NodeIndex::new(source);
         let index_b = NodeIndex::new(target);
         let edge_index = match self.graph.find_edge(index_a, index_b) {
             Some(edge_index) => edge_index,
-            None => {
-                return Err(NoEdgeBetweenNodes::new_err(
-                    "No edge found between nodes",
-                ))
-            }
+            None => return Err(NoEdgeBetweenNodes::new_err("No edge found between nodes")),
         };
         let data = self.graph.edge_weight_mut(edge_index).unwrap();
         *data = edge;
@@ -590,16 +555,10 @@ impl PyGraph {
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, edge, /)")]
-    pub fn update_edge_by_index(
-        &mut self,
-        edge_index: usize,
-        edge: PyObject,
-    ) -> PyResult<()> {
+    pub fn update_edge_by_index(&mut self, edge_index: usize, edge: PyObject) -> PyResult<()> {
         match self.graph.edge_weight_mut(EdgeIndex::new(edge_index)) {
             Some(data) => *data = edge,
-            None => {
-                return Err(PyIndexError::new_err("No edge found for index"))
-            }
+            None => return Err(PyIndexError::new_err("No edge found for index")),
         };
         Ok(())
     }
@@ -615,9 +574,7 @@ impl PyGraph {
         let index = NodeIndex::new(node);
         let node = match self.graph.node_weight(index) {
             Some(node) => node,
-            None => {
-                return Err(PyIndexError::new_err("No node found for index"))
-            }
+            None => return Err(PyIndexError::new_err("No node found for index")),
         };
         Ok(node)
     }
@@ -631,11 +588,7 @@ impl PyGraph {
     /// :rtype: list
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
-    pub fn get_all_edge_data(
-        &self,
-        node_a: usize,
-        node_b: usize,
-    ) -> PyResult<Vec<&PyObject>> {
+    pub fn get_all_edge_data(&self, node_a: usize, node_b: usize) -> PyResult<Vec<&PyObject>> {
         let index_a = NodeIndex::new(node_a);
         let index_b = NodeIndex::new(node_b);
         let out: Vec<&PyObject> = self
@@ -750,12 +703,7 @@ impl PyGraph {
     ///     of an existing edge with ``multigraph=False``) edge.
     /// :rtype: int
     #[pyo3(text_signature = "(self, node_a, node_b, edge, /)")]
-    pub fn add_edge(
-        &mut self,
-        node_a: usize,
-        node_b: usize,
-        edge: PyObject,
-    ) -> PyResult<usize> {
+    pub fn add_edge(&mut self, node_a: usize, node_b: usize, edge: PyObject) -> PyResult<usize> {
         let p_index = NodeIndex::new(node_a);
         let c_index = NodeIndex::new(node_b);
         if !self.multigraph {
@@ -797,8 +745,7 @@ impl PyGraph {
             if !self.multigraph {
                 let exists = self.graph.find_edge(p_index, c_index);
                 if let Some(index) = exists {
-                    let edge_weight =
-                        self.graph.edge_weight_mut(index).unwrap();
+                    let edge_weight = self.graph.edge_weight_mut(index).unwrap();
                     *edge_weight = obj.2;
                     out_list.push(index.index());
                     continue;
@@ -837,8 +784,7 @@ impl PyGraph {
             if !self.multigraph {
                 let exists = self.graph.find_edge(p_index, c_index);
                 if let Some(index) = exists {
-                    let edge_weight =
-                        self.graph.edge_weight_mut(index).unwrap();
+                    let edge_weight = self.graph.edge_weight_mut(index).unwrap();
                     *edge_weight = py.None();
                     out_list.push(index.index());
                     continue;
@@ -864,11 +810,7 @@ impl PyGraph {
     ///     is not present in the graph, nodes will be added (with a node
     ///     weight of ``None``) to that index.
     #[pyo3(text_signature = "(self, edge_list, /)")]
-    pub fn extend_from_edge_list(
-        &mut self,
-        py: Python,
-        edge_list: Vec<(usize, usize)>,
-    ) {
+    pub fn extend_from_edge_list(&mut self, py: Python, edge_list: Vec<(usize, usize)>) {
         for (source, target) in edge_list {
             let max_index = cmp::max(source, target);
             while max_index >= self.node_count() {
@@ -879,8 +821,7 @@ impl PyGraph {
             if !self.multigraph {
                 let exists = self.graph.find_edge(source_index, target_index);
                 if let Some(index) = exists {
-                    let edge_weight =
-                        self.graph.edge_weight_mut(index).unwrap();
+                    let edge_weight = self.graph.edge_weight_mut(index).unwrap();
                     *edge_weight = py.None();
                     continue;
                 }
@@ -920,8 +861,7 @@ impl PyGraph {
             if !self.multigraph {
                 let exists = self.graph.find_edge(source_index, target_index);
                 if let Some(index) = exists {
-                    let edge_weight =
-                        self.graph.edge_weight_mut(index).unwrap();
+                    let edge_weight = self.graph.edge_weight_mut(index).unwrap();
                     *edge_weight = weight;
                     continue;
                 }
@@ -941,20 +881,12 @@ impl PyGraph {
     /// :raises NoEdgeBetweenNodes: If there are no edges between the nodes
     ///     specified
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
-    pub fn remove_edge(
-        &mut self,
-        node_a: usize,
-        node_b: usize,
-    ) -> PyResult<()> {
+    pub fn remove_edge(&mut self, node_a: usize, node_b: usize) -> PyResult<()> {
         let p_index = NodeIndex::new(node_a);
         let c_index = NodeIndex::new(node_b);
         let edge_index = match self.graph.find_edge(p_index, c_index) {
             Some(edge_index) => edge_index,
-            None => {
-                return Err(NoEdgeBetweenNodes::new_err(
-                    "No edge found between nodes",
-                ))
-            }
+            None => return Err(NoEdgeBetweenNodes::new_err("No edge found between nodes")),
         };
         self.graph.remove_edge(edge_index);
         Ok(())
@@ -981,21 +913,14 @@ impl PyGraph {
     /// :raises NoEdgeBetweenNodes: If there are no edges between a specified
     ///     pair of nodes.
     #[pyo3(text_signature = "(self, index_list, /)")]
-    pub fn remove_edges_from(
-        &mut self,
-        index_list: Vec<(usize, usize)>,
-    ) -> PyResult<()> {
+    pub fn remove_edges_from(&mut self, index_list: Vec<(usize, usize)>) -> PyResult<()> {
         for (p_index, c_index) in index_list
             .iter()
             .map(|(x, y)| (NodeIndex::new(*x), NodeIndex::new(*y)))
         {
             let edge_index = match self.graph.find_edge(p_index, c_index) {
                 Some(edge_index) => edge_index,
-                None => {
-                    return Err(NoEdgeBetweenNodes::new_err(
-                        "No edge found between nodes",
-                    ))
-                }
+                None => return Err(NoEdgeBetweenNodes::new_err("No edge found between nodes")),
             };
             self.graph.remove_edge(edge_index);
         }
@@ -1037,10 +962,7 @@ impl PyGraph {
     /// :param list index_list: A list of node indicies to remove from the
     ///     the graph
     #[pyo3(text_signature = "(self, index_list, /)")]
-    pub fn remove_nodes_from(
-        &mut self,
-        index_list: Vec<usize>,
-    ) -> PyResult<()> {
+    pub fn remove_nodes_from(&mut self, index_list: Vec<usize>) -> PyResult<()> {
         for node in index_list.iter().map(|x| NodeIndex::new(*x)) {
             self.graph.remove_node(node);
         }
@@ -1059,13 +981,8 @@ impl PyGraph {
     ///     weight. If no match is found ``None`` will be returned.
     /// :rtype: int
     #[pyo3(text_signature = "(self, obj, /)")]
-    pub fn find_node_by_weight(
-        &self,
-        py: Python,
-        obj: PyObject,
-    ) -> PyResult<Option<usize>> {
-        find_node_by_weight(py, &self.graph, &obj)
-            .map(|node| node.map(|x| x.index()))
+    pub fn find_node_by_weight(&self, py: Python, obj: PyObject) -> PyResult<Option<usize>> {
+        find_node_by_weight(py, &self.graph, &obj).map(|node| node.map(|x| x.index()))
     }
 
     /// Get the index and data for the neighbors of a node.
@@ -1149,12 +1066,9 @@ impl PyGraph {
     #[pyo3(text_signature = "(self)")]
     pub fn to_directed(&self, py: Python) -> crate::digraph::PyDiGraph {
         let node_count = self.node_count();
-        let mut new_graph = StablePyGraph::<Directed>::with_capacity(
-            node_count,
-            2 * self.graph.edge_count(),
-        );
-        let mut node_map: HashMap<NodeIndex, NodeIndex> =
-            HashMap::with_capacity(node_count);
+        let mut new_graph =
+            StablePyGraph::<Directed>::with_capacity(node_count, 2 * self.graph.edge_count());
+        let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::with_capacity(node_count);
         for node_index in self.graph.node_indices() {
             let node = self.graph[node_index].clone_ref(py);
             let new_index = new_graph.add_node(node);
@@ -1242,26 +1156,12 @@ impl PyGraph {
         match filename {
             Some(filename) => {
                 let mut file = File::create(filename)?;
-                build_dot(
-                    py,
-                    &self.graph,
-                    &mut file,
-                    graph_attr,
-                    node_attr,
-                    edge_attr,
-                )?;
+                build_dot(py, &self.graph, &mut file, graph_attr, node_attr, edge_attr)?;
                 Ok(None)
             }
             None => {
                 let mut file = Vec::<u8>::new();
-                build_dot(
-                    py,
-                    &self.graph,
-                    &mut file,
-                    graph_attr,
-                    node_attr,
-                    edge_attr,
-                )?;
+                build_dot(py, &self.graph, &mut file, graph_attr, node_attr, edge_attr)?;
                 Ok(Some(
                     PyString::new(py, str::from_utf8(&file)?).to_object(py),
                 ))
@@ -1307,9 +1207,7 @@ impl PyGraph {
     ///
     #[staticmethod]
     #[args(labels = "false")]
-    #[pyo3(
-        text_signature = "(path, /, comment=None, deliminator=None, labels=False)"
-    )]
+    #[pyo3(text_signature = "(path, /, comment=None, deliminator=None, labels=False)")]
     pub fn read_edge_list(
         py: Python,
         path: &str,
@@ -1351,8 +1249,7 @@ impl PyGraph {
                 src = match label_map.get(src_str) {
                     Some(index) => *index,
                     None => {
-                        let index =
-                            out_graph.add_node(src_str.to_object(py)).index();
+                        let index = out_graph.add_node(src_str.to_object(py)).index();
                         label_map.insert(src_str.to_string(), index);
                         index
                     }
@@ -1360,9 +1257,7 @@ impl PyGraph {
                 target = match label_map.get(target_str) {
                     Some(index) => *index,
                     None => {
-                        let index = out_graph
-                            .add_node(target_str.to_object(py))
-                            .index();
+                        let index = out_graph.add_node(target_str.to_object(py)).index();
                         label_map.insert(target_str.to_string(), index);
                         index
                     }
@@ -1386,11 +1281,7 @@ impl PyGraph {
             } else {
                 py.None()
             };
-            out_graph.add_edge(
-                NodeIndex::new(src),
-                NodeIndex::new(target),
-                weight,
-            );
+            out_graph.add_edge(NodeIndex::new(src), NodeIndex::new(target), weight);
         }
         Ok(PyGraph {
             graph: out_graph,
@@ -1426,9 +1317,7 @@ impl PyGraph {
     ///     with open(path, 'rt') as edge_file:
     ///         print(edge_file.read())
     ///
-    #[pyo3(
-        text_signature = "(self, path, /, deliminator=None, weight_fn=None)"
-    )]
+    #[pyo3(text_signature = "(self, path, /, deliminator=None, weight_fn=None)")]
     pub fn write_edge_list(
         &self,
         py: Python,
@@ -1453,14 +1342,8 @@ impl PyGraph {
                 )
                 .as_bytes(),
             )?;
-            match weight_callable(
-                py,
-                &weight_fn,
-                edge.weight(),
-                None as Option<String>,
-            )? {
-                Some(weight) => buf_writer
-                    .write_all(format!("{}{}\n", delim, weight).as_bytes()),
+            match weight_callable(py, &weight_fn, edge.weight(), None as Option<String>)? {
+                Some(weight) => buf_writer.write_all(format!("{}{}\n", delim, weight).as_bytes()),
                 None => buf_writer.write_all(b"\n"),
             }?;
         }
@@ -1609,9 +1492,7 @@ impl PyGraph {
     ///   graph.compose(other_graph, node_map)
     ///   mpl_draw(graph, with_labels=True, labels=str, edge_labels=str)
     ///
-    #[pyo3(
-        text_signature = "(self, other, node_map, /, node_map_func=None, edge_map_func=None)"
-    )]
+    #[pyo3(text_signature = "(self, other, node_map, /, node_map_func=None, edge_map_func=None)")]
     pub fn compose(
         &mut self,
         py: Python,
@@ -1638,8 +1519,7 @@ impl PyGraph {
         for edge in other.graph.edge_references() {
             let new_p_index = new_node_map.get(&edge.source()).unwrap();
             let new_c_index = new_node_map.get(&edge.target()).unwrap();
-            let weight =
-                weight_transform_callable(py, &edge_map_func, edge.weight())?;
+            let weight = weight_transform_callable(py, &edge_map_func, edge.weight())?;
             self.graph.add_edge(*new_p_index, *new_c_index, weight);
         }
         // Add edges from map
@@ -1723,8 +1603,7 @@ impl PyGraph {
         // to that function, even if this is a multigraph. If unspecified,
         // defer parallel edge handling to `add_edge`.
         if let Some(merge_fn) = weight_combo_fn {
-            edges =
-                merge_duplicates(edges, |w1, w2| merge_fn.call1(py, (w1, w2)))?;
+            edges = merge_duplicates(edges, |w1, w2| merge_fn.call1(py, (w1, w2)))?;
         }
 
         for (source, weight) in edges {
@@ -1750,10 +1629,8 @@ impl PyGraph {
     #[pyo3(text_signature = "(self, nodes, /)")]
     pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
-        let mut node_map: HashMap<NodeIndex, NodeIndex> =
-            HashMap::with_capacity(nodes.len());
-        let node_filter =
-            |node: NodeIndex| -> bool { node_set.contains(&node.index()) };
+        let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::with_capacity(nodes.len());
+        let node_filter = |node: NodeIndex| -> bool { node_set.contains(&node.index()) };
         let mut out_graph = StablePyGraph::<Undirected>::default();
         let filtered = NodeFiltered(&self.graph, node_filter);
         for node in filtered.node_references() {
@@ -1763,11 +1640,7 @@ impl PyGraph {
         for edge in filtered.edge_references() {
             let new_source = *node_map.get(&edge.source()).unwrap();
             let new_target = *node_map.get(&edge.target()).unwrap();
-            out_graph.add_edge(
-                new_source,
-                new_target,
-                edge.weight().clone_ref(py),
-            );
+            out_graph.add_edge(new_source, new_target, edge.weight().clone_ref(py));
         }
         PyGraph {
             graph: out_graph,
@@ -1808,8 +1681,7 @@ impl PyGraph {
             .copied()
             .map(NodeIndex::new)
             .collect();
-        let mut edge_set: HashSet<[NodeIndex; 2]> =
-            HashSet::with_capacity(edges.len());
+        let mut edge_set: HashSet<[NodeIndex; 2]> = HashSet::with_capacity(edges.len());
         for edge in edges {
             let source_index = NodeIndex::new(edge[0]);
             let target_index = NodeIndex::new(edge[1]);
@@ -1859,9 +1731,7 @@ impl PyMappingProtocol for PyGraph {
     fn __setitem__(&'p mut self, idx: usize, value: PyObject) -> PyResult<()> {
         let data = match self.graph.node_weight_mut(NodeIndex::new(idx)) {
             Some(node_data) => node_data,
-            None => {
-                return Err(PyIndexError::new_err("No node found for index"))
-            }
+            None => return Err(PyIndexError::new_err("No node found for index")),
         };
         *data = value;
         Ok(())

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -126,12 +126,9 @@ where
     ) -> (StablePyGraph<Ty>, HashMap<usize, usize>) {
         let order = self.sort(graph);
 
-        let mut new_graph = StablePyGraph::<Ty>::with_capacity(
-            graph.node_count(),
-            graph.edge_count(),
-        );
-        let mut id_map: HashMap<NodeIndex, NodeIndex> =
-            HashMap::with_capacity(graph.node_count());
+        let mut new_graph =
+            StablePyGraph::<Ty>::with_capacity(graph.node_count(), graph.edge_count());
+        let mut id_map: HashMap<NodeIndex, NodeIndex> = HashMap::with_capacity(graph.node_count());
         for node_index in order {
             let node_data = graph.node_weight(node_index).unwrap();
             let new_index = new_graph.add_node(node_data.clone_ref(py));
@@ -217,16 +214,12 @@ where
                 vd.swap(i, i + index);
                 order.push(NodeIndex::new(item));
 
-                for neigh in
-                    graph.neighbors_directed(graph.from_index(item), Outgoing)
-                {
+                for neigh in graph.neighbors_directed(graph.from_index(item), Outgoing) {
                     conn_in[graph.to_index(neigh)] += 1;
                 }
 
                 if graph.is_directed() {
-                    for neigh in graph
-                        .neighbors_directed(graph.from_index(item), Incoming)
-                    {
+                    for neigh in graph.neighbors_directed(graph.from_index(item), Incoming) {
                         conn_out[graph.to_index(neigh)] += 1;
                     }
                 }
@@ -252,10 +245,7 @@ where
 
                 next_level = Vec::new();
                 for bfs_node in this_level {
-                    for neighbor in graph.neighbors_directed(
-                        graph.from_index(bfs_node),
-                        Outgoing,
-                    ) {
+                    for neighbor in graph.neighbors_directed(graph.from_index(bfs_node), Outgoing) {
                         let neigh = graph.to_index(neighbor);
                         if !seen[neigh] {
                             seen[neigh] = true;
@@ -266,10 +256,8 @@ where
             }
         };
 
-        let mut sorted_nodes: Vec<usize> =
-            graph.node_indices().map(|node| node.index()).collect();
-        sorted_nodes
-            .par_sort_by_key(|&node| (dout[node], din[node], Reverse(node)));
+        let mut sorted_nodes: Vec<usize> = graph.node_indices().map(|node| node.index()).collect();
+        sorted_nodes.par_sort_by_key(|&node| (dout[node], din[node], Reverse(node)));
         sorted_nodes.reverse();
 
         for node in sorted_nodes {
@@ -453,8 +441,7 @@ pub fn is_isomorphic<Ty: EdgeType>(
     }
 
     let mut vf2 = Vf2Algorithm::new(
-        py, g0, g1, node_match, edge_match, id_order, ordering, induced,
-        call_limit,
+        py, g0, g1, node_match, edge_match, id_order, ordering, induced, call_limit,
     );
     if vf2.next(py)?.is_some() {
         return Ok(true);
@@ -545,18 +532,13 @@ where
             .iter()
             .enumerate()
             .for_each(|(index, val)| {
-                mapping.insert(
-                    self.node_map_g0[&val.index()],
-                    self.node_map_g1[&index],
-                );
+                mapping.insert(self.node_map_g0[&val.index()], self.node_map_g1[&index]);
             });
 
         NodeMap { node_map: mapping }
     }
 
-    fn next_candidate(
-        st: &mut [Vf2State<Ty>; 2],
-    ) -> Option<(NodeIndex, NodeIndex, OpenList)> {
+    fn next_candidate(st: &mut [Vf2State<Ty>; 2]) -> Option<(NodeIndex, NodeIndex, OpenList)> {
         // Try the out list
         let mut to_index = st[1].next_out_index(0);
         let mut from_index = None;
@@ -584,9 +566,7 @@ where
             }
         }
         match (from_index, to_index) {
-            (Some(n), Some(m)) => {
-                Some((NodeIndex::new(n), NodeIndex::new(m), open_list))
-            }
+            (Some(n), Some(m)) => Some((NodeIndex::new(n), NodeIndex::new(m), open_list)),
             // No more candidates
             _ => None,
         }
@@ -668,12 +648,8 @@ where
                 if m_neigh == end {
                     continue;
                 }
-                let val = edge_multiplicity(
-                    &st[j].graph,
-                    &st[j].adjacency_matrix,
-                    nodes[j],
-                    n_neigh,
-                );
+                let val =
+                    edge_multiplicity(&st[j].graph, &st[j].adjacency_matrix, nodes[j], n_neigh);
 
                 let has_edge = is_adjacent(
                     &st[1 - j].graph,
@@ -694,9 +670,7 @@ where
         if st[0].graph.is_directed() {
             let mut pred_count = [0, 0];
             for j in 0..2 {
-                for n_neigh in
-                    st[j].graph.neighbors_directed(nodes[j], Incoming)
-                {
+                for n_neigh in st[j].graph.neighbors_directed(nodes[j], Incoming) {
                     pred_count[j] += 1;
                     if !induced && j == 0 {
                         continue;
@@ -706,12 +680,8 @@ where
                     if m_neigh == end {
                         continue;
                     }
-                    let val = edge_multiplicity(
-                        &st[j].graph,
-                        &st[j].adjacency_matrix,
-                        n_neigh,
-                        nodes[j],
-                    );
+                    let val =
+                        edge_multiplicity(&st[j].graph, &st[j].adjacency_matrix, n_neigh, nodes[j]);
 
                     let has_edge = is_adjacent(
                         &st[1 - j].graph,
@@ -732,8 +702,7 @@ where
         macro_rules! rule {
             ($arr:ident, $j:expr, $dir:expr) => {{
                 let mut count = 0;
-                for n_neigh in st[$j].graph.neighbors_directed(nodes[$j], $dir)
-                {
+                for n_neigh in st[$j].graph.neighbors_directed(nodes[$j], $dir) {
                     let index = n_neigh.index();
                     if st[$j].$arr[index] > 0 && st[$j].mapping[index] == end {
                         count += 1;
@@ -782,9 +751,7 @@ where
             for j in 0..2 {
                 for n_neigh in st[j].graph.neighbors(nodes[j]) {
                     let index = n_neigh.index();
-                    if st[j].out[index] == 0
-                        && (st[j].ins.is_empty() || st[j].ins[index] == 0)
-                    {
+                    if st[j].out[index] == 0 && (st[j].ins.is_empty() || st[j].ins[index] == 0) {
                         new_count[j] += 1;
                     }
                 }
@@ -795,9 +762,7 @@ where
             if st[0].graph.is_directed() {
                 let mut new_count = [0, 0];
                 for j in 0..2 {
-                    for n_neigh in
-                        st[j].graph.neighbors_directed(nodes[j], Incoming)
-                    {
+                    for n_neigh in st[j].graph.neighbors_directed(nodes[j], Incoming) {
                         let index = n_neigh.index();
                         if st[j].out[index] == 0 && st[j].ins[index] == 0 {
                             new_count[j] += 1;
@@ -811,26 +776,21 @@ where
         }
         // semantic feasibility: compare associated data for nodes
         if node_match.enabled()
-            && !node_match.eq(
-                py,
-                &st[0].graph[nodes[0]],
-                &st[1].graph[nodes[1]],
-            )?
+            && !node_match.eq(py, &st[0].graph[nodes[0]], &st[1].graph[nodes[1]])?
         {
             return Ok(false);
         }
         // semantic feasibility: compare associated data for edges
         if edge_match.enabled() {
-            let matcher = |a: (NodeIndex, &PyObject),
-                           b: (NodeIndex, &PyObject)|
-             -> PyResult<bool> {
-                let (nx, n_edge) = a;
-                let (mx, m_edge) = b;
-                if nx == mx && edge_match.eq(py, n_edge, m_edge)? {
-                    return Ok(true);
-                }
-                Ok(false)
-            };
+            let matcher =
+                |a: (NodeIndex, &PyObject), b: (NodeIndex, &PyObject)| -> PyResult<bool> {
+                    let (nx, n_edge) = a;
+                    let (mx, m_edge) = b;
+                    if nx == mx && edge_match.eq(py, n_edge, m_edge)? {
+                        return Ok(true);
+                    }
+                    Ok(false)
+                };
 
             // outgoing edges
             let range = if induced { 0..2 } else { 1..2 };
@@ -929,11 +889,7 @@ where
                 } => {
                     Vf2Algorithm::<Ty, F, G>::pop_state(&mut self.st, nodes);
 
-                    match Vf2Algorithm::<Ty, F, G>::next_from_ix(
-                        &mut self.st,
-                        nodes[0],
-                        ol,
-                    ) {
+                    match Vf2Algorithm::<Ty, F, G>::next_from_ix(&mut self.st, nodes[0], ol) {
                         None => continue,
                         Some(nx) => {
                             let f = Frame::Inner {
@@ -944,24 +900,21 @@ where
                         }
                     }
                 }
-                Frame::Outer => {
-                    match Vf2Algorithm::<Ty, F, G>::next_candidate(&mut self.st)
-                    {
-                        None => {
-                            if self.st[1].is_complete() {
-                                return Ok(Some(self.mapping()));
-                            }
-                            continue;
+                Frame::Outer => match Vf2Algorithm::<Ty, F, G>::next_candidate(&mut self.st) {
+                    None => {
+                        if self.st[1].is_complete() {
+                            return Ok(Some(self.mapping()));
                         }
-                        Some((nx, mx, ol)) => {
-                            let f = Frame::Inner {
-                                nodes: [nx, mx],
-                                open_list: ol,
-                            };
-                            self.stack.push(f);
-                        }
+                        continue;
                     }
-                }
+                    Some((nx, mx, ol)) => {
+                        let f = Frame::Inner {
+                            nodes: [nx, mx],
+                            open_list: ol,
+                        };
+                        self.stack.push(f);
+                    }
+                },
                 Frame::Inner {
                     nodes,
                     open_list: ol,
@@ -975,10 +928,7 @@ where
                         self.ordering,
                         self.induced,
                     )? {
-                        Vf2Algorithm::<Ty, F, G>::push_state(
-                            &mut self.st,
-                            nodes,
-                        );
+                        Vf2Algorithm::<Ty, F, G>::push_state(&mut self.st, nodes);
                         // Check cardinalities of Tin, Tout sets
                         if self.st[0]
                             .out_size
@@ -1006,16 +956,9 @@ where
                             self.stack.push(Frame::Outer);
                             continue;
                         }
-                        Vf2Algorithm::<Ty, F, G>::pop_state(
-                            &mut self.st,
-                            nodes,
-                        );
+                        Vf2Algorithm::<Ty, F, G>::pop_state(&mut self.st, nodes);
                     }
-                    match Vf2Algorithm::<Ty, F, G>::next_from_ix(
-                        &mut self.st,
-                        nodes[0],
-                        ol,
-                    ) {
+                    match Vf2Algorithm::<Ty, F, G>::next_from_ix(&mut self.st, nodes[0], ol) {
                         None => continue,
                         Some(nx) => {
                             let f = Frame::Inner {
@@ -1052,8 +995,7 @@ macro_rules! vf2_mapping_impl {
                 call_limit: Option<usize>,
             ) -> Self {
                 let vf2 = Vf2Algorithm::new(
-                    py, g0, g1, node_match, edge_match, id_order, ordering,
-                    induced, call_limit,
+                    py, g0, g1, node_match, edge_match, id_order, ordering, induced, call_limit,
                 );
                 $name { vf2 }
             }
@@ -1077,10 +1019,7 @@ macro_rules! vf2_mapping_impl {
 
         #[pyproto]
         impl PyGCProtocol for $name {
-            fn __traverse__(
-                &self,
-                visit: PyVisit,
-            ) -> Result<(), PyTraverseError> {
+            fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
                 for j in 0..2 {
                     for node in self.vf2.st[j].graph.node_weights() {
                         visit.call(node)?;

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -477,23 +477,17 @@ macro_rules! custom_vec_iter_impl {
                         Ok(res) => Ok(!res),
                         Err(err) => Err(err),
                     },
-                    _ => Err(PyNotImplementedError::new_err(
-                        "Comparison not implemented",
-                    )),
+                    _ => Err(PyNotImplementedError::new_err("Comparison not implemented")),
                 }
             }
 
             fn __str__(&self) -> PyResult<String> {
-                Python::with_gil(|py| {
-                    Ok(format!("{}{}", stringify!($name), self.$data.str(py)?))
-                })
+                Python::with_gil(|py| Ok(format!("{}{}", stringify!($name), self.$data.str(py)?)))
             }
 
             fn __hash__(&self) -> PyResult<u64> {
                 let mut hasher = DefaultHasher::new();
-                Python::with_gil(|py| {
-                    PyHash::hash(&self.$data, py, &mut hasher)
-                })?;
+                Python::with_gil(|py| PyHash::hash(&self.$data, py, &mut hasher))?;
 
                 Ok(hasher.finish())
             }
@@ -507,10 +501,7 @@ macro_rules! custom_vec_iter_impl {
 
             fn __getitem__(&'p self, idx: isize) -> PyResult<$T> {
                 if idx >= self.$data.len().try_into().unwrap() {
-                    Err(PyIndexError::new_err(format!(
-                        "Invalid index, {}",
-                        idx
-                    )))
+                    Err(PyIndexError::new_err(format!("Invalid index, {}", idx)))
                 } else {
                     Ok(self.$data[idx as usize].clone())
                 }
@@ -781,11 +772,7 @@ macro_rules! py_object_protocol_impl {
     ($name:ident, $data:ident) => {
         #[pyproto]
         impl<'p> PyObjectProtocol<'p> for $name {
-            fn __richcmp__(
-                &self,
-                other: PyObject,
-                op: pyo3::basic::CompareOp,
-            ) -> PyResult<bool> {
+            fn __richcmp__(&self, other: PyObject, op: pyo3::basic::CompareOp) -> PyResult<bool> {
                 let compare = |other: PyObject| -> PyResult<bool> {
                     Python::with_gil(|py| PyEq::eq(&self.$data, &other, py))
                 };
@@ -795,23 +782,17 @@ macro_rules! py_object_protocol_impl {
                         Ok(res) => Ok(!res),
                         Err(err) => Err(err),
                     },
-                    _ => Err(PyNotImplementedError::new_err(
-                        "Comparison not implemented",
-                    )),
+                    _ => Err(PyNotImplementedError::new_err("Comparison not implemented")),
                 }
             }
 
             fn __str__(&self) -> PyResult<String> {
-                Python::with_gil(|py| {
-                    Ok(format!("{}{}", stringify!($name), self.$data.str(py)?))
-                })
+                Python::with_gil(|py| Ok(format!("{}{}", stringify!($name), self.$data.str(py)?)))
             }
 
             fn __hash__(&self) -> PyResult<u64> {
                 let mut hasher = DefaultHasher::new();
-                Python::with_gil(|py| {
-                    PyHash::hash(&self.$data, py, &mut hasher)
-                })?;
+                Python::with_gil(|py| PyHash::hash(&self.$data, py, &mut hasher))?;
 
                 Ok(hasher.finish())
             }
@@ -832,12 +813,9 @@ macro_rules! py_iter_protocol_impl {
             fn __iter__(slf: PyRef<Self>) -> Py<$name> {
                 slf.into()
             }
-            fn __next__(
-                mut slf: PyRefMut<Self>,
-            ) -> IterNextOutput<$T, &'static str> {
+            fn __next__(mut slf: PyRefMut<Self>) -> IterNextOutput<$T, &'static str> {
                 if slf.iter_pos < slf.$data.len() {
-                    let res =
-                        IterNextOutput::Yield(slf.$data[slf.iter_pos].clone());
+                    let res = IterNextOutput::Yield(slf.$data[slf.iter_pos].clone());
                     slf.iter_pos += 1;
                     res
                 } else {
@@ -924,9 +902,7 @@ macro_rules! custom_hash_map_iter_impl {
             fn __getitem__(&'p self, key: $K) -> PyResult<$V> {
                 match self.$data.get(&key) {
                     Some(data) => Ok(data.clone()),
-                    None => {
-                        Err(PyIndexError::new_err("No node found for index"))
-                    }
+                    None => Err(PyIndexError::new_err("No node found for index")),
                 }
             }
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -355,9 +355,7 @@ pub fn digraph_circular_layout(
 /// :returns: The shell layout of the graph.
 /// :rtype: Pos2DMapping
 #[pyfunction]
-#[pyo3(
-    text_signature = "(graph, /, nlist=None, rotate=None, scale=1, center=None)"
-)]
+#[pyo3(text_signature = "(graph, /, nlist=None, rotate=None, scale=1, center=None)")]
 pub fn graph_shell_layout(
     graph: &graph::PyGraph,
     nlist: Option<Vec<Vec<usize>>>,
@@ -381,9 +379,7 @@ pub fn graph_shell_layout(
 /// :returns: The shell layout of the graph.
 /// :rtype: Pos2DMapping
 #[pyfunction]
-#[pyo3(
-    text_signature = "(graph, /, nlist=None, rotate=None, scale=1, center=None)"
-)]
+#[pyo3(text_signature = "(graph, /, nlist=None, rotate=None, scale=1, center=None)")]
 pub fn digraph_shell_layout(
     graph: &digraph::PyDiGraph,
     nlist: Option<Vec<Vec<usize>>>,

--- a/src/layout/random.rs
+++ b/src/layout/random.rs
@@ -36,10 +36,7 @@ pub fn random_layout<Ty: EdgeType>(
                 match center {
                     Some(center) => (
                         n.index(),
-                        [
-                            random_tuple[0] + center[0],
-                            random_tuple[1] + center[1],
-                        ],
+                        [random_tuple[0] + center[0], random_tuple[1] + center[1]],
                     ),
                     None => (n.index(), random_tuple),
                 }

--- a/src/layout/spring.rs
+++ b/src/layout/spring.rs
@@ -251,11 +251,10 @@ where
             let fa = f_a.total(&pos[v], ys);
 
             // repulsive forces
-            let ys =
-                graph.node_indices().filter(|&n| n.index() != v).map(|n| {
-                    let n = n.index();
-                    (&pos[n], 1.0)
-                });
+            let ys = graph.node_indices().filter(|&n| n.index() != v).map(|n| {
+                let n = n.index();
+                (&pos[n], 1.0)
+            });
             let fr = f_r.total(&pos[v], ys);
 
             // update current position
@@ -345,8 +344,7 @@ where
     let tol = tol.unwrap_or(1e-6);
     let step = 0.1;
 
-    let mut weights: HashMap<(usize, usize), f64> =
-        HashMap::with_capacity(2 * graph.edge_count());
+    let mut weights: HashMap<(usize, usize), f64> = HashMap::with_capacity(2 * graph.edge_count());
     for e in graph.edge_references() {
         let w = weight_callable(py, &weight_fn, e.weight(), default_weight)?;
         let source = e.source().index();
@@ -360,15 +358,13 @@ where
         Some(false) => {
             let cs = LinearCoolingScheme::new(step, num_iter);
             evolve(
-                graph, vpos, fixed, f_a, f_r, cs, num_iter, tol, weights,
-                scale, center,
+                graph, vpos, fixed, f_a, f_r, cs, num_iter, tol, weights, scale, center,
             )
         }
         _ => {
             let cs = AdaptiveCoolingScheme::new(step);
             evolve(
-                graph, vpos, fixed, f_a, f_r, cs, num_iter, tol, weights,
-                scale, center,
+                graph, vpos, fixed, f_a, f_r, cs, num_iter, tol, weights, scale, center,
             )
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,7 @@ use pyo3::Python;
 use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::{
-    Data, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeIdentifiers,
-    NodeCount, NodeIndexable,
+    Data, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeIdentifiers, NodeCount, NodeIndexable,
 };
 use petgraph::EdgeType;
 
@@ -111,9 +110,7 @@ where
     }
 }
 
-pub fn get_edge_iter_with_weights<G>(
-    graph: G,
-) -> impl Iterator<Item = (usize, usize, PyObject)>
+pub fn get_edge_iter_with_weights<G>(graph: G) -> impl Iterator<Item = (usize, usize, PyObject)>
 where
     G: GraphBase
         + IntoEdgeReferences
@@ -141,10 +138,8 @@ where
         let j: usize;
         match &node_map {
             Some(map) => {
-                let source_index =
-                    NodeIndex::new(graph.to_index(edge.source()));
-                let target_index =
-                    NodeIndex::new(graph.to_index(edge.target()));
+                let source_index = NodeIndex::new(graph.to_index(edge.source()));
+                let target_index = NodeIndex::new(graph.to_index(edge.target()));
                 i = *map.get(&source_index).unwrap();
                 j = *map.get(&target_index).unwrap();
             }
@@ -211,9 +206,7 @@ impl TryFrom<f64> for CostFn {
 impl TryFrom<(Option<PyObject>, f64)> for CostFn {
     type Error = PyErr;
 
-    fn try_from(
-        func_or_default: (Option<PyObject>, f64),
-    ) -> Result<Self, Self::Error> {
+    fn try_from(func_or_default: (Option<PyObject>, f64)) -> Result<Self, Self::Error> {
         let (obj, val) = func_or_default;
         match obj {
             Some(obj) => Ok(CostFn::PyFunction(obj)),
@@ -255,10 +248,7 @@ fn find_node_by_weight<Ty: EdgeType>(
     Ok(index)
 }
 
-fn merge_duplicates<K, V, F, E>(
-    xs: Vec<(K, V)>,
-    mut merge_fn: F,
-) -> Result<Vec<(K, V)>, E>
+fn merge_duplicates<K, V, F, E>(xs: Vec<(K, V)>, mut merge_fn: F) -> Result<Vec<(K, V)>, E>
 where
     K: Hash + Eq,
     F: FnMut(&V, &V) -> Result<V, E>,

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -88,10 +88,7 @@ pub fn max_weight_matching(
     )
 }
 
-fn _inner_is_matching(
-    graph: &graph::PyGraph,
-    matching: &HashSet<(usize, usize)>,
-) -> bool {
+fn _inner_is_matching(graph: &graph::PyGraph, matching: &HashSet<(usize, usize)>) -> bool {
     let has_edge = |e: &(usize, usize)| -> bool {
         graph
             .graph
@@ -125,10 +122,7 @@ fn _inner_is_matching(
 /// :rtype: bool
 #[pyfunction]
 #[pyo3(text_signature = "(graph, matching, /)")]
-pub fn is_matching(
-    graph: &graph::PyGraph,
-    matching: HashSet<(usize, usize)>,
-) -> bool {
+pub fn is_matching(graph: &graph::PyGraph, matching: HashSet<(usize, usize)>) -> bool {
     _inner_is_matching(graph, &matching)
 }
 
@@ -151,10 +145,7 @@ pub fn is_matching(
 /// :rtype: bool
 #[pyfunction]
 #[pyo3(text_signature = "(graph, matching, /)")]
-pub fn is_maximal_matching(
-    graph: &graph::PyGraph,
-    matching: HashSet<(usize, usize)>,
-) -> bool {
+pub fn is_maximal_matching(graph: &graph::PyGraph, matching: HashSet<(usize, usize)>) -> bool {
     if !_inner_is_matching(graph, &matching) {
         return false;
     }

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -431,9 +431,7 @@ fn distance(x: &[f64], y: &[f64], p: f64) -> f64 {
 /// :return: A PyGraph object
 /// :rtype: PyGraph
 #[pyfunction(dim = "2", p = "2.0")]
-#[pyo3(
-    text_signature = "(num_nodes, radius, /, dim=2, pos=None, p=2.0, seed=None)"
-)]
+#[pyo3(text_signature = "(num_nodes, radius, /, dim=2, pos=None, p=2.0, seed=None)")]
 pub fn random_geometric_graph(
     py: Python,
     num_nodes: usize,
@@ -478,11 +476,7 @@ pub fn random_geometric_graph(
     for u in 0..(num_nodes - 1) {
         for v in (u + 1)..num_nodes {
             if distance(&pos[u], &pos[v], p) < radius_p {
-                inner_graph.add_edge(
-                    NodeIndex::new(u),
-                    NodeIndex::new(v),
-                    py.None(),
-                );
+                inner_graph.add_edge(NodeIndex::new(u), NodeIndex::new(v), py.None());
             }
         }
     }

--- a/src/shortest_path/all_pairs_dijkstra.rs
+++ b/src/shortest_path/all_pairs_dijkstra.rs
@@ -29,8 +29,7 @@ use petgraph::EdgeType;
 use rayon::prelude::*;
 
 use crate::iterators::{
-    AllPairsPathLengthMapping, AllPairsPathMapping, PathLengthMapping,
-    PathMapping,
+    AllPairsPathLengthMapping, AllPairsPathMapping, PathLengthMapping, PathMapping,
 };
 use crate::{CostFn, StablePyGraph};
 
@@ -59,14 +58,11 @@ pub fn all_pairs_dijkstra_path_lengths<Ty: EdgeType + Sync>(
         });
     }
     let edge_cost_callable = CostFn::from(edge_cost_fn);
-    let mut edge_weights: Vec<Option<f64>> =
-        Vec::with_capacity(graph.edge_bound());
+    let mut edge_weights: Vec<Option<f64>> = Vec::with_capacity(graph.edge_bound());
     for index in 0..=graph.edge_bound() {
         let raw_weight = graph.edge_weight(EdgeIndex::new(index));
         match raw_weight {
-            Some(weight) => {
-                edge_weights.push(Some(edge_cost_callable.call(py, weight)?))
-            }
+            Some(weight) => edge_weights.push(Some(edge_cost_callable.call(py, weight)?)),
             None => edge_weights.push(None),
         };
     }
@@ -130,14 +126,11 @@ pub fn all_pairs_dijkstra_shortest_paths<Ty: EdgeType + Sync>(
         });
     }
     let edge_cost_callable = CostFn::from(edge_cost_fn);
-    let mut edge_weights: Vec<Option<f64>> =
-        Vec::with_capacity(graph.edge_bound());
+    let mut edge_weights: Vec<Option<f64>> = Vec::with_capacity(graph.edge_bound());
     for index in 0..=graph.edge_bound() {
         let raw_weight = graph.edge_weight(EdgeIndex::new(index));
         match raw_weight {
-            Some(weight) => {
-                edge_weights.push(Some(edge_cost_callable.call(py, weight)?))
-            }
+            Some(weight) => edge_weights.push(Some(edge_cost_callable.call(py, weight)?)),
             None => edge_weights.push(None),
         };
     }
@@ -148,27 +141,20 @@ pub fn all_pairs_dijkstra_shortest_paths<Ty: EdgeType + Sync>(
         }
     };
     let node_indices: Vec<NodeIndex> = graph.node_indices().collect();
-    let temp_distances: RwLock<HashMap<usize, DictMap<NodeIndex, f64>>> =
-        if distances.is_some() {
-            RwLock::new(HashMap::with_capacity(graph.node_count()))
-        } else {
-            // Avoid extra allocation if HashMap isn't used
-            RwLock::new(HashMap::new())
-        };
+    let temp_distances: RwLock<HashMap<usize, DictMap<NodeIndex, f64>>> = if distances.is_some() {
+        RwLock::new(HashMap::with_capacity(graph.node_count()))
+    } else {
+        // Avoid extra allocation if HashMap isn't used
+        RwLock::new(HashMap::new())
+    };
     let out_map = AllPairsPathMapping {
         paths: node_indices
             .into_par_iter()
             .map(|x| {
                 let mut paths: DictMap<NodeIndex, Vec<NodeIndex>> =
                     DictMap::with_capacity(graph.node_count());
-                let distance = dijkstra(
-                    graph,
-                    x,
-                    None,
-                    |e| edge_cost(e.id()),
-                    Some(&mut paths),
-                )
-                .unwrap();
+                let distance =
+                    dijkstra(graph, x, None, |e| edge_cost(e.id()), Some(&mut paths)).unwrap();
                 if distances.is_some() {
                     temp_distances.write().unwrap().insert(x.index(), distance);
                 }
@@ -181,11 +167,7 @@ pub fn all_pairs_dijkstra_shortest_paths<Ty: EdgeType + Sync>(
                             if index != path_index {
                                 Some((
                                     path_index,
-                                    path_mapping
-                                        .1
-                                        .iter()
-                                        .map(|x| x.index())
-                                        .collect(),
+                                    path_mapping.1.iter().map(|x| x.index()).collect(),
                                 ))
                             } else {
                                 None

--- a/src/shortest_path/average_length.rs
+++ b/src/shortest_path/average_length.rs
@@ -48,15 +48,11 @@ pub fn compute_distance_sum<Ty: EdgeType + Sync>(
                 break;
             }
             for node in found {
-                for v in graph
-                    .neighbors_directed(node, petgraph::Direction::Outgoing)
-                {
+                for v in graph.neighbors_directed(node, petgraph::Direction::Outgoing) {
                     next_level.insert(v);
                 }
                 if graph.is_directed() && as_undirected {
-                    for v in graph
-                        .neighbors_directed(node, petgraph::Direction::Incoming)
-                    {
+                    for v in graph.neighbors_directed(node, petgraph::Direction::Incoming) {
                         next_level.insert(v);
                     }
                 }

--- a/src/shortest_path/distance_matrix.rs
+++ b/src/shortest_path/distance_matrix.rs
@@ -85,15 +85,11 @@ pub fn compute_distance_matrix<Ty: EdgeType + Sync>(
                 return;
             }
             for node in found {
-                for v in graph
-                    .neighbors_directed(node, petgraph::Direction::Outgoing)
-                {
+                for v in graph.neighbors_directed(node, petgraph::Direction::Outgoing) {
                     next_level.insert(v);
                 }
                 if graph.is_directed() && as_undirected {
-                    for v in graph
-                        .neighbors_directed(node, petgraph::Direction::Incoming)
-                    {
+                    for v in graph.neighbors_directed(node, petgraph::Direction::Incoming) {
                         next_level.insert(v);
                     }
                 }

--- a/src/shortest_path/floyd_warshall.rs
+++ b/src/shortest_path/floyd_warshall.rs
@@ -87,8 +87,7 @@ pub fn floyd_warshall<Ty: EdgeType>(
         let j = NodeIndexable::to_index(&graph, edge.target());
         let weight = edge.weight().clone();
 
-        let edge_weight =
-            weight_callable(py, &weight_fn, &weight, default_weight)?;
+        let edge_weight = weight_callable(py, &weight_fn, &weight, default_weight)?;
         if let Some(row_i) = mat.get_mut(i) {
             insert_or_minimize!(row_i, j, edge_weight);
         }
@@ -133,10 +132,7 @@ pub fn floyd_warshall<Ty: EdgeType>(
         .node_indices()
         .map(|i| {
             let out_map = PathLengthMapping {
-                path_lengths: mat[i.index()]
-                    .iter()
-                    .map(|(k, v)| (*k, *v))
-                    .collect(),
+                path_lengths: mat[i.index()].iter().map(|(k, v)| (*k, *v)).collect(),
             };
             (i.index(), out_map)
         })
@@ -160,8 +156,7 @@ pub fn floyd_warshall_numpy<Ty: EdgeType>(
 
     // Build adjacency matrix
     for (i, j, weight) in get_edge_iter_with_weights(graph) {
-        let edge_weight =
-            weight_callable(py, &weight_fn, &weight, default_weight)?;
+        let edge_weight = weight_callable(py, &weight_fn, &weight, default_weight)?;
         mat[[i, j]] = mat[[i, j]].min(edge_weight);
         if as_undirected {
             mat[[j, i]] = mat[[j, i]].min(edge_weight);
@@ -192,14 +187,12 @@ pub fn floyd_warshall_numpy<Ty: EdgeType>(
                 .into_par_iter()
                 .for_each(|mut row_i| {
                     let m_ik = row_i[k];
-                    row_i.iter_mut().zip(row_k.iter()).for_each(
-                        |(m_ij, m_kj)| {
-                            let d_ijk = m_ik + *m_kj;
-                            if d_ijk < *m_ij {
-                                *m_ij = d_ijk;
-                            }
-                        },
-                    )
+                    row_i.iter_mut().zip(row_k.iter()).for_each(|(m_ij, m_kj)| {
+                        let d_ijk = m_ik + *m_kj;
+                        if d_ijk < *m_ij {
+                            *m_ij = d_ijk;
+                        }
+                    })
                 })
         }
     }

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -32,8 +32,8 @@ use retworkx_core::dictmap::*;
 use retworkx_core::shortest_path::{astar, dijkstra, k_shortest_path};
 
 use crate::iterators::{
-    AllPairsPathLengthMapping, AllPairsPathMapping, NodeIndices,
-    NodesCountMapping, PathLengthMapping, PathMapping,
+    AllPairsPathLengthMapping, AllPairsPathMapping, NodeIndices, NodesCountMapping,
+    PathLengthMapping, PathMapping,
 };
 
 /// Find the shortest path from a node
@@ -58,9 +58,7 @@ use crate::iterators::{
 /// :raises ValueError: when an edge weight with NaN or negative value
 ///     is provided.
 #[pyfunction(default_weight = "1.0", as_undirected = "false")]
-#[pyo3(
-    text_signature = "(graph, source, /, target=None weight_fn=None, default_weight=1.0)"
-)]
+#[pyo3(text_signature = "(graph, source, /, target=None weight_fn=None, default_weight=1.0)")]
 pub fn graph_dijkstra_shortest_paths(
     py: Python,
     graph: &graph::PyGraph,
@@ -71,8 +69,7 @@ pub fn graph_dijkstra_shortest_paths(
 ) -> PyResult<PathMapping> {
     let start = NodeIndex::new(source);
     let goal_index: Option<NodeIndex> = target.map(NodeIndex::new);
-    let mut paths: DictMap<NodeIndex, Vec<NodeIndex>> =
-        DictMap::with_capacity(graph.node_count());
+    let mut paths: DictMap<NodeIndex, Vec<NodeIndex>> = DictMap::with_capacity(graph.node_count());
 
     let cost_fn = CostFn::try_from((weight_fn, default_weight))?;
 
@@ -89,9 +86,7 @@ pub fn graph_dijkstra_shortest_paths(
             .iter()
             .filter_map(|(k, v)| {
                 let k_int = k.index();
-                if k_int == source
-                    || target.is_some() && target.unwrap() != k_int
-                {
+                if k_int == source || target.is_some() && target.unwrap() != k_int {
                     None
                 } else {
                     Some((
@@ -140,8 +135,7 @@ pub fn digraph_dijkstra_shortest_paths(
 ) -> PyResult<PathMapping> {
     let start = NodeIndex::new(source);
     let goal_index: Option<NodeIndex> = target.map(NodeIndex::new);
-    let mut paths: DictMap<NodeIndex, Vec<NodeIndex>> =
-        DictMap::with_capacity(graph.node_count());
+    let mut paths: DictMap<NodeIndex, Vec<NodeIndex>> = DictMap::with_capacity(graph.node_count());
     let cost_fn = CostFn::try_from((weight_fn, default_weight))?;
 
     if as_undirected {
@@ -169,15 +163,10 @@ pub fn digraph_dijkstra_shortest_paths(
             .iter()
             .filter_map(|(k, v)| {
                 let k_int = k.index();
-                if k_int == source
-                    || target.is_some() && target.unwrap() != k_int
-                {
+                if k_int == source || target.is_some() && target.unwrap() != k_int {
                     None
                 } else {
-                    Some((
-                        k_int,
-                        v.iter().map(|x| x.index()).collect::<Vec<usize>>(),
-                    ))
+                    Some((k_int, v.iter().map(|x| x.index()).collect::<Vec<usize>>()))
                 }
             })
             .collect(),
@@ -359,11 +348,7 @@ pub fn digraph_all_pairs_dijkstra_path_lengths(
     graph: &digraph::PyDiGraph,
     edge_cost_fn: PyObject,
 ) -> PyResult<AllPairsPathLengthMapping> {
-    all_pairs_dijkstra::all_pairs_dijkstra_path_lengths(
-        py,
-        &graph.graph,
-        edge_cost_fn,
-    )
+    all_pairs_dijkstra::all_pairs_dijkstra_path_lengths(py, &graph.graph, edge_cost_fn)
 }
 
 /// For each node in the graph, finds the shortest paths to all others in a
@@ -402,12 +387,7 @@ pub fn digraph_all_pairs_dijkstra_shortest_paths(
     graph: &digraph::PyDiGraph,
     edge_cost_fn: PyObject,
 ) -> PyResult<AllPairsPathMapping> {
-    all_pairs_dijkstra::all_pairs_dijkstra_shortest_paths(
-        py,
-        &graph.graph,
-        edge_cost_fn,
-        None,
-    )
+    all_pairs_dijkstra::all_pairs_dijkstra_shortest_paths(py, &graph.graph, edge_cost_fn, None)
 }
 
 /// For each node in the graph, calculates the lengths of the shortest paths
@@ -442,11 +422,7 @@ pub fn graph_all_pairs_dijkstra_path_lengths(
     graph: &graph::PyGraph,
     edge_cost_fn: PyObject,
 ) -> PyResult<AllPairsPathLengthMapping> {
-    all_pairs_dijkstra::all_pairs_dijkstra_path_lengths(
-        py,
-        &graph.graph,
-        edge_cost_fn,
-    )
+    all_pairs_dijkstra::all_pairs_dijkstra_path_lengths(py, &graph.graph, edge_cost_fn)
 }
 
 /// For each node in the graph, finds the shortest paths to all others in a
@@ -481,12 +457,7 @@ pub fn graph_all_pairs_dijkstra_shortest_paths(
     graph: &graph::PyGraph,
     edge_cost_fn: PyObject,
 ) -> PyResult<AllPairsPathMapping> {
-    all_pairs_dijkstra::all_pairs_dijkstra_shortest_paths(
-        py,
-        &graph.graph,
-        edge_cost_fn,
-        None,
-    )
+    all_pairs_dijkstra::all_pairs_dijkstra_shortest_paths(py, &graph.graph, edge_cost_fn, None)
 }
 
 /// Compute the A* shortest path for a PyDiGraph
@@ -512,9 +483,7 @@ pub fn graph_all_pairs_dijkstra_shortest_paths(
 /// :raises ValueError: when an edge weight with NaN or negative value
 ///     is provided.
 #[pyfunction]
-#[pyo3(
-    text_signature = "(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn, /)"
-)]
+#[pyo3(text_signature = "(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn, /)")]
 fn digraph_astar_shortest_path(
     py: Python,
     graph: &digraph::PyDiGraph,
@@ -542,11 +511,7 @@ fn digraph_astar_shortest_path(
     )?;
     let path = match astar_res {
         Some(path) => path,
-        None => {
-            return Err(NoPathFound::new_err(
-                "No path found that satisfies goal_fn",
-            ))
-        }
+        None => return Err(NoPathFound::new_err("No path found that satisfies goal_fn")),
     };
     Ok(NodeIndices {
         nodes: path.1.into_iter().map(|x| x.index()).collect(),
@@ -576,9 +541,7 @@ fn digraph_astar_shortest_path(
 /// :raises ValueError: when an edge weight with NaN or negative value
 ///     is provided.
 #[pyfunction]
-#[pyo3(
-    text_signature = "(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn /)"
-)]
+#[pyo3(text_signature = "(graph, node, goal_fn, edge_cost_fn, estimate_cost_fn /)")]
 fn graph_astar_shortest_path(
     py: Python,
     graph: &graph::PyGraph,
@@ -606,11 +569,7 @@ fn graph_astar_shortest_path(
     )?;
     let path = match astar_res {
         Some(path) => path,
-        None => {
-            return Err(NoPathFound::new_err(
-                "No path found that satisfies goal_fn",
-            ))
-        }
+        None => return Err(NoPathFound::new_err("No path found that satisfies goal_fn")),
     };
     Ok(NodeIndices {
         nodes: path.1.into_iter().map(|x| x.index()).collect(),
@@ -650,13 +609,10 @@ fn digraph_k_shortest_path_lengths(
     let out_goal = goal.map(NodeIndex::new);
     let edge_cost_callable = CostFn::from(edge_cost);
 
-    let out_map: Vec<Option<f64>> = k_shortest_path(
-        &graph.graph,
-        NodeIndex::new(start),
-        out_goal,
-        k,
-        |e| edge_cost_callable.call(py, e.weight()),
-    )?;
+    let out_map: Vec<Option<f64>> =
+        k_shortest_path(&graph.graph, NodeIndex::new(start), out_goal, k, |e| {
+            edge_cost_callable.call(py, e.weight())
+        })?;
 
     if let Some(goal_usize) = goal {
         return Ok(PathLengthMapping {
@@ -713,13 +669,10 @@ pub fn graph_k_shortest_path_lengths(
     let out_goal = goal.map(NodeIndex::new);
     let edge_cost_callable = CostFn::from(edge_cost);
 
-    let out_map: Vec<Option<f64>> = k_shortest_path(
-        &graph.graph,
-        NodeIndex::new(start),
-        out_goal,
-        k,
-        |e| edge_cost_callable.call(py, e.weight()),
-    )?;
+    let out_map: Vec<Option<f64>> =
+        k_shortest_path(&graph.graph, NodeIndex::new(start), out_goal, k, |e| {
+            edge_cost_callable.call(py, e.weight())
+        })?;
 
     if let Some(goal_usize) = goal {
         return Ok(PathLengthMapping {
@@ -852,9 +805,7 @@ fn digraph_floyd_warshall(
 ///
 /// :rtype: AllPairsPathLengthMapping
 #[pyfunction(parallel_threshold = "300", default_weight = "1.0")]
-#[pyo3(
-    text_signature = "(graph, /, weight_fn=None, default_weight=1.0, parallel_threshold=300)"
-)]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, parallel_threshold=300)")]
 pub fn graph_floyd_warshall(
     py: Python,
     graph: &graph::PyGraph,
@@ -907,9 +858,7 @@ pub fn graph_floyd_warshall(
 ///     ``np.inf``.
 /// :rtype: numpy.ndarray
 #[pyfunction(parallel_threshold = "300", default_weight = "1.0")]
-#[pyo3(
-    text_signature = "(graph, /, weight_fn=None, default_weight=1.0, parallel_threshold=300)"
-)]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, parallel_threshold=300)")]
 pub fn graph_floyd_warshall_numpy(
     py: Python,
     graph: &graph::PyGraph,
@@ -1006,10 +955,7 @@ pub fn digraph_num_shortest_paths_unweighted(
     source: usize,
 ) -> PyResult<NodesCountMapping> {
     Ok(NodesCountMapping {
-        map: num_shortest_path::num_shortest_paths_unweighted(
-            &graph.graph,
-            source,
-        )?,
+        map: num_shortest_path::num_shortest_paths_unweighted(&graph.graph, source)?,
     })
 }
 
@@ -1029,10 +975,7 @@ pub fn graph_num_shortest_paths_unweighted(
     source: usize,
 ) -> PyResult<NodesCountMapping> {
     Ok(NodesCountMapping {
-        map: num_shortest_path::num_shortest_paths_unweighted(
-            &graph.graph,
-            source,
-        )?,
+        map: num_shortest_path::num_shortest_paths_unweighted(&graph.graph, source)?,
     })
 }
 
@@ -1065,9 +1008,7 @@ pub fn graph_num_shortest_paths_unweighted(
     as_undirected = "false",
     null_value = "0.0"
 )]
-#[pyo3(
-    text_signature = "(graph, /, parallel_threshold=300, as_undirected=False, null_value=0.0)"
-)]
+#[pyo3(text_signature = "(graph, /, parallel_threshold=300, as_undirected=False, null_value=0.0)")]
 pub fn digraph_distance_matrix(
     py: Python,
     graph: &digraph::PyDiGraph,
@@ -1177,11 +1118,8 @@ pub fn digraph_unweighted_average_shortest_path_length(
         return std::f64::NAN;
     }
 
-    let (sum, conn_pairs) = average_length::compute_distance_sum(
-        &graph.graph,
-        parallel_threshold,
-        as_undirected,
-    );
+    let (sum, conn_pairs) =
+        average_length::compute_distance_sum(&graph.graph, parallel_threshold, as_undirected);
 
     let tot_pairs = n * (n - 1);
     if disconnected && conn_pairs == 0 {
@@ -1229,9 +1167,7 @@ pub fn digraph_unweighted_average_shortest_path_length(
 ///     in the calculation this will return NaN.
 /// :rtype: float
 #[pyfunction(parallel_threshold = "300", disconnected = "false")]
-#[pyo3(
-    text_signature = "(graph, /, parallel_threshold=300, disconnected=False)"
-)]
+#[pyo3(text_signature = "(graph, /, parallel_threshold=300, disconnected=False)")]
 pub fn graph_unweighted_average_shortest_path_length(
     graph: &graph::PyGraph,
     parallel_threshold: usize,
@@ -1242,11 +1178,8 @@ pub fn graph_unweighted_average_shortest_path_length(
         return std::f64::NAN;
     }
 
-    let (sum, conn_pairs) = average_length::compute_distance_sum(
-        &graph.graph,
-        parallel_threshold,
-        true,
-    );
+    let (sum, conn_pairs) =
+        average_length::compute_distance_sum(&graph.graph, parallel_threshold, true);
 
     let tot_pairs = n * (n - 1);
     if disconnected && conn_pairs == 0 {

--- a/src/shortest_path/num_shortest_path.rs
+++ b/src/shortest_path/num_shortest_path.rs
@@ -27,8 +27,7 @@ pub fn num_shortest_paths_unweighted<Ty: EdgeType>(
     graph: &StablePyGraph<Ty>,
     source: usize,
 ) -> PyResult<DictMap<usize, BigUint>> {
-    let mut out_map: Vec<BigUint> =
-        vec![0.to_biguint().unwrap(); graph.node_bound()];
+    let mut out_map: Vec<BigUint> = vec![0.to_biguint().unwrap(); graph.node_bound()];
     let node_index = NodeIndex::new(source);
     if graph.node_weight(node_index).is_none() {
         return Err(PyIndexError::new_err(format!(
@@ -43,9 +42,7 @@ pub fn num_shortest_paths_unweighted<Ty: EdgeType>(
     while let Some(current) = bfs.next(graph) {
         let dist_plus_one = distance[current.index()].unwrap_or_default() + 1;
         let count_current = out_map[current.index()].clone();
-        for neighbor_index in
-            graph.neighbors_directed(current, petgraph::Direction::Outgoing)
-        {
+        for neighbor_index in graph.neighbors_directed(current, petgraph::Direction::Outgoing) {
             let neighbor: usize = neighbor_index.index();
             if distance[neighbor].is_none() {
                 distance[neighbor] = Some(dist_plus_one);

--- a/src/steiner_tree.rs
+++ b/src/steiner_tree.rs
@@ -83,23 +83,16 @@ fn _metric_closure_edges(
     }
     let mut out_vec = Vec::with_capacity(node_count * (node_count - 1) / 2);
     let mut distances = HashMap::with_capacity(graph.graph.node_count());
-    let paths = all_pairs_dijkstra_shortest_paths(
-        py,
-        &graph.graph,
-        weight_fn,
-        Some(&mut distances),
-    )?
-    .paths;
-    let mut nodes: HashSet<usize> =
-        graph.graph.node_indices().map(|x| x.index()).collect();
+    let paths =
+        all_pairs_dijkstra_shortest_paths(py, &graph.graph, weight_fn, Some(&mut distances))?.paths;
+    let mut nodes: HashSet<usize> = graph.graph.node_indices().map(|x| x.index()).collect();
     let first_node = graph
         .graph
         .node_indices()
         .map(|x| x.index())
         .next()
         .unwrap();
-    let path_keys: HashSet<usize> =
-        paths[&first_node].paths.keys().copied().collect();
+    let path_keys: HashSet<usize> = paths[&first_node].paths.keys().copied().collect();
     // first_node will always be missing from path_keys so if the difference
     // is > 1 with nodes that means there is another node in the graph that
     // first_node doesn't have a path to.
@@ -153,8 +146,7 @@ fn fast_metric_edges(
 
     let cost_fn = |edge: EdgeReference<'_, PyObject>| -> PyResult<f64> {
         if edge.source() != dummy && edge.target() != dummy {
-            let weight: f64 =
-                weight_fn.call1(py, (edge.weight(),))?.extract(py)?;
+            let weight: f64 = weight_fn.call1(py, (edge.weight(),))?.extract(py)?;
             is_valid_weight(weight)
         } else {
             Ok(0.0)
@@ -169,15 +161,13 @@ fn fast_metric_edges(
     graph.graph.remove_node(dummy);
 
     // ``partition[u]`` holds the terminal node closest to node ``u``.
-    let mut partition: Vec<usize> =
-        vec![std::usize::MAX; graph.graph.node_bound()];
+    let mut partition: Vec<usize> = vec![std::usize::MAX; graph.graph.node_bound()];
     for (u, path) in paths.iter() {
         let u = u.index();
         partition[u] = path[1].index();
     }
 
-    let mut out_edges: Vec<MetricClosureEdge> =
-        Vec::with_capacity(graph.graph.edge_count());
+    let mut out_edges: Vec<MetricClosureEdge> = Vec::with_capacity(graph.graph.edge_count());
 
     for edge in graph.graph.edge_references() {
         let source = edge.source();
@@ -185,8 +175,7 @@ fn fast_metric_edges(
         // assert that ``source`` is reachable from a terminal node.
         if distance.contains_key(&source) {
             let weight = distance[&source] + cost_fn(edge)? + distance[&target];
-            let mut path: Vec<usize> =
-                paths[&source].iter().skip(1).map(|x| x.index()).collect();
+            let mut path: Vec<usize> = paths[&source].iter().skip(1).map(|x| x.index()).collect();
             path.append(
                 &mut paths[&target]
                     .iter()
@@ -278,8 +267,7 @@ pub fn steiner_tree(
     terminal_nodes: Vec<usize>,
     weight_fn: PyObject,
 ) -> PyResult<graph::PyGraph> {
-    let mut edge_list =
-        fast_metric_edges(py, graph, &terminal_nodes, &weight_fn)?;
+    let mut edge_list = fast_metric_edges(py, graph, &terminal_nodes, &weight_fn)?;
     let mut subgraphs = UnionFind::<usize>::new(graph.graph.node_bound());
     edge_list.par_sort_unstable_by(|a, b| {
         let weight_a = (a.distance, a.source, a.target);
@@ -295,8 +283,7 @@ pub fn steiner_tree(
         }
     }
     // assert that the terminal nodes are connected.
-    if !terminal_nodes.is_empty() && mst_edges.len() != terminal_nodes.len() - 1
-    {
+    if !terminal_nodes.is_empty() && mst_edges.len() != terminal_nodes.len() - 1 {
         return Err(PyValueError::new_err(
             "The terminal nodes in the input graph must belong to the same connected component. \
                   The steiner tree is not defined for a graph with unconnected terminal nodes",
@@ -308,8 +295,7 @@ pub fn steiner_tree(
         .flat_map(|edge| pairwise(edge.path))
         .filter_map(|x| x.0.map(|a| [a, x.1]))
         .collect();
-    let out_edges: HashSet<(usize, usize)> =
-        out_edge_list.iter().map(|x| (x[0], x[1])).collect();
+    let out_edges: HashSet<(usize, usize)> = out_edge_list.iter().map(|x| (x[0], x[1])).collect();
     let mut out_graph = graph.clone();
     let out_nodes: HashSet<NodeIndex> = out_edge_list
         .iter()
@@ -328,8 +314,7 @@ pub fn steiner_tree(
     for edge in graph.graph.edge_references().filter(|edge| {
         let source = edge.source().index();
         let target = edge.target().index();
-        !out_edges.contains(&(source, target))
-            && !out_edges.contains(&(target, source))
+        !out_edges.contains(&(source, target)) && !out_edges.contains(&(target, source))
     }) {
         out_graph.graph.remove_edge(edge.id());
     }
@@ -345,19 +330,14 @@ fn deduplicate_edges(
 ) -> PyResult<()> {
     if out_graph.multigraph {
         // Find all edges between nodes
-        let mut duplicate_map: HashMap<
-            [NodeIndex; 2],
-            Vec<(EdgeIndex, PyObject)>,
-        > = HashMap::new();
+        let mut duplicate_map: HashMap<[NodeIndex; 2], Vec<(EdgeIndex, PyObject)>> = HashMap::new();
         for edge in out_graph.graph.edge_references() {
             if duplicate_map.contains_key(&[edge.source(), edge.target()]) {
                 duplicate_map
                     .get_mut(&[edge.source(), edge.target()])
                     .unwrap()
                     .push((edge.id(), edge.weight().clone_ref(py)));
-            } else if duplicate_map
-                .contains_key(&[edge.target(), edge.source()])
-            {
+            } else if duplicate_map.contains_key(&[edge.target(), edge.source()]) {
                 duplicate_map
                     .get_mut(&[edge.target(), edge.source()])
                     .unwrap()
@@ -371,8 +351,7 @@ fn deduplicate_edges(
         }
         // For a node pair with > 1 edge find minimum edge and remove others
         for edges_raw in duplicate_map.values().filter(|x| x.len() > 1) {
-            let mut edges: Vec<(EdgeIndex, f64)> =
-                Vec::with_capacity(edges_raw.len());
+            let mut edges: Vec<(EdgeIndex, f64)> = Vec::with_capacity(edges_raw.len());
             for edge in edges_raw {
                 let res = weight_fn.call1(py, (&edge.1,))?;
                 let raw = res.to_object(py);

--- a/src/toposort.rs
+++ b/src/toposort.rs
@@ -76,20 +76,11 @@ pub struct TopologicalSorter {
 impl TopologicalSorter {
     #[new]
     #[args(check_cycle = "true")]
-    fn new(
-        py: Python,
-        dag: Py<PyDiGraph>,
-        check_cycle: bool,
-    ) -> PyResult<Self> {
+    fn new(py: Python, dag: Py<PyDiGraph>, check_cycle: bool) -> PyResult<Self> {
         {
             let dag = &dag.borrow(py);
-            if !dag.check_cycle
-                && check_cycle
-                && !is_directed_acyclic_graph(dag)
-            {
-                return Err(DAGHasCycle::new_err(
-                    "PyDiGraph object has a cycle",
-                ));
+            if !dag.check_cycle && check_cycle && !is_directed_acyclic_graph(dag) {
+                return Err(DAGHasCycle::new_err("PyDiGraph object has a cycle"));
             }
         }
 
@@ -100,10 +91,7 @@ impl TopologicalSorter {
                 .node_identifiers()
                 .filter(|node| {
                     dag.graph
-                        .neighbors_directed(
-                            *node,
-                            petgraph::Direction::Incoming,
-                        )
+                        .neighbors_directed(*node, petgraph::Direction::Incoming)
                         .next()
                         .is_none()
                 })
@@ -198,10 +186,7 @@ impl TopologicalSorter {
                     Entry::Vacant(entry) => {
                         let in_degree = dag
                             .graph
-                            .neighbors_directed(
-                                succ,
-                                petgraph::Direction::Incoming,
-                            )
+                            .neighbors_directed(succ, petgraph::Direction::Incoming)
                             .count()
                             - 1;
 

--- a/src/transitivity.rs
+++ b/src/transitivity.rs
@@ -22,8 +22,7 @@ fn _graph_triangles(graph: &graph::PyGraph, node: usize) -> (usize, usize) {
     let mut triangles: usize = 0;
 
     let index = NodeIndex::new(node);
-    let mut neighbors: HashSet<NodeIndex> =
-        graph.graph.neighbors(index).collect();
+    let mut neighbors: HashSet<NodeIndex> = graph.graph.neighbors(index).collect();
     neighbors.remove(&index);
 
     for nodev in &neighbors {
@@ -87,10 +86,7 @@ fn graph_transitivity(graph: &graph::PyGraph) -> f64 {
     }
 }
 
-fn _digraph_triangles(
-    graph: &digraph::PyDiGraph,
-    node: usize,
-) -> (usize, usize) {
+fn _digraph_triangles(graph: &digraph::PyDiGraph, node: usize) -> (usize, usize) {
     let mut triangles: usize = 0;
 
     let index = NodeIndex::new(node);

--- a/src/traversal/dfs_visit.rs
+++ b/src/traversal/dfs_visit.rs
@@ -33,9 +33,7 @@ pub fn dfs_handler(
     event: DfsEvent<NodeIndex, &PyObject>,
 ) -> PyResult<Control<()>> {
     let res = match event {
-        DfsEvent::Discover(u, Time(t)) => {
-            vis.discover_vertex.call1(py, (u.index(), t))
-        }
+        DfsEvent::Discover(u, Time(t)) => vis.discover_vertex.call1(py, (u.index(), t)),
         DfsEvent::TreeEdge(u, v, weight) => {
             let edge = (u.index(), v.index(), weight);
             vis.tree_edge.call1(py, (edge,))
@@ -48,9 +46,7 @@ pub fn dfs_handler(
             let edge = (u.index(), v.index(), weight);
             vis.forward_or_cross_edge.call1(py, (edge,))
         }
-        DfsEvent::Finish(u, Time(t)) => {
-            vis.finish_vertex.call1(py, (u.index(), t))
-        }
+        DfsEvent::Finish(u, Time(t)) => vis.finish_vertex.call1(py, (u.index(), t)),
     };
 
     match res {

--- a/src/traversal/dijkstra_visit.rs
+++ b/src/traversal/dijkstra_visit.rs
@@ -33,9 +33,7 @@ pub fn dijkstra_handler(
     event: DijkstraEvent<NodeIndex, &PyObject, f64>,
 ) -> PyResult<Control<()>> {
     let res = match event {
-        DijkstraEvent::Discover(u, score) => {
-            vis.discover_vertex.call1(py, (u.index(), score))
-        }
+        DijkstraEvent::Discover(u, score) => vis.discover_vertex.call1(py, (u.index(), score)),
         DijkstraEvent::ExamineEdge(u, v, weight) => {
             let edge = (u.index(), v.index(), weight);
             vis.examine_edge.call1(py, (edge,))

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -71,10 +71,7 @@ use crate::iterators::EdgeList;
 /// :rtype: EdgeList
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /, source=None)")]
-fn digraph_dfs_edges(
-    graph: &digraph::PyDiGraph,
-    source: Option<usize>,
-) -> EdgeList {
+fn digraph_dfs_edges(graph: &digraph::PyDiGraph, source: Option<usize>) -> EdgeList {
     EdgeList {
         edges: dfs_edges(&graph.graph, source.map(NodeIndex::new)),
     }
@@ -140,23 +137,17 @@ fn graph_dfs_edges(graph: &graph::PyGraph, source: Option<usize>) -> EdgeList {
 /// :rtype: BFSSuccessors
 #[pyfunction]
 #[pyo3(text_signature = "(graph, node, /)")]
-fn bfs_successors(
-    py: Python,
-    graph: &digraph::PyDiGraph,
-    node: usize,
-) -> iterators::BFSSuccessors {
+fn bfs_successors(py: Python, graph: &digraph::PyDiGraph, node: usize) -> iterators::BFSSuccessors {
     let index = NodeIndex::new(node);
     let mut bfs = Bfs::new(&graph.graph, index);
-    let mut out_list: Vec<(PyObject, Vec<PyObject>)> =
-        Vec::with_capacity(graph.node_count());
+    let mut out_list: Vec<(PyObject, Vec<PyObject>)> = Vec::with_capacity(graph.node_count());
     while let Some(nx) = bfs.next(&graph.graph) {
         let children = graph
             .graph
             .neighbors_directed(nx, petgraph::Direction::Outgoing);
         let mut succesors: Vec<PyObject> = Vec::new();
         for succ in children {
-            succesors
-                .push(graph.graph.node_weight(succ).unwrap().clone_ref(py));
+            succesors.push(graph.graph.node_weight(succ).unwrap().clone_ref(py));
         }
         if !succesors.is_empty() {
             out_list.push((

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -62,8 +62,7 @@ pub fn minimum_spanning_edges(
     let mut edge_list: Vec<(f64, EdgeReference<PyObject>)> =
         Vec::with_capacity(graph.graph.edge_count());
     for edge in graph.graph.edge_references() {
-        let weight =
-            weight_callable(py, &weight_fn, edge.weight(), default_weight)?;
+        let weight = weight_callable(py, &weight_fn, edge.weight(), default_weight)?;
         if weight.is_nan() {
             return Err(PyValueError::new_err("NaN found as an edge weight"));
         }

--- a/src/union.rs
+++ b/src/union.rs
@@ -43,8 +43,7 @@ fn union<Ty: EdgeType>(
 ) -> PyResult<StablePyGraph<Ty>> {
     let mut out_graph = first.clone();
 
-    let mut node_map: Vec<Entry<NodeIndex>> =
-        vec![Entry::None; second.node_bound()];
+    let mut node_map: Vec<Entry<NodeIndex>> = vec![Entry::None; second.node_bound()];
     for node in second.node_indices() {
         let weight = &second[node];
         if merge_nodes {
@@ -77,9 +76,7 @@ fn union<Ty: EdgeType>(
                 (node_map[source], node_map[target])
             {
                 for edge in first.edges(new_source) {
-                    if edge.target() == new_target
-                        && weights_equal(new_weight, edge.weight())?
-                    {
+                    if edge.target() == new_target && weights_equal(new_weight, edge.weight())? {
                         found = true;
                         break;
                     }
@@ -90,11 +87,7 @@ fn union<Ty: EdgeType>(
         if !found {
             let new_source = extract(node_map[source]);
             let new_target = extract(node_map[target]);
-            out_graph.add_edge(
-                new_source,
-                new_target,
-                new_weight.clone_ref(py),
-            );
+            out_graph.add_edge(new_source, new_target, new_weight.clone_ref(py));
         }
     }
 
@@ -132,9 +125,7 @@ fn union<Ty: EdgeType>(
 ///     passed by reference from ``first`` and ``second`` to this new object.
 /// :rtype: PyGraph
 #[pyfunction(merge_nodes = false, merge_edges = false)]
-#[pyo3(
-    text_signature = "(first, second, /, merge_nodes=False, merge_edges=False)"
-)]
+#[pyo3(text_signature = "(first, second, /, merge_nodes=False, merge_edges=False)")]
 fn graph_union(
     py: Python,
     first: &graph::PyGraph,
@@ -142,8 +133,7 @@ fn graph_union(
     merge_nodes: bool,
     merge_edges: bool,
 ) -> PyResult<graph::PyGraph> {
-    let out_graph =
-        union(py, &first.graph, &second.graph, merge_nodes, merge_edges)?;
+    let out_graph = union(py, &first.graph, &second.graph, merge_nodes, merge_edges)?;
 
     Ok(graph::PyGraph {
         graph: out_graph,
@@ -183,9 +173,7 @@ fn graph_union(
 ///     passed by reference from ``first`` and ``second`` to this new object.
 /// :rtype: PyDiGraph
 #[pyfunction(merge_nodes = false, merge_edges = false)]
-#[pyo3(
-    text_signature = "(first, second, /, merge_nodes=False, merge_edges=False)"
-)]
+#[pyo3(text_signature = "(first, second, /, merge_nodes=False, merge_edges=False)")]
 fn digraph_union(
     py: Python,
     first: &digraph::PyDiGraph,
@@ -193,8 +181,7 @@ fn digraph_union(
     merge_nodes: bool,
     merge_edges: bool,
 ) -> PyResult<digraph::PyDiGraph> {
-    let out_graph =
-        union(py, &first.graph, &second.graph, merge_nodes, merge_edges)?;
+    let out_graph = union(py, &first.graph, &second.graph, merge_nodes, merge_edges)?;
 
     Ok(digraph::PyDiGraph {
         graph: out_graph,

--- a/tests/digraph/test_adj.py
+++ b/tests/digraph/test_adj.py
@@ -56,9 +56,7 @@ class TestAdj(unittest.TestCase):
         node_b = dag.add_child(node_a, "b", {"a": 1})
         node_c = dag.add_child(node_a, "c", {"a": 2})
         res = dag.out_edges(node_a)
-        self.assertEqual(
-            [(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res
-        )
+        self.assertEqual([(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res)
 
     def test_neighbor_dir_surrounded_in_out_edges(self):
         dag = retworkx.PyDAG()

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -91,13 +91,9 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
-        res = retworkx.adjacency_matrix(
-            graph, lambda x: float(x), null_value=np.inf
-        )
+        res = retworkx.adjacency_matrix(graph, lambda x: float(x), null_value=np.inf)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(
-            np.array_equal(np.array([[np.inf, 7.5], [np.inf, np.inf]]), res)
-        )
+        self.assertTrue(np.array_equal(np.array([[np.inf, 7.5], [np.inf, np.inf]]), res))
 
     def test_graph_to_digraph_adjacency_matrix(self):
         graph = retworkx.PyGraph()
@@ -137,16 +133,12 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         graph = retworkx.PyDiGraph.from_adjacency_matrix(
             input_matrix.astype(np.float64, copy=False)
         )
@@ -164,9 +156,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
             [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
             dtype=np.float64,
         )
-        graph = retworkx.PyDiGraph.from_adjacency_matrix(
-            input_matrix, null_value=np.Inf
-        )
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix, null_value=np.Inf)
         adj_matrix = retworkx.adjacency_matrix(graph, float)
         expected_matrix = np.array(
             [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
@@ -175,9 +165,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
 
     def test_negative_weight(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=float
-        )
+        input_matrix = np.array([[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=float)
         graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.digraph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
@@ -191,13 +179,9 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
             [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
             dtype=np.float64,
         )
-        graph = retworkx.PyDiGraph.from_adjacency_matrix(
-            input_matrix, null_value=np.nan
-        )
+        graph = retworkx.PyDiGraph.from_adjacency_matrix(input_matrix, null_value=np.nan)
         adj_matrix = retworkx.adjacency_matrix(graph, float)
-        expected_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
-        )
+        expected_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64)
         self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
 
 
@@ -217,16 +201,12 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyDiGraph.from_complex_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(
             input_matrix.astype(np.complex128, copy=False)
         )
@@ -239,9 +219,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_random_graph_complex_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=complex
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=complex)
         graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(input_matrix)
         expected = [
             (0, 1, 1 + 0j),
@@ -256,9 +234,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
             dtype=np.complex128,
         )
-        graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(
-            input_matrix, null_value=np.Inf
-        )
+        graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(input_matrix, null_value=np.Inf)
         expected = [
             (0, 1, 1 + 0j),
             (1, 0, 1 + 0j),
@@ -268,9 +244,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_negative_weight(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=complex
-        )
+        input_matrix = np.array([[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=complex)
         graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(input_matrix)
         self.assertEqual(
             [(0, 1, 1), (1, 0, -1), (1, 2, -1), (2, 1, 1)],
@@ -282,9 +256,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
             dtype=np.complex128,
         )
-        graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(
-            input_matrix, null_value=np.nan
-        )
+        graph = retworkx.PyDiGraph.from_complex_adjacency_matrix(input_matrix, null_value=np.nan)
         edge_list = graph.weighted_edge_list()
         self.assertEqual(
             edge_list,

--- a/tests/digraph/test_all_simple_paths.py
+++ b/tests/digraph/test_all_simple_paths.py
@@ -82,9 +82,7 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         for i in range(6):
             dag.add_node(i)
         dag.add_edges_from_no_data(self.edges)
-        paths = retworkx.digraph_all_simple_paths(
-            dag, 0, 5, min_depth=5, cutoff=5
-        )
+        paths = retworkx.digraph_all_simple_paths(dag, 0, 5, min_depth=5, cutoff=5)
         expected = [
             [0, 3, 2, 4, 5],
             [0, 2, 3, 4, 5],
@@ -112,6 +110,4 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyGraph()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(
-            TypeError, retworkx.digraph_all_simple_paths, (dag, 0, 1)
-        )
+        self.assertRaises(TypeError, retworkx.digraph_all_simple_paths, (dag, 0, 1))

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -95,9 +95,7 @@ class TestAstarDigraph(unittest.TestCase):
         g = retworkx.PyGraph()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.digraph_astar_shortest_path(
-                g, 0, lambda x: x, lambda y: 1, lambda z: 0
-            )
+            retworkx.digraph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)
 
     def test_astar_with_invalid_weights(self):
         g = retworkx.PyDAG()

--- a/tests/digraph/test_avg_shortest_path.py
+++ b/tests/digraph/test_avg_shortest_path.py
@@ -68,9 +68,7 @@ class TestAvgShortestPath(unittest.TestCase):
             self.assertTrue(math.isinf(res), "Output is not infinity")
 
         with self.subTest(disconnected=True):
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, disconnected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, disconnected=True)
             self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_partially_connected_graph(self):
@@ -83,9 +81,7 @@ class TestAvgShortestPath(unittest.TestCase):
         with self.subTest(disconnected=True):
             s = 15872
             den = 992  # n*(n-1), n=32 (only connected pairs considered)
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, disconnected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, disconnected=True)
             self.assertAlmostEqual(s / den, res, delta=1e-7)
 
     def test_connected_cycle_graph(self):
@@ -101,63 +97,47 @@ class TestAvgShortestPathAsUndirected(unittest.TestCase):
         edge_list = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (3, 6), (6, 7)]
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(edge_list)
-        res = retworkx.digraph_unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.digraph_unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertAlmostEqual(2.5714285714285716, res, delta=1e-7)
 
     def test_cycle_graph(self):
         graph = retworkx.generators.directed_cycle_graph(7)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertAlmostEqual(2, res, delta=1e-7)
 
     def test_path_graph(self):
         graph = retworkx.generators.directed_path_graph(5)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertAlmostEqual(2, res, delta=1e-7)
 
     def test_parallel_grid(self):
         graph = retworkx.generators.directed_grid_graph(30, 11)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertAlmostEqual(13.666666666666666, res, delta=1e-7)
 
     def test_empty(self):
         graph = retworkx.PyDiGraph()
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_single_node(self):
         graph = retworkx.PyDiGraph()
         graph.add_node(0)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_single_node_self_edge(self):
         graph = retworkx.PyDiGraph()
         node = graph.add_node(0)
         graph.add_edge(node, node, 0)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_disconnected_graph(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(32)))
         with self.subTest(disconnected=False):
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, as_undirected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
             self.assertTrue(math.isinf(res), "Output is not infinity")
 
         with self.subTest(disconnected=True):
@@ -170,9 +150,7 @@ class TestAvgShortestPathAsUndirected(unittest.TestCase):
         graph = retworkx.generators.directed_cycle_graph(32)
         graph.add_nodes_from(list(range(32)))
         with self.subTest(disconnected=False):
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, as_undirected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
             self.assertTrue(math.isinf(res), "Output is not infinity")
 
         with self.subTest(disconnected=True):
@@ -185,9 +163,7 @@ class TestAvgShortestPathAsUndirected(unittest.TestCase):
 
     def test_connected_cycle_graph(self):
         graph = retworkx.generators.directed_cycle_graph(32)
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
+        res = retworkx.unweighted_average_shortest_path_length(graph, as_undirected=True)
         s = 8192
         den = 992  # n*(n-1)
         self.assertAlmostEqual(s / den, res, delta=1e-7)

--- a/tests/digraph/test_bfs_search.py
+++ b/tests/digraph/test_bfs_search.py
@@ -53,9 +53,7 @@ class TestBfsSearch(unittest.TestCase):
 
         vis = TreeEdgesRecorder()
         retworkx.digraph_bfs_search(self.graph, None, vis)
-        self.assertEqual(
-            vis.edges, [(0, 2), (0, 1), (2, 6), (2, 5), (1, 3), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 2), (0, 1), (2, 6), (2, 5), (1, 3), (4, 7)])
 
     def test_digraph_bfs_tree_edges_restricted(self):
         class TreeEdgesRecorderRestricted(retworkx.visit.BFSVisitor):

--- a/tests/digraph/test_centrality.py
+++ b/tests/digraph/test_centrality.py
@@ -40,9 +40,7 @@ class TestCentralityDiGraph(unittest.TestCase):
         self.assertEqual(expected, betweenness)
 
     def test_betweenness_centrality_endpoints(self):
-        betweenness = retworkx.digraph_betweenness_centrality(
-            self.graph, endpoints=True
-        )
+        betweenness = retworkx.digraph_betweenness_centrality(self.graph, endpoints=True)
         expected = {
             0: 0.25,
             1: 0.41666666666666663,
@@ -59,9 +57,7 @@ class TestCentralityDiGraph(unittest.TestCase):
         self.assertEqual(expected, betweenness)
 
     def test_betweenness_centrality_parallel(self):
-        betweenness = retworkx.digraph_betweenness_centrality(
-            self.graph, parallel_threshold=1
-        )
+        betweenness = retworkx.digraph_betweenness_centrality(self.graph, parallel_threshold=1)
         expected = {
             0: 0.0,
             1: 0.3333333333333333,
@@ -117,9 +113,7 @@ class TestCentralityDiGraphDeletedNode(unittest.TestCase):
         self.assertEqual(expected, betweenness)
 
     def test_betweenness_centrality_endpoints(self):
-        betweenness = retworkx.digraph_betweenness_centrality(
-            self.graph, endpoints=True
-        )
+        betweenness = retworkx.digraph_betweenness_centrality(self.graph, endpoints=True)
         expected = {
             0: 0.25,
             1: 0.41666666666666663,

--- a/tests/digraph/test_complement.py
+++ b/tests/digraph/test_complement.py
@@ -25,9 +25,7 @@ class TestComplement(unittest.TestCase):
     def test_clique_directed(self):
         N = 5
         graph = retworkx.PyDiGraph()
-        graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j]
-        )
+        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -39,9 +37,7 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyDiGraph()
-        expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i != j]
-        )
+        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i != j])
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -55,22 +51,12 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i != j and (i + j) % 3 == 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 == 0]
         )
 
         expected_graph = retworkx.PyDiGraph()
         expected_graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i != j and (i + j) % 3 != 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i != j and (i + j) % 3 != 0]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/digraph/test_compose.py
+++ b/tests/digraph/test_compose.py
@@ -74,9 +74,7 @@ class TestCompose(unittest.TestCase):
             original_op_nodes[0]: (op_nodes[0], "qr[0]"),
             original_input_nodes[1]: (op_nodes[0], "qr[1]"),
         }
-        res = digraph.compose(
-            other_digraph, node_map, node_map_func=map_fn, edge_map_func=map_fn
-        )
+        res = digraph.compose(other_digraph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
         self.assertEqual(digraph[res[other_output_nodes[0]]], "qr[0]")
         self.assertEqual(digraph[res[other_output_nodes[1]]], "qr[1]")

--- a/tests/digraph/test_contract_nodes.py
+++ b/tests/digraph/test_contract_nodes.py
@@ -37,18 +37,14 @@ class TestContractNodesCheckCycleSwitch(unittest.TestCase):
          └─►┤c│
             └─┘
         """
-        self.dag.contract_nodes(
-            [self.node_a, self.node_c], self.new_weight, **kwargs
-        )
+        self.dag.contract_nodes([self.node_a, self.node_c], self.new_weight, **kwargs)
 
     def test_cycle_check_enable_local(self):
         # Disable at class level.
         self.dag.check_cycle = False
 
         # Check removal is not allowed with explicit check_cycle=True.
-        self.assertRaises(
-            retworkx.DAGWouldCycle, self.contract, check_cycle=True
-        )
+        self.assertRaises(retworkx.DAGWouldCycle, self.contract, check_cycle=True)
 
     def test_cycle_check_disable_local(self):
         # Enable at class level.

--- a/tests/digraph/test_core_number.py
+++ b/tests/digraph/test_core_number.py
@@ -82,9 +82,7 @@ class TestCoreNumber(unittest.TestCase):
     def test_directed_all_3(self):
         digraph = retworkx.PyDiGraph()
         digraph.add_nodes_from(list(range(4)))
-        digraph.add_edges_from_no_data(
-            [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
-        )
+        digraph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
         res = retworkx.core_number(digraph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/digraph/test_deepcopy.py
+++ b/tests/digraph/test_deepcopy.py
@@ -23,9 +23,7 @@ class TestDeepcopy(unittest.TestCase):
         dag_a.add_child(node_a, "a_2", "a_1")
         dag_a.add_child(node_a, "a_3", "a_2")
         dag_b = copy.deepcopy(dag_a)
-        self.assertTrue(
-            retworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y)
-        )
+        self.assertTrue(retworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y))
 
     def test_deepcopy_with_holes(self):
         dag_a = retworkx.PyDAG()

--- a/tests/digraph/test_depth.py
+++ b/tests/digraph/test_depth.py
@@ -135,9 +135,7 @@ class TestLongestPath(unittest.TestCase):
         )
         self.assertEqual(
             4,
-            retworkx.dag_longest_path_length(
-                dag, weight_fn=lambda _, __, weight: weight
-            ),
+            retworkx.dag_longest_path_length(dag, weight_fn=lambda _, __, weight: weight),
         )
 
     def test_less_linear_with_weight(self):
@@ -152,35 +150,23 @@ class TestLongestPath(unittest.TestCase):
         dag.add_edge(node_c, node_e, 3)
         self.assertEqual(
             6,
-            retworkx.dag_longest_path_length(
-                dag, weight_fn=lambda _, __, weight: weight
-            ),
+            retworkx.dag_longest_path_length(dag, weight_fn=lambda _, __, weight: weight),
         )
         self.assertEqual(
             [node_a, node_c, node_e],
-            retworkx.dag_longest_path(
-                dag, weight_fn=lambda _, __, weight: weight
-            ),
+            retworkx.dag_longest_path(dag, weight_fn=lambda _, __, weight: weight),
         )
 
     def test_degenerate_graph_with_weight(self):
         dag = retworkx.PyDAG()
         dag.add_node(0)
-        self.assertEqual(
-            [0], retworkx.dag_longest_path(dag, weight_fn=weight_fn)
-        )
-        self.assertEqual(
-            0, retworkx.dag_longest_path_length(dag, weight_fn=weight_fn)
-        )
+        self.assertEqual([0], retworkx.dag_longest_path(dag, weight_fn=weight_fn))
+        self.assertEqual(0, retworkx.dag_longest_path_length(dag, weight_fn=weight_fn))
 
     def test_empty_graph_with_weights(self):
         dag = retworkx.PyDAG()
-        self.assertEqual(
-            [], retworkx.dag_longest_path(dag, weight_fn=weight_fn)
-        )
-        self.assertEqual(
-            0, retworkx.dag_longest_path_length(dag, weight_fn=weight_fn)
-        )
+        self.assertEqual([], retworkx.dag_longest_path(dag, weight_fn=weight_fn))
+        self.assertEqual(0, retworkx.dag_longest_path_length(dag, weight_fn=weight_fn))
 
     def test_cycle(self):
         not_a_dag = retworkx.generators.directed_cycle_graph(250)
@@ -218,15 +204,11 @@ class TestWeightedLongestPath(unittest.TestCase):
         node_g = dag.add_child(node_c, "g", 15)
         self.assertEqual(
             23.0,
-            retworkx.dag_weighted_longest_path_length(
-                dag, lambda _, __, weight: float(weight)
-            ),
+            retworkx.dag_weighted_longest_path_length(dag, lambda _, __, weight: float(weight)),
         )
         self.assertEqual(
             [node_a, node_b, node_c, node_g],
-            retworkx.dag_weighted_longest_path(
-                dag, lambda _, __, weight: float(weight)
-            ),
+            retworkx.dag_weighted_longest_path(dag, lambda _, __, weight: float(weight)),
         )
 
     def test_parallel_edges_with_weights(self):
@@ -249,9 +231,7 @@ class TestWeightedLongestPath(unittest.TestCase):
         )
         self.assertEqual(
             [0, 1, 2],
-            retworkx.dag_weighted_longest_path(
-                dag, lambda _, __, weight: float(weight)
-            ),
+            retworkx.dag_weighted_longest_path(dag, lambda _, __, weight: float(weight)),
         )
 
     def test_less_linear_with_weight(self):
@@ -272,9 +252,7 @@ class TestWeightedLongestPath(unittest.TestCase):
         )
         self.assertEqual(
             [node_a, node_c, node_e],
-            retworkx.dag_weighted_longest_path(
-                dag, weight_fn=lambda _, __, weight: float(weight)
-            ),
+            retworkx.dag_weighted_longest_path(dag, weight_fn=lambda _, __, weight: float(weight)),
         )
 
     def test_degenerate_graph_with_weight(self):
@@ -282,30 +260,22 @@ class TestWeightedLongestPath(unittest.TestCase):
         dag.add_node(0)
         self.assertEqual(
             0.0,
-            retworkx.dag_weighted_longest_path_length(
-                dag, lambda x: float(weight_fn(x))
-            ),
+            retworkx.dag_weighted_longest_path_length(dag, lambda x: float(weight_fn(x))),
         )
         self.assertEqual(
             [0],
-            retworkx.dag_weighted_longest_path(
-                dag, lambda x: float(weight_fn(x))
-            ),
+            retworkx.dag_weighted_longest_path(dag, lambda x: float(weight_fn(x))),
         )
 
     def test_empty_graph_with_weights(self):
         dag = retworkx.PyDAG()
         self.assertEqual(
             0.0,
-            retworkx.dag_weighted_longest_path_length(
-                dag, lambda x: float(weight_fn(x))
-            ),
+            retworkx.dag_weighted_longest_path_length(dag, lambda x: float(weight_fn(x))),
         )
         self.assertEqual(
             [],
-            retworkx.dag_weighted_longest_path(
-                dag, lambda x: float(weight_fn(x))
-            ),
+            retworkx.dag_weighted_longest_path(dag, lambda x: float(weight_fn(x))),
         )
 
     def test_nan_not_valid_weight(self):

--- a/tests/digraph/test_dfs_search.py
+++ b/tests/digraph/test_dfs_search.py
@@ -53,9 +53,7 @@ class TestDfsSearch(unittest.TestCase):
 
         vis = TreeEdgesRecorder()
         retworkx.digraph_dfs_search(self.graph, None, vis)
-        self.assertEqual(
-            vis.edges, [(0, 2), (2, 6), (2, 5), (5, 3), (2, 1), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 2), (2, 6), (2, 5), (5, 3), (2, 1), (4, 7)])
 
     def test_digraph_dfs_tree_edges_restricted(self):
         class TreeEdgesRecorderRestricted(retworkx.visit.DFSVisitor):

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -71,9 +71,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_weight_fn(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: x
-        )
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)
         expected = {
             1: [0, 1],
             2: [0, 3, 2],
@@ -84,9 +82,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_with_target(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, target=self.e
-        )
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, target=self.e)
         expected = {
             4: [0, 3, 4],
         }
@@ -102,9 +98,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_path_undirected(self):
-        paths = retworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, as_undirected=True
-        )
+        paths = retworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, as_undirected=True)
         expected = {
             1: [0, 1],
             2: [0, 2],
@@ -150,9 +144,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, paths)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: 1
-        )
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
         expected = {1: 1.0, 2: 2.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
@@ -160,9 +152,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         g = retworkx.PyDiGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: float(x)
-        )
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
@@ -180,9 +170,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         b = g.add_child(a, "B", 1.2)
         g.add_node("C")
         g.add_parent(b, "D", 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: x
-        )
+        path = retworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: x)
         expected = {1: 1.2}
         self.assertEqual(expected, path)
 
@@ -193,9 +181,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
             retworkx.digraph_dijkstra_shortest_path_lengths(g, 0, lambda x: x)
 
     def test_dijkstra_all_pair_path_lengths(self):
-        lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(
-            self.graph, float
-        )
+        lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(self.graph, float)
         expected = {
             0: {1: 7.0, 2: 16.0, 3: 14.0, 4: 23.0, 5: 22.0},
             1: {0: 19.0, 2: 10.0, 3: 33.0, 4: 42.0, 5: 15.0},
@@ -207,9 +193,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.assertEqual(expected, lengths)
 
     def test_dijkstra_all_pair_paths(self):
-        paths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(
-            self.graph, float
-        )
+        paths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(self.graph, float)
         print(paths)
         expected = {
             0: {1: [0, 1], 2: [0, 3, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
@@ -241,9 +225,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_path_lengths_with_node_removal(self):
         self.graph.remove_node(3)
-        lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(
-            self.graph, float
-        )
+        lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(self.graph, float)
         expected = {
             0: {1: 7.0, 2: 17.0, 5: 22.0},
             1: {0: 19.0, 2: 10.0, 5: 15.0},
@@ -255,9 +237,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_paths_with_node_removal(self):
         self.graph.remove_node(3)
-        lengths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(
-            self.graph, float
-        )
+        lengths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(self.graph, float)
         expected = {
             0: {1: [0, 1], 2: [0, 1, 2], 5: [0, 1, 5]},
             1: {0: [1, 2, 0], 2: [1, 2], 5: [1, 5]},
@@ -269,15 +249,11 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_path_lengths_empty_graph(self):
         graph = retworkx.PyDiGraph()
-        self.assertEqual(
-            {}, retworkx.digraph_all_pairs_dijkstra_path_lengths(graph, float)
-        )
+        self.assertEqual({}, retworkx.digraph_all_pairs_dijkstra_path_lengths(graph, float))
 
     def test_dijkstra_all_pair_shortest_paths_empty_graph(self):
         graph = retworkx.PyDiGraph()
-        self.assertEqual(
-            {}, retworkx.digraph_all_pairs_dijkstra_shortest_paths(graph, float)
-        )
+        self.assertEqual({}, retworkx.digraph_all_pairs_dijkstra_shortest_paths(graph, float))
 
     def test_dijkstra_all_pair_path_lengths_graph_no_edges(self):
         graph = retworkx.PyDiGraph()
@@ -301,9 +277,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         graph = retworkx.generators.directed_path_graph(2)
         for invalid_weight in [float("nan"), -1]:
             for as_undirected in [False, True]:
-                with self.subTest(
-                    invalid_weight=invalid_weight, as_undirected=as_undirected
-                ):
+                with self.subTest(invalid_weight=invalid_weight, as_undirected=as_undirected):
                     with self.assertRaises(ValueError):
                         retworkx.digraph_dijkstra_shortest_paths(
                             graph,

--- a/tests/digraph/test_dijkstra_search.py
+++ b/tests/digraph/test_dijkstra_search.py
@@ -67,9 +67,7 @@ class TestDijkstraSearch(unittest.TestCase):
 
         vis = DijkstraTreeEdgesRecorder()
         retworkx.digraph_dijkstra_search(self.graph, None, float, vis)
-        self.assertEqual(
-            vis.edges, [(0, 1), (0, 2), (2, 6), (2, 5), (5, 3), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 1), (0, 2), (2, 6), (2, 5), (5, 3), (4, 7)])
 
     def test_digraph_dijkstra_goal_search_with_stop_search_exception(self):
         class GoalSearch(retworkx.visit.DijkstraVisitor):

--- a/tests/digraph/test_dist_matrix.py
+++ b/tests/digraph/test_dist_matrix.py
@@ -21,9 +21,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph)
         expected = np.array(
             [
@@ -41,9 +39,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_parallel(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5)
         expected = np.array(
             [
@@ -61,9 +57,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_distance_matrix(graph, as_undirected=True)
         expected = np.array(
             [
@@ -81,12 +75,8 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_parallel_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
-        dist = retworkx.digraph_distance_matrix(
-            graph, parallel_threshold=5, as_undirected=True
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        dist = retworkx.digraph_distance_matrix(graph, parallel_threshold=5, as_undirected=True)
         expected = np.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
@@ -103,13 +93,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_non_zero_null(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         graph.add_node(7)
-        dist = retworkx.distance_matrix(
-            graph, as_undirected=True, null_value=np.nan
-        )
+        dist = retworkx.distance_matrix(graph, as_undirected=True, null_value=np.nan)
         expected = np.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0, np.nan],
@@ -127,9 +113,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_digraph_distance_matrix_parallel_non_zero_null(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         graph.add_node(7)
         dist = retworkx.distance_matrix(
             graph, as_undirected=True, parallel_threshold=5, null_value=np.nan

--- a/tests/digraph/test_dot.py
+++ b/tests/digraph/test_dot.py
@@ -47,9 +47,7 @@ class TestDot(unittest.TestCase):
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
             'style=filled];\n0 -> 1 [label="1", name=1];\n}\n'
         )
-        res = graph.to_dot(
-            lambda node: node, lambda edge: edge, filename=self.path
-        )
+        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
         with open(self.path, "r") as fd:
@@ -59,22 +57,17 @@ class TestDot(unittest.TestCase):
     def test_digraph_empty_dicts(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {})
-        self.assertEqual(
-            "digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str
-        )
+        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)
 
     def test_digraph_graph_attrs(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
         self.assertEqual(
-            "digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n"
-            "0 -> 2 ;\n}\n",
+            "digraph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n" "0 -> 2 ;\n}\n",
             dot_str,
         )
 
     def test_digraph_no_args(self):
         graph = retworkx.directed_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual(
-            "digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str
-        )
+        self.assertEqual("digraph {\n0 ;\n1 ;\n2 ;\n0 -> 1 ;\n0 -> 2 ;\n}\n", dot_str)

--- a/tests/digraph/test_edgelist.py
+++ b/tests/digraph/test_edgelist.py
@@ -104,9 +104,7 @@ class TestEdgeList(unittest.TestCase):
             fd.write("1|2|1\n")
             fd.write("//2|3\n")
             fd.flush()
-            graph = retworkx.PyDiGraph.read_edge_list(
-                fd.name, comment="//", deliminator="|"
-            )
+            graph = retworkx.PyDiGraph.read_edge_list(fd.name, comment="//", deliminator="|")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -36,9 +36,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.get_edge_data, node_a, node_b)
 
     def test_num_edges(self):
         graph = retworkx.PyDiGraph()
@@ -65,9 +63,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, dag.update_edge, node_a, node_b, None
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.update_edge, node_a, node_b, None)
 
     def test_update_edge_by_index(self):
         dag = retworkx.PyDAG()
@@ -141,9 +137,7 @@ class TestEdges(unittest.TestCase):
         dag = retworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, dag.remove_edge, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, dag.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         dag = retworkx.PyDAG()
@@ -198,9 +192,7 @@ class TestEdges(unittest.TestCase):
         dag.check_cycle = True
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", {})
-        self.assertRaises(
-            retworkx.DAGWouldCycle, dag.add_edge, node_b, node_a, {}
-        )
+        self.assertRaises(retworkx.DAGWouldCycle, dag.add_edge, node_b, node_a, {})
 
     def test_add_edge_with_cycle_check_enabled(self):
         dag = retworkx.PyDAG(True)
@@ -375,9 +367,7 @@ class TestEdges(unittest.TestCase):
         node_b = dag.add_child(node_a, "b", {})
         node_c = dag.add_child(node_b, "c", {})
         with self.assertRaises(retworkx.DAGWouldCycle):
-            dag.extend_from_weighted_edge_list(
-                [(node_a, node_c, {}), (node_c, node_b, {})]
-            )
+            dag.extend_from_weighted_edge_list([(node_a, node_c, {}), (node_c, node_b, {})])
 
     def test_extend_from_edge_list_nodes_exist(self):
         dag = retworkx.PyDiGraph()
@@ -460,9 +450,7 @@ class TestEdges(unittest.TestCase):
         in_node_1 = graph.add_node("qr[1]")
         out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
         cx_gate = graph.add_node("cx")
-        graph.insert_node_on_in_edges_multiple(
-            cx_gate, [out_node_0, out_node_1]
-        )
+        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
         self.assertEqual(
             {
                 (in_node_0, cx_gate, "qr[0]"),
@@ -498,12 +486,8 @@ class TestEdges(unittest.TestCase):
         out_node_1 = graph.add_child(in_node_1, "qr[1]", "qr[1]")
         cx_gate = graph.add_node("cx")
         cz_gate = graph.add_node("cz")
-        graph.insert_node_on_in_edges_multiple(
-            cx_gate, [out_node_0, out_node_1]
-        )
-        graph.insert_node_on_in_edges_multiple(
-            cz_gate, [out_node_0, out_node_1]
-        )
+        graph.insert_node_on_in_edges_multiple(cx_gate, [out_node_0, out_node_1])
+        graph.insert_node_on_in_edges_multiple(cz_gate, [out_node_0, out_node_1])
         self.assertEqual(
             {
                 (in_node_0, cx_gate, "qr[0]"),
@@ -782,17 +766,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyDiGraph(multigraph=False)
@@ -833,9 +813,7 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyDiGraph(multigraph=False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyDiGraph(multigraph=False)

--- a/tests/digraph/test_floyd_warshall.py
+++ b/tests/digraph/test_floyd_warshall.py
@@ -97,9 +97,7 @@ class TestFloydWarshall(unittest.TestCase):
         ]
         graph.add_edges_from(edge_list)
 
-        dijkstra_lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(
-            graph, float
-        )
+        dijkstra_lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(graph, float)
 
         expected = {k: {**v, k: 0.0} for k, v in dijkstra_lengths.items()}
 
@@ -131,9 +129,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph.add_edges_from(edge_list)
         graph.remove_node(d)
 
-        dijkstra_lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(
-            graph, float
-        )
+        dijkstra_lengths = retworkx.digraph_all_pairs_dijkstra_path_lengths(graph, float)
 
         expected = {k: {**v, k: 0.0} for k, v in dijkstra_lengths.items()}
 
@@ -159,9 +155,7 @@ class TestFloydWarshall(unittest.TestCase):
     def test_directed_floyd_warshall_cycle_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_floyd_warshall(
             graph,
             lambda _: 1,
@@ -182,12 +176,8 @@ class TestFloydWarshall(unittest.TestCase):
     def test_directed_floyd_warshall_numpy_cycle_as_undirected(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
-        dist = retworkx.digraph_floyd_warshall_numpy(
-            graph, lambda x: 1, as_undirected=True
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        dist = retworkx.digraph_floyd_warshall_numpy(graph, lambda x: 1, as_undirected=True)
         expected = numpy.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0],
@@ -237,9 +227,7 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_digraph_cycle(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -274,9 +262,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -287,9 +273,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 4)
@@ -298,9 +282,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.digraph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -23,9 +23,7 @@ class TestIsomorphic(unittest.TestCase):
 
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
 
     def test_empty_isomorphic_compare_nodes(self):
         dag_a = retworkx.PyDAG()
@@ -34,9 +32,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_identical(self):
@@ -52,9 +48,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
 
     def test_isomorphic_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
@@ -69,9 +63,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "b_3", "b_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(dag_a, dag_b, id_order=id_order))
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         dag_a = retworkx.PyDAG()
@@ -87,9 +79,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_is_isomorphic_nodes_compare_raises(self):
@@ -107,9 +97,7 @@ class TestIsomorphic(unittest.TestCase):
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(
-            TypeError, retworkx.is_isomorphic, (dag_a, dag_b, compare_nodes)
-        )
+        self.assertRaises(TypeError, retworkx.is_isomorphic, (dag_a, dag_b, compare_nodes))
 
     def test_isomorphic_compare_nodes_identical(self):
         dag_a = retworkx.PyDAG()
@@ -125,9 +113,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_compare_edges_identical(self):
@@ -192,9 +178,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        dag_a, dag_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_compare_nodes_with_removals_deepcopy(self):
@@ -247,14 +231,8 @@ class TestIsomorphic(unittest.TestCase):
 
     def test_digraph_isomorphic_parallel_edges_with_edge_matcher(self):
         graph = retworkx.PyDiGraph()
-        graph.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "b"), (1, 2, "c")]
-        )
-        self.assertTrue(
-            retworkx.is_isomorphic(
-                graph, graph, edge_matcher=lambda x, y: x == y
-            )
-        )
+        graph.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "b"), (1, 2, "c")])
+        self.assertTrue(retworkx.is_isomorphic(graph, graph, edge_matcher=lambda x, y: x == y))
 
     def test_digraph_isomorphic_self_loop(self):
         graph = retworkx.PyDiGraph()
@@ -270,9 +248,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph.add_nodes_from([0])
         second_graph.add_edges_from([(0, 0, "b")])
         self.assertFalse(
-            retworkx.is_isomorphic(
-                graph, second_graph, edge_matcher=lambda x, y: x == y
-            )
+            retworkx.is_isomorphic(graph, second_graph, edge_matcher=lambda x, y: x == y)
         )
 
     def test_digraph_non_isomorphic_rule_out_incoming(self):
@@ -282,9 +258,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = retworkx.PyDiGraph()
         second_graph.add_nodes_from([0, 1, 2, 3])
         second_graph.add_edges_from_no_data([(0, 1), (0, 2), (3, 1)])
-        self.assertFalse(
-            retworkx.is_isomorphic(graph, second_graph, id_order=True)
-        )
+        self.assertFalse(retworkx.is_isomorphic(graph, second_graph, id_order=True))
 
     def test_digraph_non_isomorphic_rule_ins_outgoing(self):
         graph = retworkx.PyDiGraph()
@@ -293,9 +267,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = retworkx.PyDiGraph()
         second_graph.add_nodes_from([0, 1, 2, 3])
         second_graph.add_edges_from_no_data([(1, 0), (2, 0), (1, 3)])
-        self.assertFalse(
-            retworkx.is_isomorphic(graph, second_graph, id_order=True)
-        )
+        self.assertFalse(retworkx.is_isomorphic(graph, second_graph, id_order=True))
 
     def test_digraph_non_isomorphic_rule_ins_incoming(self):
         graph = retworkx.PyDiGraph()
@@ -304,9 +276,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = retworkx.PyDiGraph()
         second_graph.add_nodes_from([0, 1, 2, 3])
         second_graph.add_edges_from_no_data([(1, 0), (2, 0), (3, 1)])
-        self.assertFalse(
-            retworkx.is_isomorphic(graph, second_graph, id_order=True)
-        )
+        self.assertFalse(retworkx.is_isomorphic(graph, second_graph, id_order=True))
 
     def test_isomorphic_parallel_edges(self):
         first = retworkx.PyDiGraph()
@@ -344,9 +314,7 @@ class TestIsomorphic(unittest.TestCase):
     def test_digraph_vf2_mapping_identical_vf2pp(self):
         graph = retworkx.generators.directed_grid_graph(2, 2)
         second_graph = retworkx.generators.directed_grid_graph(2, 2)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual(next(mapping), {0: 0, 1: 1, 2: 2, 3: 3})
 
     def test_digraph_vf2_mapping_identical_removals_vf2pp(self):
@@ -354,9 +322,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = retworkx.generators.directed_path_graph(4)
         second_graph.remove_nodes_from([1, 2])
         second_graph.add_edge(0, 3, None)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual({0: 0, 1: 3}, next(mapping))
 
     def test_digraph_vf2_mapping_identical_removals_first_vf2pp(self):
@@ -364,9 +330,7 @@ class TestIsomorphic(unittest.TestCase):
         graph = retworkx.generators.directed_path_graph(4)
         graph.remove_nodes_from([1, 2])
         graph.add_edge(0, 3, None)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual({0: 0, 3: 1}, next(mapping))
 
     def test_digraph_vf2_number_of_valid_mappings(self):
@@ -382,7 +346,5 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyDiGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                mapping = retworkx.digraph_vf2_mapping(
-                    g_a, g_b, id_order=id_order, subgraph=False
-                )
+                mapping = retworkx.digraph_vf2_mapping(g_a, g_b, id_order=id_order, subgraph=False)
                 self.assertEqual({}, next(mapping))

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -61,9 +61,7 @@ class TestKShortestpath(unittest.TestCase):
                 (7, 5),
             ]
         )
-        res = retworkx.digraph_k_shortest_path_lengths(
-            graph, 1, 2, lambda _: 1, 3
-        )
+        res = retworkx.digraph_k_shortest_path_lengths(graph, 1, 2, lambda _: 1, 3)
         self.assertEqual(res, {3: 6})
 
     def test_digraph_k_shortest_path_with_goal_node_hole(self):

--- a/tests/digraph/test_layout.py
+++ b/tests/digraph/test_layout.py
@@ -22,10 +22,7 @@ class LayoutTest(unittest.TestCase):
         for k in exp:
             ev = exp[k]
             rv = res[k]
-            if (
-                abs(ev[0] - rv[0]) > self.thres
-                or abs(ev[1] - rv[1]) > self.thres
-            ):
+            if abs(ev[0] - rv[0]) > self.thres or abs(ev[1] - rv[1]) > self.thres:
                 self.fail(
                     "The position for node %s, %s, differs from the expected "
                     "position, %s by more than the allowed threshold of %s"
@@ -54,9 +51,7 @@ class TestRandomLayout(LayoutTest):
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.digraph_random_layout(
-            self.graph, center=(0.5, 0.5), seed=42
-        )
+        res = retworkx.digraph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],
@@ -117,9 +112,7 @@ class TestBipartiteLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_bipartite_layout_horizontal(self):
-        res = retworkx.bipartite_layout(
-            self.graph, {0, 1, 2, 3}, horizontal=True
-        )
+        res = retworkx.bipartite_layout(self.graph, {0, 1, 2, 3}, horizontal=True)
         expected = {
             0: (1.0, -0.9),
             1: (0.3333333333333333, -0.9),
@@ -151,9 +144,7 @@ class TestBipartiteLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_bipartite_layout_center(self):
-        res = retworkx.bipartite_layout(
-            self.graph, {4, 5, 6}, center=(0.5, 0.5)
-        )
+        res = retworkx.bipartite_layout(self.graph, {4, 5, 6}, center=(0.5, 0.5))
         expected = {
             4: (-0.5, -0.0357142857142857),
             5: (-0.5, 0.5),
@@ -194,9 +185,7 @@ class TestCircularLayout(LayoutTest):
         self.assertEqual({}, res)
 
     def test_circular_layout_one_node(self):
-        res = retworkx.circular_layout(
-            retworkx.generators.directed_path_graph(1)
-        )
+        res = retworkx.circular_layout(retworkx.generators.directed_path_graph(1))
         self.assertEqual({0: (0.0, 0.0)}, res)
 
     def test_circular_layout_hole(self):
@@ -313,9 +302,7 @@ class TestShellLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_shell_layout_nlist(self):
-        res = retworkx.shell_layout(
-            self.graph, nlist=[[0, 2], [1, 3], [4, 9], [8, 7], [6, 5]]
-        )
+        res = retworkx.shell_layout(self.graph, nlist=[[0, 2], [1, 3], [4, 9], [8, 7], [6, 5]])
         expected = {
             0: (0.16180340945720673, 0.11755704879760742),
             2: (-0.16180339455604553, -0.11755707114934921),
@@ -349,9 +336,7 @@ class TestShellLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_shell_layout_scale(self):
-        res = retworkx.shell_layout(
-            self.graph, nlist=[[0, 1, 2, 3, 4], [9, 8, 7, 6, 5]], scale=2
-        )
+        res = retworkx.shell_layout(self.graph, nlist=[[0, 1, 2, 3, 4], [9, 8, 7, 6, 5]], scale=2)
         expected = {
             0: (-4.371138828673793e-08, 1.0),
             1: (-0.9510565996170044, 0.30901679396629333),

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -155,9 +155,7 @@ class TestNodes(unittest.TestCase):
         dag.add_edge(node_b, node_d, "Multiple out edgy")
         dag.add_edge(node_e, node_b, "multiple in edgy")
         node_c = dag.add_child(node_b, "c", "Edgy_mk2")
-        dag.remove_node_retain_edges(
-            node_b, condition=lambda a, b: a == "multiple in edgy"
-        )
+        dag.remove_node_retain_edges(node_b, condition=lambda a, b: a == "multiple in edgy")
         res = dag.nodes()
         self.assertEqual(["a", "d", "e", "c"], res)
         self.assertEqual([0, 1, 2, 4], dag.node_indexes())
@@ -243,9 +241,7 @@ class TestNodes(unittest.TestCase):
         cr_1_out = dag.add_node("cr[1]_out")
         dag.add_edge(cr_1, cr_1_out, "cr[1]")
 
-        res = list(
-            retworkx.lexicographical_topological_sort(dag, lambda x: str(x))
-        )
+        res = list(retworkx.lexicographical_topological_sort(dag, lambda x: str(x)))
         expected = [
             "cr[0]",
             "cr[0]_out",
@@ -383,9 +379,7 @@ class TestNodes(unittest.TestCase):
         graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 1)
         self.assertEqual(graph.node_indexes(), [1, 2, 3])
-        self.assertEqual(
-            [(3, 1, "edge1"), (1, 2, "edge0")], graph.weighted_edge_list()
-        )
+        self.assertEqual([(3, 1, "edge1"), (1, 2, "edge0")], graph.weighted_edge_list())
 
     def test_merge_nodes_no_match(self):
         graph = retworkx.PyDiGraph()
@@ -394,9 +388,7 @@ class TestNodes(unittest.TestCase):
         graph.add_edge(3, 0, "edge1")
         graph.merge_nodes(0, 2)
         self.assertEqual(graph.node_indexes(), [0, 1, 2, 3])
-        self.assertEqual(
-            [(0, 2, "edge0"), (3, 0, "edge1")], graph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 2, "edge0"), (3, 0, "edge1")], graph.weighted_edge_list())
 
     def test_merge_nodes_invalid_node_first_index(self):
         graph = retworkx.PyDiGraph()

--- a/tests/digraph/test_pred_succ.py
+++ b/tests/digraph/test_pred_succ.py
@@ -106,13 +106,9 @@ class TestFindPredecessorsByEdge(unittest.TestCase):
         dag.add_child(node_a, "b", {"a": 1})
         node_c = dag.add_child(node_a, "c", {"a": 2})
 
-        res_even = dag.find_predecessors_by_edge(
-            node_c, lambda x: x["a"] % 2 == 0
-        )
+        res_even = dag.find_predecessors_by_edge(node_c, lambda x: x["a"] % 2 == 0)
 
-        res_odd = dag.find_predecessors_by_edge(
-            node_c, lambda x: x["a"] % 2 != 0
-        )
+        res_odd = dag.find_predecessors_by_edge(node_c, lambda x: x["a"] % 2 != 0)
 
         self.assertEqual(["a"], res_even)
         self.assertEqual([], res_odd)
@@ -124,13 +120,9 @@ class TestFindPredecessorsByEdge(unittest.TestCase):
         node_c = dag.add_child(node_a, "c", {"a": 2})
         dag.add_edge(node_a, node_c, {"a": 3})
 
-        res_even = dag.find_predecessors_by_edge(
-            node_c, lambda x: x["a"] % 2 == 0
-        )
+        res_even = dag.find_predecessors_by_edge(node_c, lambda x: x["a"] % 2 == 0)
 
-        res_odd = dag.find_predecessors_by_edge(
-            node_c, lambda x: x["a"] % 2 == 0
-        )
+        res_odd = dag.find_predecessors_by_edge(node_c, lambda x: x["a"] % 2 == 0)
 
         self.assertEqual(["a"], res_even)
         self.assertEqual(["a"], res_odd)
@@ -141,13 +133,9 @@ class TestFindPredecessorsByEdge(unittest.TestCase):
         for i in range(10):
             dag.add_parent(node_a, {"numeral": i}, {"edge": i})
 
-        res_even = dag.find_predecessors_by_edge(
-            node_a, lambda x: x["edge"] % 2 == 0
-        )
+        res_even = dag.find_predecessors_by_edge(node_a, lambda x: x["edge"] % 2 == 0)
 
-        res_odd = dag.find_predecessors_by_edge(
-            node_a, lambda x: x["edge"] % 2 != 0
-        )
+        res_odd = dag.find_predecessors_by_edge(node_a, lambda x: x["edge"] % 2 != 0)
 
         self.assertEqual(
             [
@@ -188,9 +176,7 @@ class TestFindSuccessorsByEdge(unittest.TestCase):
         node_c = dag.add_child(node_b, "c", {"a": 2})
         dag.add_child(node_c, "d", {"a": 1})
 
-        res_even = dag.find_successors_by_edge(
-            node_b, lambda x: x["a"] % 2 == 0
-        )
+        res_even = dag.find_successors_by_edge(node_b, lambda x: x["a"] % 2 == 0)
         res_odd = dag.find_successors_by_edge(node_b, lambda x: x["a"] % 2 != 0)
 
         self.assertEqual(["c"], res_even)
@@ -204,9 +190,7 @@ class TestFindSuccessorsByEdge(unittest.TestCase):
         dag.add_child(node_c, "d", {"a": 1})
         dag.add_edge(node_b, node_c, {"a": 3})
 
-        res_even = dag.find_successors_by_edge(
-            node_b, lambda x: x["a"] % 2 == 0
-        )
+        res_even = dag.find_successors_by_edge(node_b, lambda x: x["a"] % 2 == 0)
         res_odd = dag.find_successors_by_edge(node_b, lambda x: x["a"] % 2 != 0)
 
         self.assertEqual(["c"], res_even)
@@ -218,13 +202,9 @@ class TestFindSuccessorsByEdge(unittest.TestCase):
         for i in range(10):
             dag.add_child(node_a, {"numeral": i}, {"edge": i})
 
-        res_even = dag.find_successors_by_edge(
-            node_a, lambda x: x["edge"] % 2 == 0
-        )
+        res_even = dag.find_successors_by_edge(node_a, lambda x: x["edge"] % 2 == 0)
 
-        res_odd = dag.find_successors_by_edge(
-            node_a, lambda x: x["edge"] % 2 != 0
-        )
+        res_odd = dag.find_successors_by_edge(node_a, lambda x: x["edge"] % 2 != 0)
 
         self.assertEqual(
             [

--- a/tests/digraph/test_subgraph.py
+++ b/tests/digraph/test_subgraph.py
@@ -57,9 +57,7 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual(
-            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0]["a"] = 4
         self.assertEqual(subgraph[0]["a"], 4)
@@ -72,9 +70,7 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual(
-            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
         self.assertEqual(subgraph[0]["a"], 0)
@@ -105,9 +101,7 @@ class TestSubgraph(unittest.TestCase):
         )
         subgraph = graph.edge_subgraph([(0, 1), (1, 2)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
-        self.assertEqual(
-            [(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())
 
     def test_edge_subgraph_empty_list(self):
         graph = retworkx.PyDiGraph()
@@ -141,6 +135,4 @@ class TestSubgraph(unittest.TestCase):
         # 1->3 isn't an edge in graph
         subgraph = graph.edge_subgraph([(0, 1), (1, 2), (1, 3)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
-        self.assertEqual(
-            [(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -20,18 +20,14 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_a = retworkx.PyDiGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order))
 
     def test_empty_subgraph_isomorphic(self):
         g_a = retworkx.PyDiGraph()
         g_b = retworkx.PyDiGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_empty_subgraph_isomorphic_compare_nodes(self):
         g_a = retworkx.PyDiGraph()
@@ -47,14 +43,10 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_subgraph_isomorphic_identical(self):
         g_a = retworkx.PyDiGraph()
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order))
 
     def test_subgraph_isomorphic_mismatch_node_data(self):
         g_a = retworkx.PyDiGraph()
@@ -70,14 +62,10 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_subgraph_isomorphic_compare_nodes_mismatch_node_data(self):
         g_a = retworkx.PyDiGraph()
@@ -93,9 +81,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
@@ -118,9 +104,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
@@ -132,9 +116,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_is_subgraph_isomorphic_nodes_compare_raises(self):
         g_a = retworkx.PyDiGraph()
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
@@ -159,9 +141,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
@@ -184,15 +164,11 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b.add_edges_from([(nodes[0], nodes[1], "a_1")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertFalse(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_subgraph_isomorphic_edge_matcher(self):
         first = retworkx.PyDiGraph()
-        first.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (1, 2, "b"), (2, 0, "c")]
-        )
+        first.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b"), (2, 0, "c")])
         second = retworkx.PyDiGraph()
         second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
 
@@ -204,13 +180,9 @@ class TestSubgraphIsomorphic(unittest.TestCase):
 
     def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
         first = retworkx.PyDiGraph()
-        first.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")]
-        )
+        first.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")])
         second = retworkx.PyDiGraph()
-        second.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "a"), (1, 2, "b")]
-        )
+        second.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "a"), (1, 2, "b")])
 
         self.assertFalse(
             retworkx.is_subgraph_isomorphic(
@@ -232,21 +204,15 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order, induced=True):
                 self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(
-                        g_a, g_b, id_order=id_order, induced=True
-                    )
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order, induced=True)
                 )
             with self.subTest(id_order=id_order, induced=False):
                 self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(
-                        g_a, g_b, id_order=id_order, induced=False
-                    )
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order, induced=False)
                 )
 
     def test_non_induced_grid_subgraph_isomorphic(self):
@@ -255,37 +221,27 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b.add_nodes_from([0, 1, 2, 3])
         g_b.add_edges_from_no_data([(0, 1), (2, 3)])
 
-        self.assertFalse(
-            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True)
-        )
+        self.assertFalse(retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True))
 
-        self.assertTrue(
-            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False)
-        )
+        self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False))
 
     def test_subgraph_vf2_mapping(self):
         graph = retworkx.generators.directed_grid_graph(10, 10)
         second_graph = retworkx.generators.directed_grid_graph(2, 2)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, subgraph=True
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, subgraph=True)
         self.assertEqual(next(mapping), {0: 0, 1: 1, 10: 2, 11: 3})
 
     def test_subgraph_vf2_all_mappings(self):
         graph = retworkx.generators.directed_path_graph(3)
         second_graph = retworkx.generators.directed_path_graph(2)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=True
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, subgraph=True, id_order=True)
         self.assertEqual(next(mapping), {0: 0, 1: 1})
         self.assertEqual(next(mapping), {2: 1, 1: 0})
 
     def test_subgraph_vf2_mapping_vf2pp(self):
         graph = retworkx.generators.directed_grid_graph(3, 3)
         second_graph = retworkx.generators.directed_grid_graph(2, 2)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=False
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, subgraph=True, id_order=False)
         self.assertEqual(next(mapping), {4: 0, 5: 1, 7: 2, 8: 3})
 
     def test_vf2pp_remapping(self):
@@ -298,9 +254,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         graph.remove_node(dummy)
 
         second_graph = retworkx.generators.directed_grid_graph(2, 2)
-        mapping = retworkx.digraph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=False
-        )
+        mapping = retworkx.digraph_vf2_mapping(graph, second_graph, subgraph=True, id_order=False)
         self.assertEqual(next(mapping), {5: 0, 6: 1, 8: 2, 9: 3})
 
     def test_empty_digraph_subgraph_vf2_mapping(self):
@@ -308,7 +262,5 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b = retworkx.PyDiGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                mapping = retworkx.digraph_vf2_mapping(
-                    g_a, g_b, id_order=id_order, subgraph=True
-                )
+                mapping = retworkx.digraph_vf2_mapping(g_a, g_b, id_order=id_order, subgraph=True)
                 self.assertEqual({}, next(mapping))

--- a/tests/digraph/test_substitute_node_with_subgraph.py
+++ b/tests/digraph/test_substitute_node_with_subgraph.py
@@ -21,9 +21,7 @@ class TestSubstitute(unittest.TestCase):
 
     def test_empty_replacement(self):
         in_graph = retworkx.PyDiGraph()
-        res = self.graph.substitute_node_with_subgraph(
-            2, in_graph, lambda _, __, ___: None
-        )
+        res = self.graph.substitute_node_with_subgraph(2, in_graph, lambda _, __, ___: None)
         self.assertEqual(res, {})
         self.assertEqual([(0, 1), (3, 4)], self.graph.edge_list())
 
@@ -31,12 +29,8 @@ class TestSubstitute(unittest.TestCase):
         in_graph = retworkx.PyDiGraph()
         in_graph.add_node(0)
         in_graph.add_child(0, 1, "edge")
-        res = self.graph.substitute_node_with_subgraph(
-            2, in_graph, lambda _, __, ___: 0
-        )
-        self.assertEqual(
-            [(0, 1), (3, 4), (5, 6), (1, 5), (5, 3)], self.graph.edge_list()
-        )
+        res = self.graph.substitute_node_with_subgraph(2, in_graph, lambda _, __, ___: 0)
+        self.assertEqual([(0, 1), (3, 4), (5, 6), (1, 5), (5, 3)], self.graph.edge_list())
         self.assertEqual("edge", self.graph.get_edge_data(5, 6))
         self.assertEqual(res, {0: 5, 1: 6})
 
@@ -50,9 +44,7 @@ class TestSubstitute(unittest.TestCase):
             lambda _, __, ___: 0,
             node_filter=lambda node: node == 0,
         )
-        self.assertEqual(
-            [(0, 1), (3, 4), (1, 5), (5, 3)], self.graph.edge_list()
-        )
+        self.assertEqual([(0, 1), (3, 4), (1, 5), (5, 3)], self.graph.edge_list())
         self.assertEqual(res, {0: 5})
 
     def test_edge_weight_modifier(self):
@@ -65,9 +57,7 @@ class TestSubstitute(unittest.TestCase):
             lambda _, __, ___: 0,
             edge_weight_map=lambda edge: edge + "-migrated",
         )
-        self.assertEqual(
-            [(0, 1), (3, 4), (5, 6), (1, 5), (5, 3)], self.graph.edge_list()
-        )
+        self.assertEqual([(0, 1), (3, 4), (5, 6), (1, 5), (5, 3)], self.graph.edge_list())
         self.assertEqual("edge-migrated", self.graph.get_edge_data(5, 6))
         self.assertEqual(res, {0: 5, 1: 6})
 
@@ -75,9 +65,7 @@ class TestSubstitute(unittest.TestCase):
         in_graph = retworkx.PyDiGraph()
         in_graph.add_node(0)
         in_graph.add_child(0, 1, "edge")
-        res = self.graph.substitute_node_with_subgraph(
-            2, in_graph, lambda _, __, ___: None
-        )
+        res = self.graph.substitute_node_with_subgraph(2, in_graph, lambda _, __, ___: None)
         self.assertEqual([(0, 1), (3, 4), (5, 6)], self.graph.edge_list())
         self.assertEqual(res, {0: 5, 1: 6})
 
@@ -97,9 +85,7 @@ class TestSubstitute(unittest.TestCase):
 
     def test_multiple_mapping_full(self):
         graph = retworkx.generators.directed_star_graph(5)
-        in_graph = retworkx.generators.directed_star_graph(
-            weights=list(range(3)), inward=True
-        )
+        in_graph = retworkx.generators.directed_star_graph(weights=list(range(3)), inward=True)
         in_graph.add_edge(1, 2, None)
 
         def map_function(source, target, _weight):
@@ -113,9 +99,7 @@ class TestSubstitute(unittest.TestCase):
         def map_weight(_):
             return "migrated"
 
-        res = graph.substitute_node_with_subgraph(
-            0, in_graph, map_function, filter_fn, map_weight
-        )
+        res = graph.substitute_node_with_subgraph(0, in_graph, map_function, filter_fn, map_weight)
         self.assertEqual({1: 5, 2: 6}, res)
         expected = [
             (5, 6, "migrated"),
@@ -129,9 +113,7 @@ class TestSubstitute(unittest.TestCase):
     def test_invalid_target(self):
         in_graph = retworkx.generators.directed_grid_graph(5, 5)
         with self.assertRaises(IndexError):
-            self.graph.substitute_node_with_subgraph(
-                0, in_graph, lambda *args: 42
-            )
+            self.graph.substitute_node_with_subgraph(0, in_graph, lambda *args: 42)
 
     def test_invalid_target_both_directions(self):
         graph = retworkx.generators.directed_star_graph(4, inward=True)
@@ -145,15 +127,11 @@ class TestSubstitute(unittest.TestCase):
     def test_invalid_node_id(self):
         in_graph = retworkx.generators.directed_grid_graph(5, 5)
         with self.assertRaises(IndexError):
-            self.graph.substitute_node_with_subgraph(
-                16, in_graph, lambda *args: None
-            )
+            self.graph.substitute_node_with_subgraph(16, in_graph, lambda *args: None)
 
     def test_bidrectional(self):
         graph = retworkx.generators.directed_path_graph(5, bidirectional=True)
-        in_graph = retworkx.generators.directed_star_graph(
-            5, bidirectional=True
-        )
+        in_graph = retworkx.generators.directed_star_graph(5, bidirectional=True)
 
         def map_function(source, target, _weight):
             if source != 2:

--- a/tests/digraph/test_to_undirected.py
+++ b/tests/digraph/test_to_undirected.py
@@ -24,18 +24,14 @@ class TestToUndirected(unittest.TestCase):
     def test_single_direction_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         graph = digraph.to_undirected()
-        self.assertEqual(
-            digraph.weighted_edge_list(), graph.weighted_edge_list()
-        )
+        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
 
     def test_bidirectional_graph(self):
         digraph = retworkx.generators.directed_path_graph(5)
         for i in range(0, 4):
             digraph.add_edge(i + 1, i, None)
         graph = digraph.to_undirected()
-        self.assertEqual(
-            digraph.weighted_edge_list(), graph.weighted_edge_list()
-        )
+        self.assertEqual(digraph.weighted_edge_list(), graph.weighted_edge_list())
 
     def test_bidirectional_not_multigraph(self):
         digraph = retworkx.generators.directed_path_graph(5)
@@ -48,9 +44,7 @@ class TestToUndirected(unittest.TestCase):
         digraph = retworkx.PyDiGraph()
         digraph.add_nodes_from([0, 1])
         digraph.add_edges_from([(0, 1, "a"), (0, 1, "b")])
-        graph = digraph.to_undirected(
-            multigraph=False, weight_combo_fn=lambda x, y: x + y
-        )
+        graph = digraph.to_undirected(multigraph=False, weight_combo_fn=lambda x, y: x + y)
         self.assertEqual(graph.weighted_edge_list(), [(0, 1, "ab")])
 
     def test_shared_ref(self):

--- a/tests/digraph/test_transitivity.py
+++ b/tests/digraph/test_transitivity.py
@@ -33,9 +33,7 @@ class TestTransitivity(unittest.TestCase):
     def test_transitivity_fulltriangle_directed(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(3)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)])
         res = retworkx.transitivity(graph)
         self.assertEqual(res, 1.0)
 

--- a/tests/digraph/test_union.py
+++ b/tests/digraph/test_union.py
@@ -75,9 +75,7 @@ class TestUnion(unittest.TestCase):
         nodes = second.add_nodes_from([0, 1])
         second.add_edges_from([(nodes[0], nodes[1], "b")])
 
-        final = retworkx.digraph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.digraph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 1, "b")])
 
     def test_union_node_hole(self):
@@ -91,9 +89,7 @@ class TestUnion(unittest.TestCase):
         second.add_edges_from([(nodes[0], nodes[1], "a")])
         second.remove_node(dummy)
 
-        final = retworkx.digraph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.digraph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])
 
     def test_union_edge_between_merged_and_unmerged_nodes(self):
@@ -105,7 +101,5 @@ class TestUnion(unittest.TestCase):
         nodes = second.add_nodes_from([0, 2])
         second.add_edges_from([(nodes[0], nodes[1], "b")])
 
-        final = retworkx.digraph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.digraph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 2, "b")])

--- a/tests/generators/test_binomial_tree.py
+++ b/tests/generators/test_binomial_tree.py
@@ -43,14 +43,12 @@ class TestBinomialTreeGraph(unittest.TestCase):
         for n in range(5):
             with self.subTest(n=n):
                 graph = retworkx.generators.binomial_tree_graph(n)
-                self.assertEqual(len(graph), 2 ** n)
-                self.assertEqual(len(graph.edges()), 2 ** n - 1)
+                self.assertEqual(len(graph), 2**n)
+                self.assertEqual(len(graph.edges()), 2**n - 1)
                 self.assertEqual(list(graph.edge_list()), expected_edges[n])
 
     def test_binomial_tree_graph_weights(self):
-        graph = retworkx.generators.binomial_tree_graph(
-            2, weights=list(range(4))
-        )
+        graph = retworkx.generators.binomial_tree_graph(2, weights=list(range(4)))
         expected_edges = [(0, 1), (2, 3), (0, 2)]
         self.assertEqual(len(graph), 4)
         self.assertEqual([x for x in range(4)], graph.nodes())
@@ -58,9 +56,7 @@ class TestBinomialTreeGraph(unittest.TestCase):
         self.assertEqual(list(graph.edge_list()), expected_edges)
 
     def test_binomial_tree_graph_weight_less_nodes(self):
-        graph = retworkx.generators.binomial_tree_graph(
-            2, weights=list(range(2))
-        )
+        graph = retworkx.generators.binomial_tree_graph(2, weights=list(range(2)))
         self.assertEqual(len(graph), 4)
         expected_weights = [x for x in range(2)]
         expected_weights.extend([None, None])
@@ -103,22 +99,18 @@ class TestBinomialTreeGraph(unittest.TestCase):
         for n in range(5):
             with self.subTest(n=n):
                 graph = retworkx.generators.directed_binomial_tree_graph(n)
-                self.assertEqual(len(graph), 2 ** n)
-                self.assertEqual(len(graph.edges()), 2 ** n - 1)
+                self.assertEqual(len(graph), 2**n)
+                self.assertEqual(len(graph.edges()), 2**n - 1)
                 self.assertEqual(list(graph.edge_list()), expected_edges[n])
 
     def test_directed_binomial_tree_graph_weights(self):
-        graph = retworkx.generators.directed_binomial_tree_graph(
-            2, weights=list(range(4))
-        )
+        graph = retworkx.generators.directed_binomial_tree_graph(2, weights=list(range(4)))
         self.assertEqual(len(graph), 4)
         self.assertEqual([x for x in range(4)], graph.nodes())
         self.assertEqual(len(graph.edges()), 3)
 
     def test_directed_binomial_tree_graph_weight_less_nodes(self):
-        graph = retworkx.generators.directed_binomial_tree_graph(
-            2, weights=list(range(2))
-        )
+        graph = retworkx.generators.directed_binomial_tree_graph(2, weights=list(range(2)))
         self.assertEqual(len(graph), 4)
         expected_weights = [x for x in range(2)]
         expected_weights.extend([None, None])
@@ -127,15 +119,11 @@ class TestBinomialTreeGraph(unittest.TestCase):
 
     def test_directed_binomial_tree_graph_weights_greater_nodes(self):
         with self.assertRaises(IndexError):
-            retworkx.generators.directed_binomial_tree_graph(
-                2, weights=list(range(7))
-            )
+            retworkx.generators.directed_binomial_tree_graph(2, weights=list(range(7)))
 
     def test_directed_binomial_tree_no_order(self):
         with self.assertRaises(TypeError):
-            retworkx.generators.directed_binomial_tree_graph(
-                weights=list(range(4))
-            )
+            retworkx.generators.directed_binomial_tree_graph(weights=list(range(4)))
 
     def test_directed_binomial_tree_graph_bidirectional(self):
         expected_edges = {
@@ -193,11 +181,9 @@ class TestBinomialTreeGraph(unittest.TestCase):
         }
         for n in range(5):
             with self.subTest(n=n):
-                graph = retworkx.generators.directed_binomial_tree_graph(
-                    n, bidirectional=True
-                )
-                self.assertEqual(len(graph), 2 ** n)
-                self.assertEqual(len(graph.edges()), 2 * (2 ** n - 1))
+                graph = retworkx.generators.directed_binomial_tree_graph(n, bidirectional=True)
+                self.assertEqual(len(graph), 2**n)
+                self.assertEqual(len(graph.edges()), 2 * (2**n - 1))
                 self.assertEqual(list(graph.edge_list()), expected_edges[n])
 
     def test_overflow_binomial_tree(self):

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -25,9 +25,7 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(19), [(19, 0, None)])
 
     def test_directed_cycle_graph_weights(self):
-        graph = retworkx.generators.directed_cycle_graph(
-            weights=list(range(20))
-        )
+        graph = retworkx.generators.directed_cycle_graph(weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 20)
@@ -40,12 +38,8 @@ class TestCycleGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(0), [(0, 19, None), (0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(19, 0, None), (1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(
-                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)]
-            )
-            self.assertEqual(
-                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)]
-            )
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
         self.assertEqual(graph.out_edges(19), [(19, 0, None), (19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(0, 19, None), (18, 19, None)])
 

--- a/tests/generators/test_full_rary_tree.py
+++ b/tests/generators/test_full_rary_tree.py
@@ -61,9 +61,7 @@ class TestFullRaryTreeTreeGraph(unittest.TestCase):
         }
         for n in range(4):
             with self.subTest(n=n):
-                graph = retworkx.generators.full_rary_tree(
-                    b_factors[n], num_nodes[n]
-                )
+                graph = retworkx.generators.full_rary_tree(b_factors[n], num_nodes[n])
                 self.assertEqual(list(graph.edge_list()), expected_edges[n])
 
     def test_full_rary_tree_graph_weights(self):

--- a/tests/generators/test_grid.py
+++ b/tests/generators/test_grid.py
@@ -44,9 +44,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), [])
 
     def test_directed_grid_graph_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(20))
-        )
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(20)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -62,9 +60,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_more_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(16))
-        )
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(16)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(16)] + [None] * 4, graph.nodes())
         self.assertEqual(len(graph.edges()), 31)
@@ -80,9 +76,7 @@ class TestGridGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(19), [(18, 19, None), (14, 19, None)])
 
     def test_directed_grid_graph_less_dimensions_weights(self):
-        graph = retworkx.generators.directed_grid_graph(
-            4, 5, weights=list(range(24))
-        )
+        graph = retworkx.generators.directed_grid_graph(4, 5, weights=list(range(24)))
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 31)

--- a/tests/generators/test_heavy_hex.py
+++ b/tests/generators/test_heavy_hex.py
@@ -32,9 +32,7 @@ class TestHeavyHexGraph(unittest.TestCase):
         d = 3
         graph = retworkx.generators.directed_heavy_hex_graph(d)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1)
-        )
+        self.assertEqual(len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1))
         expected_edges = [
             (0, 13),
             (1, 13),
@@ -61,13 +59,9 @@ class TestHeavyHexGraph(unittest.TestCase):
 
     def test_directed_heavy_hex_graph_3_bidirectional(self):
         d = 3
-        graph = retworkx.generators.directed_heavy_hex_graph(
-            d, bidirectional=True
-        )
+        graph = retworkx.generators.directed_heavy_hex_graph(d, bidirectional=True)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * (2 * d * (d - 1) + (d + 1) * (d - 1))
-        )
+        self.assertEqual(len(graph.edges()), 2 * (2 * d * (d - 1) + (d + 1) * (d - 1)))
         expected_edges = [
             (0, 13),
             (1, 13),
@@ -116,9 +110,7 @@ class TestHeavyHexGraph(unittest.TestCase):
         d = 3
         graph = retworkx.generators.heavy_hex_graph(d)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1)
-        )
+        self.assertEqual(len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1))
         expected_edges = [
             (0, 13),
             (13, 1),
@@ -147,9 +139,7 @@ class TestHeavyHexGraph(unittest.TestCase):
         d = 5
         graph = retworkx.generators.directed_heavy_hex_graph(d)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1)
-        )
+        self.assertEqual(len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1))
         expected_edges = [
             (0, 37),
             (1, 37),
@@ -220,13 +210,9 @@ class TestHeavyHexGraph(unittest.TestCase):
 
     def test_directed_heavy_hex_graph_5_bidirectional(self):
         d = 5
-        graph = retworkx.generators.directed_heavy_hex_graph(
-            d, bidirectional=True
-        )
+        graph = retworkx.generators.directed_heavy_hex_graph(d, bidirectional=True)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * (2 * d * (d - 1) + (d + 1) * (d - 1))
-        )
+        self.assertEqual(len(graph.edges()), 2 * (2 * d * (d - 1) + (d + 1) * (d - 1)))
         expected_edges = [
             (0, 37),
             (1, 37),
@@ -363,9 +349,7 @@ class TestHeavyHexGraph(unittest.TestCase):
         d = 5
         graph = retworkx.generators.heavy_hex_graph(d)
         self.assertEqual(len(graph), (5 * d * d - 2 * d - 1) / 2)
-        self.assertEqual(
-            len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1)
-        )
+        self.assertEqual(len(graph.edges()), 2 * d * (d - 1) + (d + 1) * (d - 1))
         expected_edges = [
             (0, 37),
             (37, 1),

--- a/tests/generators/test_heavy_square.py
+++ b/tests/generators/test_heavy_square.py
@@ -119,13 +119,9 @@ class TestHeavyHexGraph(unittest.TestCase):
 
     def test_directed_heavy_square_graph_5_bidirectional(self):
         d = 5
-        graph = retworkx.generators.directed_heavy_square_graph(
-            d, bidirectional=True
-        )
+        graph = retworkx.generators.directed_heavy_square_graph(d, bidirectional=True)
         self.assertEqual(len(graph), 3 * d * d - 2 * d)
-        self.assertEqual(
-            len(graph.edges()), 2 * (2 * d * (d - 1) + 2 * d * (d - 1))
-        )
+        self.assertEqual(len(graph.edges()), 2 * (2 * d * (d - 1) + 2 * d * (d - 1)))
         expected_edges = [
             (0, 45),
             (45, 1),
@@ -414,13 +410,9 @@ class TestHeavyHexGraph(unittest.TestCase):
 
     def test_directed_heavy_square_graph_3_bidirectional(self):
         d = 3
-        graph = retworkx.generators.directed_heavy_square_graph(
-            d, bidirectional=True
-        )
+        graph = retworkx.generators.directed_heavy_square_graph(d, bidirectional=True)
         self.assertEqual(len(graph), 3 * d * d - 2 * d)
-        self.assertEqual(
-            len(graph.edges()), 2 * (2 * d * (d - 1) + 2 * d * (d - 1))
-        )
+        self.assertEqual(len(graph.edges()), 2 * (2 * d * (d - 1) + 2 * d * (d - 1)))
         expected_edges = [
             (0, 15),
             (15, 1),

--- a/tests/generators/test_hexagonal.py
+++ b/tests/generators/test_hexagonal.py
@@ -126,16 +126,12 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
         self.assertEqual(len(graph.edges()), 0)
 
     def test_directed_hexagonal_graph_0_0_bidirectional(self):
-        graph = retworkx.generators.directed_hexagonal_lattice_graph(
-            0, 0, bidirectional=True
-        )
+        graph = retworkx.generators.directed_hexagonal_lattice_graph(0, 0, bidirectional=True)
         self.assertEqual(len(graph), 0)
         self.assertEqual(len(graph.edges()), 0)
 
     def test_directed_hexagonal_graph_2_2_bidirectional(self):
-        graph = retworkx.generators.directed_hexagonal_lattice_graph(
-            2, 2, bidirectional=True
-        )
+        graph = retworkx.generators.directed_hexagonal_lattice_graph(2, 2, bidirectional=True)
         expected_edges = [
             (0, 1),
             (1, 0),
@@ -181,9 +177,7 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
         self.assertEqual(list(graph.edge_list()), expected_edges)
 
     def test_directed_hexagonal_graph_3_2_bidirectional(self):
-        graph = retworkx.generators.directed_hexagonal_lattice_graph(
-            3, 2, bidirectional=True
-        )
+        graph = retworkx.generators.directed_hexagonal_lattice_graph(3, 2, bidirectional=True)
         expected_edges = [
             (0, 1),
             (1, 0),
@@ -245,9 +239,7 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
         self.assertEqual(list(graph.edge_list()), expected_edges)
 
     def test_directed_hexagonal_graph_2_4_bidirectional(self):
-        graph = retworkx.generators.directed_hexagonal_lattice_graph(
-            2, 4, bidirectional=True
-        )
+        graph = retworkx.generators.directed_hexagonal_lattice_graph(2, 4, bidirectional=True)
         expected_edges = [
             (0, 1),
             (1, 0),

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -38,12 +38,8 @@ class TestPathGraph(unittest.TestCase):
         self.assertEqual(graph.out_edges(0), [(0, 1, None)])
         self.assertEqual(graph.in_edges(0), [(1, 0, None)])
         for i in range(1, 19):
-            self.assertEqual(
-                graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)]
-            )
-            self.assertEqual(
-                graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)]
-            )
+            self.assertEqual(graph.out_edges(i), [(i, i + 1, None), (i, i - 1, None)])
+            self.assertEqual(graph.in_edges(i), [(i + 1, i, None), (i - 1, i, None)])
         self.assertEqual(graph.out_edges(19), [(19, 18, None)])
         self.assertEqual(graph.in_edges(19), [(18, 19, None)])
 

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -51,9 +51,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_directed_star_graph_bidirectional_inward(self):
-        graph = retworkx.generators.directed_star_graph(
-            20, bidirectional=True, inward=True
-        )
+        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=True)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -63,9 +61,7 @@ class TestStarGraph(unittest.TestCase):
             self.assertEqual(graph.in_edges(i), [(0, i, None)])
         self.assertEqual(graph.out_edges(0), outw[::-1])
         self.assertEqual(graph.in_edges(0), inw[::-1])
-        graph = retworkx.generators.directed_star_graph(
-            20, bidirectional=True, inward=False
-        )
+        graph = retworkx.generators.directed_star_graph(20, bidirectional=True, inward=False)
         outw = []
         inw = []
         for i in range(1, 20):
@@ -77,9 +73,7 @@ class TestStarGraph(unittest.TestCase):
         self.assertEqual(graph.in_edges(0), inw[::-1])
 
     def test_star_directed_graph_weights_inward(self):
-        graph = retworkx.generators.directed_star_graph(
-            weights=list(range(20)), inward=True
-        )
+        graph = retworkx.generators.directed_star_graph(weights=list(range(20)), inward=True)
         self.assertEqual(len(graph), 20)
         self.assertEqual([x for x in range(20)], graph.nodes())
         self.assertEqual(len(graph.edges()), 19)

--- a/tests/graph/test_adjencency_matrix.py
+++ b/tests/graph/test_adjencency_matrix.py
@@ -99,13 +99,9 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
-        res = retworkx.graph_adjacency_matrix(
-            graph, lambda x: float(x), null_value=np.inf
-        )
+        res = retworkx.graph_adjacency_matrix(graph, lambda x: float(x), null_value=np.inf)
         self.assertIsInstance(res, np.ndarray)
-        self.assertTrue(
-            np.array_equal(np.array([[np.inf, 7.5], [7.5, np.inf]]), res)
-        )
+        self.assertTrue(np.array_equal(np.array([[np.inf, 7.5], [7.5, np.inf]]), res))
 
     def test_dag_to_graph_adjacency_matrix(self):
         dag = retworkx.PyDAG()
@@ -147,19 +143,13 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         self.assertTrue(np.array_equal(adjacency_matrix, new_adjacency_matrix))
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyGraph.from_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
-        graph = retworkx.PyGraph.from_adjacency_matrix(
-            input_matrix.astype(np.float64, copy=False)
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix.astype(np.float64, copy=False))
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
 
@@ -178,19 +168,13 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
             [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
             dtype=np.float64,
         )
-        graph = retworkx.PyGraph.from_adjacency_matrix(
-            input_matrix, null_value=np.Inf
-        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix, null_value=np.Inf)
         adj_matrix = retworkx.adjacency_matrix(graph, float)
-        expected_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
-        )
+        expected_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64)
         self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
 
     def test_negative_weight(self):
-        input_matrix = np.array(
-            [[0, -1, 0], [-1, 0, -1], [0, -1, 0]], dtype=float
-        )
+        input_matrix = np.array([[0, -1, 0], [-1, 0, -1], [0, -1, 0]], dtype=float)
         graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix)
         adj_matrix = retworkx.graph_adjacency_matrix(graph, lambda x: x)
         self.assertTrue(np.array_equal(adj_matrix, input_matrix))
@@ -201,13 +185,9 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
             [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
             dtype=np.float64,
         )
-        graph = retworkx.PyGraph.from_adjacency_matrix(
-            input_matrix, null_value=np.nan
-        )
+        graph = retworkx.PyGraph.from_adjacency_matrix(input_matrix, null_value=np.nan)
         adj_matrix = retworkx.adjacency_matrix(graph, float)
-        expected_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64
-        )
+        expected_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.float64)
         self.assertTrue(np.array_equal(adj_matrix, expected_matrix))
 
 
@@ -225,16 +205,12 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_random_graph_different_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         with self.assertRaises(TypeError):
             retworkx.PyGraph.from_complex_adjacency_matrix(input_matrix)
 
     def test_random_graph_different_dtype_astype_no_copy(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=np.int64)
         graph = retworkx.PyGraph.from_complex_adjacency_matrix(
             input_matrix.astype(np.complex128, copy=False)
         )
@@ -245,9 +221,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_random_graph_complex_dtype(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=complex
-        )
+        input_matrix = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=complex)
         graph = retworkx.PyGraph.from_complex_adjacency_matrix(input_matrix)
         expected = [
             (0, 1, 1 + 0j),
@@ -260,9 +234,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             [[np.Inf, 1, np.Inf], [1, np.Inf, 1], [np.Inf, 1, np.Inf]],
             dtype=np.complex128,
         )
-        graph = retworkx.PyGraph.from_complex_adjacency_matrix(
-            input_matrix, null_value=np.Inf
-        )
+        graph = retworkx.PyGraph.from_complex_adjacency_matrix(input_matrix, null_value=np.Inf)
         expected = [
             (0, 1, 1 + 0j),
             (1, 2, 1 + 0j),
@@ -270,9 +242,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
         self.assertEqual(graph.weighted_edge_list(), expected)
 
     def test_negative_weight(self):
-        input_matrix = np.array(
-            [[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=complex
-        )
+        input_matrix = np.array([[0, 1, 0], [-1, 0, -1], [0, 1, 0]], dtype=complex)
         graph = retworkx.PyGraph.from_complex_adjacency_matrix(input_matrix)
         self.assertEqual(
             [(0, 1, 1), (1, 2, -1)],
@@ -284,9 +254,7 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             [[np.nan, 1, np.nan], [1, np.nan, 1], [np.nan, 1, np.nan]],
             dtype=np.complex128,
         )
-        graph = retworkx.PyGraph.from_complex_adjacency_matrix(
-            input_matrix, null_value=np.nan
-        )
+        graph = retworkx.PyGraph.from_complex_adjacency_matrix(input_matrix, null_value=np.nan)
         edge_list = graph.weighted_edge_list()
         self.assertEqual(
             edge_list,

--- a/tests/graph/test_all_simple_paths.py
+++ b/tests/graph/test_all_simple_paths.py
@@ -142,9 +142,7 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         for i in range(6):
             graph.add_node(i)
         graph.add_edges_from_no_data(self.edges)
-        paths = retworkx.graph_all_simple_paths(
-            graph, 0, 5, min_depth=4, cutoff=4
-        )
+        paths = retworkx.graph_all_simple_paths(graph, 0, 5, min_depth=4, cutoff=4)
         expected = [
             [0, 3, 4, 5],
             [0, 3, 2, 5],
@@ -177,6 +175,4 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag = retworkx.PyDAG()
         dag.add_node(0)
         dag.add_node(1)
-        self.assertRaises(
-            TypeError, retworkx.graph_all_simple_paths, (dag, 0, 1)
-        )
+        self.assertRaises(TypeError, retworkx.graph_all_simple_paths, (dag, 0, 1))

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -95,9 +95,7 @@ class TestAstarGraph(unittest.TestCase):
         g = retworkx.PyDAG()
         g.add_node(0)
         with self.assertRaises(TypeError):
-            retworkx.graph_astar_shortest_path(
-                g, 0, lambda x: x, lambda y: 1, lambda z: 0
-            )
+            retworkx.graph_astar_shortest_path(g, 0, lambda x: x, lambda y: 1, lambda z: 0)
 
     def test_astar_with_invalid_weights(self):
         g = retworkx.PyGraph()

--- a/tests/graph/test_avg_shortest_path.py
+++ b/tests/graph/test_avg_shortest_path.py
@@ -65,9 +65,7 @@ class TestUnweightedAvgShortestPath(unittest.TestCase):
             self.assertTrue(math.isinf(res), "Output is not infinity")
 
         with self.subTest(disconnected=True):
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, disconnected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, disconnected=True)
             self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_partially_connected_graph(self):
@@ -80,9 +78,7 @@ class TestUnweightedAvgShortestPath(unittest.TestCase):
         with self.subTest(disconnected=True):
             s = 8192
             den = 992  # n*(n-1), n=32 (only connected pairs considered)
-            res = retworkx.unweighted_average_shortest_path_length(
-                graph, disconnected=True
-            )
+            res = retworkx.unweighted_average_shortest_path_length(graph, disconnected=True)
             self.assertAlmostEqual(s / den, res, delta=1e-7)
 
     def test_connected_cycle_graph(self):

--- a/tests/graph/test_bfs_search.py
+++ b/tests/graph/test_bfs_search.py
@@ -53,9 +53,7 @@ class TestBfsSearch(unittest.TestCase):
 
         vis = TreeEdgesRecorder()
         retworkx.graph_bfs_search(self.graph, None, vis)
-        self.assertEqual(
-            vis.edges, [(0, 2), (0, 1), (2, 6), (2, 5), (1, 3), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 2), (0, 1), (2, 6), (2, 5), (1, 3), (4, 7)])
 
     def test_graph_bfs_tree_edges_restricted(self):
         class TreeEdgesRecorderRestricted(retworkx.visit.BFSVisitor):

--- a/tests/graph/test_biconnected.py
+++ b/tests/graph/test_biconnected.py
@@ -75,9 +75,7 @@ class TestBiconnected(unittest.TestCase):
             (3, 0): 3,
             (4, 1): 3,
         }
-        self.assertEqual(
-            retworkx.biconnected_components(self.graph), components
-        )
+        self.assertEqual(retworkx.biconnected_components(self.graph), components)
         self.assertEqual(retworkx.articulation_points(self.graph), {4, 5})
 
     def test_barbell_graph(self):
@@ -90,12 +88,8 @@ class TestBiconnected(unittest.TestCase):
             (4, 3): 0,
             (2, 3): 1,
         }
-        self.assertEqual(
-            retworkx.biconnected_components(self.barbell_graph), components
-        )
-        self.assertEqual(
-            retworkx.articulation_points(self.barbell_graph), {2, 3}
-        )
+        self.assertEqual(retworkx.biconnected_components(self.barbell_graph), components)
+        self.assertEqual(retworkx.articulation_points(self.barbell_graph), {2, 3})
 
     def test_disconnected_graph(self):
         graph = retworkx.union(self.barbell_graph, self.barbell_graph)

--- a/tests/graph/test_centrality.py
+++ b/tests/graph/test_centrality.py
@@ -40,9 +40,7 @@ class TestCentralityGraph(unittest.TestCase):
         self.assertEqual(expected, betweenness)
 
     def test_betweenness_centrality_endpoints(self):
-        betweenness = retworkx.graph_betweenness_centrality(
-            self.graph, endpoints=True
-        )
+        betweenness = retworkx.graph_betweenness_centrality(self.graph, endpoints=True)
         expected = {
             0: 0.5,
             1: 0.8333333333333333,
@@ -86,9 +84,7 @@ class TestCentralityGraphDeletedNode(unittest.TestCase):
         self.assertEqual(expected, betweenness)
 
     def test_betweenness_centrality_endpoints(self):
-        betweenness = retworkx.graph_betweenness_centrality(
-            self.graph, endpoints=True
-        )
+        betweenness = retworkx.graph_betweenness_centrality(self.graph, endpoints=True)
         expected = {
             0: 0.5,
             1: 0.8333333333333333,

--- a/tests/graph/test_complement.py
+++ b/tests/graph/test_complement.py
@@ -19,9 +19,7 @@ class TestComplement(unittest.TestCase):
     def test_clique(self):
         N = 5
         graph = retworkx.PyGraph()
-        graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i < j]
-        )
+        graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
 
         complement_graph = retworkx.complement(graph)
         self.assertEqual(graph.nodes(), complement_graph.nodes())
@@ -33,9 +31,7 @@ class TestComplement(unittest.TestCase):
         graph.add_nodes_from([i for i in range(N)])
 
         expected_graph = retworkx.PyGraph()
-        expected_graph.extend_from_edge_list(
-            [(i, j) for i in range(N) for j in range(N) if i < j]
-        )
+        expected_graph.extend_from_edge_list([(i, j) for i in range(N) for j in range(N) if i < j])
 
         complement_graph = retworkx.complement(graph)
         self.assertTrue(
@@ -55,22 +51,12 @@ class TestComplement(unittest.TestCase):
         N = 8
         graph = retworkx.PyGraph()
         graph.extend_from_edge_list(
-            [
-                (j, i)
-                for i in range(N)
-                for j in range(N)
-                if i < j and (i + j) % 3 == 0
-            ]
+            [(j, i) for i in range(N) for j in range(N) if i < j and (i + j) % 3 == 0]
         )
 
         expected_graph = retworkx.PyGraph()
         expected_graph.extend_from_edge_list(
-            [
-                (i, j)
-                for i in range(N)
-                for j in range(N)
-                if i < j and (i + j) % 3 != 0
-            ]
+            [(i, j) for i in range(N) for j in range(N) if i < j and (i + j) % 3 != 0]
         )
 
         complement_graph = retworkx.complement(graph)

--- a/tests/graph/test_compose.py
+++ b/tests/graph/test_compose.py
@@ -70,9 +70,7 @@ class TestCompose(unittest.TestCase):
             original_op_nodes[0]: (op_nodes[0], "qr[0]"),
             original_input_nodes[1]: (op_nodes[0], "qr[1]"),
         }
-        res = graph.compose(
-            other_graph, node_map, node_map_func=map_fn, edge_map_func=map_fn
-        )
+        res = graph.compose(other_graph, node_map, node_map_func=map_fn, edge_map_func=map_fn)
         self.assertEqual({2: 4, 3: 3, 4: 5}, res)
         self.assertEqual(graph[res[other_output_nodes[0]]], "qr[0]")
         self.assertEqual(graph[res[other_output_nodes[1]]], "qr[1]")

--- a/tests/graph/test_contract_nodes.py
+++ b/tests/graph/test_contract_nodes.py
@@ -118,9 +118,7 @@ class TestContractNodes(unittest.TestCase):
 
         node_m = dag.contract_nodes([node_a, node_d, node_f], "m")
 
-        self.assertEqual(
-            [node_b, node_c, node_e, node_m], list(dag.node_indexes())
-        )
+        self.assertEqual([node_b, node_c, node_e, node_m], list(dag.node_indexes()))
         self.assertEqual(
             {
                 UndirectedEdge((node_b, node_c)),

--- a/tests/graph/test_core_number.py
+++ b/tests/graph/test_core_number.py
@@ -82,9 +82,7 @@ class TestCoreNumber(unittest.TestCase):
     def test_undirected_all_3(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
         res = retworkx.core_number(graph)
         self.assertIsInstance(res, dict)
         self.assertEqual(res, {0: 3, 1: 3, 2: 3, 3: 3})

--- a/tests/graph/test_cycle_basis.py
+++ b/tests/graph/test_cycle_basis.py
@@ -39,9 +39,7 @@ class TestCycleBasis(unittest.TestCase):
     def test_cycle_basis(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(6)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5)])
         res = sorted(sorted(c) for c in retworkx.cycle_basis(graph, 0))
         self.assertEqual([[0, 1, 2, 3], [0, 3, 4, 5]], res)
 
@@ -58,9 +56,7 @@ class TestCycleBasis(unittest.TestCase):
         self.graph.add_edges_from_no_data([(10, 11), (10, 12), (11, 12)])
         cycles = retworkx.cycle_basis(self.graph, 9)
         res = sorted(sorted(x) for x in cycles[:-1]) + [sorted(cycles[-1])]
-        self.assertEqual(
-            res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [10, 11, 12]]
-        )
+        self.assertEqual(res, [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [10, 11, 12]])
 
     def test_invalid_types(self):
         digraph = retworkx.PyDiGraph()
@@ -70,6 +66,4 @@ class TestCycleBasis(unittest.TestCase):
     def test_self_loop(self):
         self.graph.add_edge(1, 1, None)
         res = sorted(sorted(c) for c in retworkx.cycle_basis(self.graph, 0))
-        self.assertEqual(
-            [[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]], res
-        )
+        self.assertEqual([[0, 1, 2, 3], [0, 1, 6, 7, 8], [0, 3, 4, 5], [1]], res)

--- a/tests/graph/test_dfs_search.py
+++ b/tests/graph/test_dfs_search.py
@@ -53,9 +53,7 @@ class TestDfsSearch(unittest.TestCase):
 
         vis = TreeEdgesRecorder()
         retworkx.graph_dfs_search(self.graph, None, vis)
-        self.assertEqual(
-            vis.edges, [(0, 2), (2, 6), (2, 5), (5, 3), (3, 1), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 2), (2, 6), (2, 5), (5, 3), (3, 1), (4, 7)])
 
     def test_graph_dfs_tree_edges_restricted(self):
         class TreeEdgesRecorderRestricted(retworkx.visit.DFSVisitor):

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -51,9 +51,7 @@ class TestDijkstraGraph(unittest.TestCase):
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_no_goal_set(self):
-        path = retworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: 1
-        )
+        path = retworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)
         expected = {1: 1.0, 2: 1.0, 3: 1.0, 4: 2.0, 5: 2.0}
         self.assertEqual(expected, path)
 
@@ -82,9 +80,7 @@ class TestDijkstraGraph(unittest.TestCase):
         g = retworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.graph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: float(x)
-        )
+        path = retworkx.graph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
@@ -92,9 +88,7 @@ class TestDijkstraGraph(unittest.TestCase):
         g = retworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = retworkx.graph_dijkstra_shortest_paths(
-            g, a, weight_fn=lambda x: float(x)
-        )
+        path = retworkx.graph_dijkstra_shortest_paths(g, a, weight_fn=lambda x: float(x))
         expected = {}
         self.assertEqual(expected, path)
 
@@ -106,9 +100,7 @@ class TestDijkstraGraph(unittest.TestCase):
         g.add_node("C")
         d = g.add_node("D")
         g.add_edge(b, d, 2.4)
-        path = retworkx.graph_dijkstra_shortest_path_lengths(
-            g, a, lambda x: round(x, 1)
-        )
+        path = retworkx.graph_dijkstra_shortest_path_lengths(g, a, lambda x: round(x, 1))
         # Computers never work:
         expected = {1: 1.2, 3: 3.5999999999999996}
         self.assertEqual(expected, path)
@@ -120,9 +112,7 @@ class TestDijkstraGraph(unittest.TestCase):
             retworkx.graph_dijkstra_shortest_path_lengths(g, 0, lambda x: x)
 
     def test_dijkstra_all_pair_path_lengths(self):
-        lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(
-            self.graph, float
-        )
+        lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(self.graph, float)
         expected = {
             0: {1: 7.0, 2: 9.0, 3: 11.0, 4: 20.0, 5: 20.0},
             1: {0: 7.0, 2: 10.0, 3: 12.0, 4: 21.0, 5: 15.0},
@@ -134,9 +124,7 @@ class TestDijkstraGraph(unittest.TestCase):
         self.assertEqual(expected, lengths)
 
     def test_dijkstra_all_pair_paths(self):
-        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
-            self.graph, float
-        )
+        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(self.graph, float)
         expected = {
             0: {
                 1: [0, 1],
@@ -161,9 +149,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_path_lengths_with_node_removal(self):
         self.graph.remove_node(3)
-        lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(
-            self.graph, float
-        )
+        lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(self.graph, float)
         expected = {
             0: {1: 7.0, 2: 9.0, 4: 26.0, 5: 20.0},
             1: {0: 7.0, 2: 10.0, 4: 21.0, 5: 15.0},
@@ -175,9 +161,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_paths_with_node_removal(self):
         self.graph.remove_node(3)
-        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(
-            self.graph, float
-        )
+        paths = retworkx.graph_all_pairs_dijkstra_shortest_paths(self.graph, float)
         expected = {
             0: {1: [0, 1], 2: [0, 2], 4: [0, 2, 5, 4], 5: [0, 2, 5]},
             1: {0: [1, 0], 2: [1, 2], 4: [1, 5, 4], 5: [1, 5]},
@@ -189,15 +173,11 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_path_lengths_empty_graph(self):
         graph = retworkx.PyGraph()
-        self.assertEqual(
-            {}, retworkx.graph_all_pairs_dijkstra_path_lengths(graph, float)
-        )
+        self.assertEqual({}, retworkx.graph_all_pairs_dijkstra_path_lengths(graph, float))
 
     def test_dijkstra_all_pair_shortest_paths_empty_graph(self):
         graph = retworkx.PyGraph()
-        self.assertEqual(
-            {}, retworkx.graph_all_pairs_dijkstra_shortest_paths(graph, float)
-        )
+        self.assertEqual({}, retworkx.graph_all_pairs_dijkstra_shortest_paths(graph, float))
 
     def test_dijkstra_all_pair_path_lengths_graph_no_edges(self):
         graph = retworkx.PyGraph()
@@ -221,9 +201,7 @@ class TestDijkstraGraph(unittest.TestCase):
         graph = retworkx.generators.path_graph(2)
         for invalid_weight in [float("nan"), -1]:
             for as_undirected in [False, True]:
-                with self.subTest(
-                    invalid_weight=invalid_weight, as_undirected=as_undirected
-                ):
+                with self.subTest(invalid_weight=invalid_weight, as_undirected=as_undirected):
                     with self.assertRaises(ValueError):
                         retworkx.graph_dijkstra_shortest_paths(
                             graph,

--- a/tests/graph/test_dijkstra_search.py
+++ b/tests/graph/test_dijkstra_search.py
@@ -67,9 +67,7 @@ class TestDijkstraSearch(unittest.TestCase):
 
         vis = DijkstraTreeEdgesRecorder()
         retworkx.graph_dijkstra_search(self.graph, None, float, vis)
-        self.assertEqual(
-            vis.edges, [(0, 1), (0, 2), (2, 6), (2, 5), (5, 3), (4, 7)]
-        )
+        self.assertEqual(vis.edges, [(0, 1), (0, 2), (2, 6), (2, 5), (5, 3), (4, 7)])
 
     def test_graph_dijkstra_goal_search_with_stop_search_exception(self):
         class GoalSearch(retworkx.visit.DijkstraVisitor):

--- a/tests/graph/test_dist_matrix.py
+++ b/tests/graph/test_dist_matrix.py
@@ -21,9 +21,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_distance_matrix(graph)
         expected = np.array(
             [
@@ -41,9 +39,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix_parallel(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_distance_matrix(graph, parallel_threshold=5)
         expected = np.array(
             [
@@ -61,9 +57,7 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix_non_zero_null(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         graph.add_node(7)
         dist = retworkx.graph_distance_matrix(graph, null_value=np.nan)
         expected = np.array(
@@ -83,13 +77,9 @@ class TestDistanceMatrix(unittest.TestCase):
     def test_graph_distance_matrix_parallel_non_zero_null(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         graph.add_node(7)
-        dist = retworkx.graph_distance_matrix(
-            graph, parallel_threshold=5, null_value=np.nan
-        )
+        dist = retworkx.graph_distance_matrix(graph, parallel_threshold=5, null_value=np.nan)
         expected = np.array(
             [
                 [0.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0, np.nan],

--- a/tests/graph/test_dot.py
+++ b/tests/graph/test_dot.py
@@ -101,9 +101,7 @@ class TestDot(unittest.TestCase):
             'style=filled];\n1 [color=black, fillcolor=red, label="a", '
             'style=filled];\n0 -- 1 [label="1", name=1];\n}\n'
         )
-        res = graph.to_dot(
-            lambda node: node, lambda edge: edge, filename=self.path
-        )
+        res = graph.to_dot(lambda node: node, lambda edge: edge, filename=self.path)
         self.addCleanup(os.remove, self.path)
         self.assertIsNone(res)
         with open(self.path, "r") as fd:
@@ -122,14 +120,11 @@ class TestDot(unittest.TestCase):
         graph = retworkx.undirected_gnp_random_graph(3, 0.9, seed=42)
         dot_str = graph.to_dot(lambda _: {}, lambda _: {}, {"bgcolor": "red"})
         self.assertEqual(
-            "graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n"
-            "2 -- 0 ;\n2 -- 1 ;\n}\n",
+            "graph {\nbgcolor=red ;\n0 ;\n1 ;\n2 ;\n1 -- 0 ;\n" "2 -- 0 ;\n2 -- 1 ;\n}\n",
             dot_str,
         )
 
     def test_graph_no_args(self):
         graph = retworkx.undirected_gnp_random_graph(3, 0.95, seed=24)
         dot_str = graph.to_dot()
-        self.assertEqual(
-            "graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str
-        )
+        self.assertEqual("graph {\n0 ;\n1 ;\n2 ;\n2 -- 0 ;\n2 -- 1 ;\n}\n", dot_str)

--- a/tests/graph/test_edgelist.py
+++ b/tests/graph/test_edgelist.py
@@ -104,9 +104,7 @@ class TestEdgeList(unittest.TestCase):
             fd.write("1,2,1# test comments\n")
             fd.write("#2,3\n")
             fd.flush()
-            graph = retworkx.PyGraph.read_edge_list(
-                fd.name, comment="#", deliminator=","
-            )
+            graph = retworkx.PyGraph.read_edge_list(fd.name, comment="#", deliminator=",")
         self.assertEqual(graph.node_indexes(), [0, 1, 2])
         self.assertTrue(graph.has_edge(0, 1))
         self.assertTrue(graph.has_edge(1, 2))

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -38,9 +38,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_num_edges(self):
         graph = retworkx.PyGraph()
@@ -68,9 +66,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.update_edge, node_a, node_b, None
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.update_edge, node_a, node_b, None)
 
     def test_update_edge_by_index(self):
         graph = retworkx.PyGraph()
@@ -102,9 +98,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyGraph()
@@ -160,9 +154,7 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyGraph()
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph()
@@ -482,9 +474,7 @@ class TestEdges(unittest.TestCase):
         node_c = g.add_node("c")
         g.add_edge(node_a, node_c, {"a": 2})
         res = g.out_edges(node_a)
-        self.assertEqual(
-            [(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res
-        )
+        self.assertEqual([(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res)
 
     def test_neighbor_surrounded_in_out_edges(self):
         g = retworkx.PyGraph()
@@ -494,13 +484,9 @@ class TestEdges(unittest.TestCase):
         g.add_edge(node_a, node_b, {"a": 1})
         g.add_edge(node_b, node_c, {"a": 2})
         res = g.out_edges(node_b)
-        self.assertEqual(
-            [(node_b, node_c, {"a": 2}), (node_b, node_a, {"a": 1})], res
-        )
+        self.assertEqual([(node_b, node_c, {"a": 2}), (node_b, node_a, {"a": 1})], res)
         res = g.in_edges(node_b)
-        self.assertEqual(
-            [(node_c, node_b, {"a": 2}), (node_a, node_b, {"a": 1})], res
-        )
+        self.assertEqual([(node_c, node_b, {"a": 2}), (node_a, node_b, {"a": 1})], res)
 
     def test_edge_index_map_empty(self):
         graph = retworkx.PyGraph()
@@ -581,17 +567,13 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_edge_data, node_a, node_b)
 
     def test_no_edge_get_all_edge_data(self):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.get_all_edge_data, node_a, node_b)
 
     def test_has_edge(self):
         graph = retworkx.PyGraph(False)
@@ -633,9 +615,7 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
-        self.assertRaises(
-            retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b
-        )
+        self.assertRaises(retworkx.NoEdgeBetweenNodes, graph.remove_edge, node_a, node_b)
 
     def test_remove_edge_single(self):
         graph = retworkx.PyGraph(False)

--- a/tests/graph/test_floyd_warshall.py
+++ b/tests/graph/test_floyd_warshall.py
@@ -41,9 +41,7 @@ class TestFloydWarshall(unittest.TestCase):
         ]
         graph.add_edges_from(edge_list)
 
-        dijkstra_lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(
-            graph, float
-        )
+        dijkstra_lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(graph, float)
 
         expected = {k: {**v, k: 0.0} for k, v in dijkstra_lengths.items()}
 
@@ -75,9 +73,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph.add_edges_from(edge_list)
         graph.remove_node(d)
 
-        dijkstra_lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(
-            graph, float
-        )
+        dijkstra_lengths = retworkx.graph_all_pairs_dijkstra_path_lengths(graph, float)
 
         expected = {k: {**v, k: 0.0} for k, v in dijkstra_lengths.items()}
 
@@ -152,9 +148,7 @@ class TestFloydWarshall(unittest.TestCase):
     def test_floyd_warshall_numpy_cycle(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -175,9 +169,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, lambda x: 1, parallel_threshold=self.parallel_threshold
         )
@@ -188,9 +180,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(graph)
         self.assertEqual(dist[0, 3], 3)
         self.assertEqual(dist[0, 4], 3)
@@ -199,9 +189,7 @@ class TestFloydWarshall(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(8)))
         graph.remove_node(0)
-        graph.add_edges_from_no_data(
-            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)]
-        )
+        graph.add_edges_from_no_data([(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)])
         dist = retworkx.graph_floyd_warshall_numpy(
             graph, default_weight=2, parallel_threshold=self.parallel_threshold
         )

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -21,18 +21,14 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_empty_isomorphic(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_empty_isomorphic_compare_nodes(self):
         g_a = retworkx.PyGraph()
@@ -40,9 +36,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_identical(self):
@@ -50,58 +44,40 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_isomorphic_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_isomorphic_compare_nodes_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_is_isomorphic_nodes_compare_raises(self):
@@ -109,41 +85,29 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
 
-        self.assertRaises(
-            TypeError, retworkx.is_isomorphic, (g_a, g_b, compare_nodes)
-        )
+        self.assertRaises(TypeError, retworkx.is_isomorphic, (g_a, g_b, compare_nodes))
 
     def test_isomorphic_compare_nodes_identical(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_compare_edges_identical(self):
@@ -151,14 +115,10 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
@@ -175,9 +135,7 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
 
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         nodes = g_b.add_nodes_from(["a_0", "a_2", "a_1", "a_3"])
         g_b.add_edges_from(
@@ -192,9 +150,7 @@ class TestIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    retworkx.is_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    retworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
                 )
 
     def test_isomorphic_node_count_not_equal(self):
@@ -209,17 +165,13 @@ class TestIsomorphic(unittest.TestCase):
         g_b.remove_node(nodes[0])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_same_degrees_non_isomorphic(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
 
-        nodes = g_a.add_nodes_from(
-            ["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"]
-        )
+        nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
         g_a.add_edges_from(
             [
                 (nodes[0], nodes[1], "a_1"),
@@ -235,9 +187,7 @@ class TestIsomorphic(unittest.TestCase):
             ]
         )
 
-        nodes = g_b.add_nodes_from(
-            ["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"]
-        )
+        nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3", "a_4", "b_1", "b_2", "b_3", "b_4"])
         g_b.add_edges_from(
             [
                 (nodes[0], nodes[1], "a_1"),
@@ -254,9 +204,7 @@ class TestIsomorphic(unittest.TestCase):
         )
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertFalse(retworkx.is_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_graph_isomorphic_self_loop(self):
         graph = retworkx.PyGraph()
@@ -279,17 +227,10 @@ class TestIsomorphic(unittest.TestCase):
                 with self.subTest(k=k, t=t):
                     self.assertEqual(
                         retworkx.is_isomorphic(
-                            retworkx.generators.generalized_petersen_graph(
-                                n, k
-                            ),
-                            retworkx.generators.generalized_petersen_graph(
-                                n, t
-                            ),
+                            retworkx.generators.generalized_petersen_graph(n, k),
+                            retworkx.generators.generalized_petersen_graph(n, t),
                         ),
-                        (k == t)
-                        or (k == n - t)
-                        or (k * t % n == 1)
-                        or (k * t % n == n - 1),
+                        (k == t) or (k == n - t) or (k * t % n == 1) or (k * t % n == n - 1),
                     )
 
     def test_isomorphic_parallel_edges(self):
@@ -301,14 +242,8 @@ class TestIsomorphic(unittest.TestCase):
 
     def test_isomorphic_parallel_edges_with_edge_matcher(self):
         graph = retworkx.PyGraph()
-        graph.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "b"), (1, 2, "c")]
-        )
-        self.assertTrue(
-            retworkx.is_isomorphic(
-                graph, graph, edge_matcher=lambda x, y: x == y
-            )
-        )
+        graph.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "b"), (1, 2, "c")])
+        self.assertTrue(retworkx.is_isomorphic(graph, graph, edge_matcher=lambda x, y: x == y))
 
     def test_graph_isomorphic_insufficient_call_limit(self):
         graph = retworkx.generators.path_graph(5)
@@ -342,9 +277,7 @@ class TestIsomorphic(unittest.TestCase):
     def test_graph_vf2_mapping_identical_vf2pp(self):
         graph = retworkx.generators.grid_graph(2, 2)
         second_graph = retworkx.generators.grid_graph(2, 2)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual(next(mapping), {0: 0, 1: 1, 2: 2, 3: 3})
 
     def test_graph_vf2_mapping_identical_removals_vf2pp(self):
@@ -352,9 +285,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = retworkx.generators.path_graph(4)
         second_graph.remove_nodes_from([1, 2])
         second_graph.add_edge(0, 3, None)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual({0: 0, 1: 3}, next(mapping))
 
     def test_graph_vf2_mapping_identical_removals_first_vf2pp(self):
@@ -362,9 +293,7 @@ class TestIsomorphic(unittest.TestCase):
         graph = retworkx.generators.path_graph(4)
         graph.remove_nodes_from([1, 2])
         graph.add_edge(0, 3, None)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, id_order=False
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, id_order=False)
         self.assertEqual({0: 0, 3: 1}, next(mapping))
 
     def test_graph_vf2_number_of_valid_mappings(self):
@@ -380,7 +309,5 @@ class TestIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                mapping = retworkx.graph_vf2_mapping(
-                    g_a, g_b, id_order=id_order, subgraph=False
-                )
+                mapping = retworkx.graph_vf2_mapping(g_a, g_b, id_order=id_order, subgraph=False)
                 self.assertEqual({}, next(mapping))

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -39,12 +39,8 @@ class TestKShortestpath(unittest.TestCase):
     def test_k_graph_shortest_path_with_goal(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(7)))
-        graph.add_edges_from_no_data(
-            [(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
-        )
-        res = retworkx.graph_k_shortest_path_lengths(
-            graph, 0, 2, lambda _: 1, 3
-        )
+        graph.add_edges_from_no_data([(0, 1), (0, 6), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)])
+        res = retworkx.graph_k_shortest_path_lengths(graph, 0, 2, lambda _: 1, 3)
         self.assertEqual({3: 4}, res)
 
     def test_k_graph_shortest_path_with_goal_node_hole(self):

--- a/tests/graph/test_layout.py
+++ b/tests/graph/test_layout.py
@@ -22,10 +22,7 @@ class LayoutTest(unittest.TestCase):
         for k in exp:
             ev = exp[k]
             rv = res[k]
-            if (
-                abs(ev[0] - rv[0]) > self.thres
-                or abs(ev[1] - rv[1]) > self.thres
-            ):
+            if abs(ev[0] - rv[0]) > self.thres or abs(ev[1] - rv[1]) > self.thres:
                 self.fail(
                     "The position for node %s, %s, differs from the expected "
                     "position, %s by more than the allowed threshold of %s"
@@ -54,9 +51,7 @@ class TestRandomLayout(LayoutTest):
         self.assertEqual(expected, res)
 
     def test_random_layout_center(self):
-        res = retworkx.graph_random_layout(
-            self.graph, center=(0.5, 0.5), seed=42
-        )
+        res = retworkx.graph_random_layout(self.graph, center=(0.5, 0.5), seed=42)
         expected = {
             1: [1.260833410686741, 1.0278396573581516],
             5: [0.7363512785218512, 1.4286365888207462],
@@ -117,9 +112,7 @@ class TestBipartiteLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_bipartite_layout_horizontal(self):
-        res = retworkx.bipartite_layout(
-            self.graph, {0, 1, 2, 3}, horizontal=True
-        )
+        res = retworkx.bipartite_layout(self.graph, {0, 1, 2, 3}, horizontal=True)
         expected = {
             0: (1.0, -0.9),
             1: (0.3333333333333333, -0.9),
@@ -151,9 +144,7 @@ class TestBipartiteLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_bipartite_layout_center(self):
-        res = retworkx.bipartite_layout(
-            self.graph, {4, 5, 6}, center=(0.5, 0.5)
-        )
+        res = retworkx.bipartite_layout(self.graph, {4, 5, 6}, center=(0.5, 0.5))
         expected = {
             4: (-0.5, -0.0357142857142857),
             5: (-0.5, 0.5),
@@ -311,9 +302,7 @@ class TestShellLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_shell_layout_nlist(self):
-        res = retworkx.shell_layout(
-            self.graph, nlist=[[0, 2], [1, 3], [4, 9], [8, 7], [6, 5]]
-        )
+        res = retworkx.shell_layout(self.graph, nlist=[[0, 2], [1, 3], [4, 9], [8, 7], [6, 5]])
         expected = {
             0: (0.16180340945720673, 0.11755704879760742),
             2: (-0.16180339455604553, -0.11755707114934921),
@@ -347,9 +336,7 @@ class TestShellLayout(LayoutTest):
         self.assertLayoutEquiv(expected, res)
 
     def test_shell_layout_scale(self):
-        res = retworkx.shell_layout(
-            self.graph, nlist=[[0, 1, 2, 3, 4], [9, 8, 7, 6, 5]], scale=2
-        )
+        res = retworkx.shell_layout(self.graph, nlist=[[0, 1, 2, 3, 4], [9, 8, 7, 6, 5]], scale=2)
         expected = {
             0: (-4.371138828673793e-08, 1.0),
             1: (-0.9510565996170044, 0.30901679396629333),

--- a/tests/graph/test_max_weight_matching.py
+++ b/tests/graph/test_max_weight_matching.py
@@ -43,9 +43,7 @@ class TestMaxWeightMatching(testtools.TestCase):
                     "output: %s" % ((u, v), (v, u), rx_match, expected_match)
                 )
 
-    def compare_rx_nx_sets(
-        self, rx_graph, rx_matches, nx_matches, seed, nx_graph
-    ):
+    def compare_rx_nx_sets(self, rx_graph, rx_matches, nx_matches, seed, nx_graph):
         def get_rx_weight(edge):
             weight = rx_graph.get_edge_data(*edge)
             if weight is None:
@@ -127,9 +125,7 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 10), (2, 3, 11)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {
                 (2, 3),
             },
@@ -139,17 +135,13 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph = retworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(1, 2, 5), (2, 3, 11), (3, 4, 5)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {
                 (2, 3),
             },
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, True, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 2), (3, 4)},
         )
 
@@ -165,17 +157,13 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {
                 (1, 2),
             },
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, True, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, True, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 3), (2, 4)},
         )
 
@@ -190,16 +178,12 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(0, 1), (2, 3)},
         )
         graph.extend_from_weighted_edge_list([(0, 5, 5), (3, 4, 6)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(0, 5), (1, 2), (3, 4)},
         )
 
@@ -216,26 +200,20 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 6), (2, 3), (4, 5)},
         )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 5)
         graph.extend_from_weighted_edge_list([(4, 5, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 6), (2, 3), (4, 5)},
         )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 2), (3, 6), (4, 5)},
         )
 
@@ -255,26 +233,20 @@ class TestMaxWeightMatching(testtools.TestCase):
         graph.remove_node(5)
         graph.add_edge(4, node_id, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 6), (2, 3), (4, 7)},
         )
         graph.remove_edge(1, 6)
         graph.remove_edge(4, 7)
         graph.extend_from_weighted_edge_list([(4, node_id, 3), (1, 6, 4)])
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 6), (2, 3), (4, 7)},
         )
         graph.remove_edge(1, 6)
         graph.add_edge(3, 6, 4)
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 2), (3, 6), (4, 7)},
         )
 
@@ -293,9 +265,7 @@ class TestMaxWeightMatching(testtools.TestCase):
         )
         expected = {(1, 3), (2, 4), (5, 6)}
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             expected,
         )
 
@@ -315,9 +285,7 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 2), (3, 4), (5, 6), (7, 8)},
         )
 
@@ -338,9 +306,7 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 2), (3, 5), (4, 6), (7, 8)},
         )
 
@@ -359,9 +325,7 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             {(1, 6), (2, 3), (4, 8), (5, 7)},
         )
 
@@ -381,9 +345,7 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             match_dict_to_set({1: 8, 2: 3, 3: 2, 4: 7, 5: 6, 6: 5, 7: 4, 8: 1}),
         )
 
@@ -404,12 +366,8 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
         )
 
     def test_blossom_relabel_multiple_path_alternate(self):
@@ -429,12 +387,8 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
         )
 
     def test_blossom_relabel_multiple_paths_least_slack(self):
@@ -454,12 +408,8 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
-            match_dict_to_set(
-                {1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 6, 2: 3, 3: 2, 4: 8, 5: 7, 6: 1, 7: 5, 8: 4, 9: 10, 10: 9}),
         )
 
     def test_nested_blossom_expand_recursively(self):
@@ -480,12 +430,8 @@ class TestMaxWeightMatching(testtools.TestCase):
             ]
         )
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
-            match_dict_to_set(
-                {1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
+            match_dict_to_set({1: 2, 2: 1, 3: 5, 4: 9, 5: 3, 6: 7, 7: 6, 8: 10, 9: 4, 10: 8}),
         )
 
     def test_nested_blossom_augmented(self):
@@ -522,72 +468,50 @@ class TestMaxWeightMatching(testtools.TestCase):
             12: 11,
         }
         self.compare_match_sets(
-            retworkx.max_weight_matching(
-                graph, weight_fn=lambda x: x, verify_optimum=True
-            ),
+            retworkx.max_weight_matching(graph, weight_fn=lambda x: x, verify_optimum=True),
             match_dict_to_set(expected),
         )
 
     def test_gnp_random_against_networkx(self):
         for i in range(1024):
             with self.subTest(i=i):
-                rx_graph = retworkx.undirected_gnp_random_graph(
-                    10, 0.75, seed=42 + i
-                )
+                rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
                 nx_graph = networkx.Graph(list(rx_graph.edge_list()))
                 nx_matches = networkx.max_weight_matching(nx_graph)
-                rx_matches = retworkx.max_weight_matching(
-                    rx_graph, verify_optimum=True
-                )
-                self.compare_rx_nx_sets(
-                    rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
-                )
+                rx_matches = retworkx.max_weight_matching(rx_graph, verify_optimum=True)
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_weight(self):
         for i in range(1024):
             with self.subTest(i=i):
                 random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(
-                    10, 0.75, seed=42 + i
-                )
+                rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
                 for edge in rx_graph.edge_list():
                     rx_graph.update_edge(*edge, random.randint(0, 5000))
                 nx_graph = networkx.Graph(
-                    [
-                        (x[0], x[1], {"weight": x[2]})
-                        for x in rx_graph.weighted_edge_list()
-                    ]
+                    [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
                 )
                 nx_matches = networkx.max_weight_matching(nx_graph)
                 rx_matches = retworkx.max_weight_matching(
                     rx_graph, weight_fn=lambda x: x, verify_optimum=True
                 )
-                self.compare_rx_nx_sets(
-                    rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
-                )
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_with_negative_weight(self):
         for i in range(1024):
             with self.subTest(i=i):
                 random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(
-                    10, 0.75, seed=42 + i
-                )
+                rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
                 for edge in rx_graph.edge_list():
                     rx_graph.update_edge(*edge, random.randint(-5000, 5000))
                 nx_graph = networkx.Graph(
-                    [
-                        (x[0], x[1], {"weight": x[2]})
-                        for x in rx_graph.weighted_edge_list()
-                    ]
+                    [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
                 )
                 nx_matches = networkx.max_weight_matching(nx_graph)
                 rx_matches = retworkx.max_weight_matching(
                     rx_graph, weight_fn=lambda x: x, verify_optimum=True
                 )
-                self.compare_rx_nx_sets(
-                    rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
-                )
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random_against_networkx_max_cardinality(self):
         rx_graph = retworkx.undirected_gnp_random_graph(10, 0.78, seed=428)
@@ -602,57 +526,39 @@ class TestMaxWeightMatching(testtools.TestCase):
         for i in range(1024):
             with self.subTest(i=i):
                 random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(
-                    10, 0.75, seed=42 + i
-                )
+                rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
                 for edge in rx_graph.edge_list():
                     rx_graph.update_edge(*edge, random.randint(0, 5000))
                 nx_graph = networkx.Graph(
-                    [
-                        (x[0], x[1], {"weight": x[2]})
-                        for x in rx_graph.weighted_edge_list()
-                    ]
+                    [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
                 )
-                nx_matches = networkx.max_weight_matching(
-                    nx_graph, maxcardinality=True
-                )
+                nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
                 rx_matches = retworkx.max_weight_matching(
                     rx_graph,
                     weight_fn=lambda x: x,
                     max_cardinality=True,
                     verify_optimum=True,
                 )
-                self.compare_rx_nx_sets(
-                    rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
-                )
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnp_random__networkx_with_negative_weight_max_cardinality(self):
         for i in range(1024):
             with self.subTest(i=i):
                 random.seed(i)
-                rx_graph = retworkx.undirected_gnp_random_graph(
-                    10, 0.75, seed=42 + i
-                )
+                rx_graph = retworkx.undirected_gnp_random_graph(10, 0.75, seed=42 + i)
                 for edge in rx_graph.edge_list():
                     rx_graph.update_edge(*edge, random.randint(-5000, 5000))
                 nx_graph = networkx.Graph(
-                    [
-                        (x[0], x[1], {"weight": x[2]})
-                        for x in rx_graph.weighted_edge_list()
-                    ]
+                    [(x[0], x[1], {"weight": x[2]}) for x in rx_graph.weighted_edge_list()]
                 )
-                nx_matches = networkx.max_weight_matching(
-                    nx_graph, maxcardinality=True
-                )
+                nx_matches = networkx.max_weight_matching(nx_graph, maxcardinality=True)
                 rx_matches = retworkx.max_weight_matching(
                     rx_graph,
                     weight_fn=lambda x: x,
                     max_cardinality=True,
                     verify_optimum=True,
                 )
-                self.compare_rx_nx_sets(
-                    rx_graph, rx_matches, nx_matches, 42 + i, nx_graph
-                )
+                self.compare_rx_nx_sets(rx_graph, rx_matches, nx_matches, 42 + i, nx_graph)
 
     def test_gnm_random_against_networkx(self):
         rx_graph = retworkx.undirected_gnm_random_graph(10, 13, seed=42)

--- a/tests/graph/test_mst.py
+++ b/tests/graph/test_mst.py
@@ -51,24 +51,16 @@ class TestMinimumSpanningTree(unittest.TestCase):
             self.assertTrue(edge in expected)
 
     def test_edges(self):
-        mst_edges = retworkx.minimum_spanning_edges(
-            self.graph, weight_fn=lambda x: x
-        )
+        mst_edges = retworkx.minimum_spanning_edges(self.graph, weight_fn=lambda x: x)
         self.assertEqual(len(self.graph.nodes()) - 1, len(mst_edges))
         for edge in mst_edges:
             self.assertTrue(edge in self.expected_edges)
 
     def test_tree(self):
-        mst_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        mst_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual(self.graph.nodes(), mst_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 1, len(mst_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            self.expected_edges, mst_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 1, len(mst_graph.edge_list()))
+        self.assertEqualEdgeList(self.expected_edges, mst_graph.weighted_edge_list())
 
     def test_forest(self):
         s = self.graph.add_node("S")
@@ -77,31 +69,19 @@ class TestMinimumSpanningTree(unittest.TestCase):
         self.graph.add_edges_from([(s, t, 10), (t, u, 9), (s, u, 8)])
         forest_expected_edges = self.expected_edges + [(s, u, 8), (t, u, 9)]
 
-        msf_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            forest_expected_edges, msf_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
+        self.assertEqualEdgeList(forest_expected_edges, msf_graph.weighted_edge_list())
 
     def test_isolated(self):
         s = self.graph.add_node("S")
 
-        msf_graph = retworkx.minimum_spanning_tree(
-            self.graph, weight_fn=lambda x: x
-        )
+        msf_graph = retworkx.minimum_spanning_tree(self.graph, weight_fn=lambda x: x)
         self.assertEqual("S", msf_graph.nodes()[s])
         self.assertEqual(self.graph.nodes(), msf_graph.nodes())
-        self.assertEqual(
-            len(self.graph.nodes()) - 2, len(msf_graph.edge_list())
-        )
-        self.assertEqualEdgeList(
-            self.expected_edges, msf_graph.weighted_edge_list()
-        )
+        self.assertEqual(len(self.graph.nodes()) - 2, len(msf_graph.edge_list()))
+        self.assertEqualEdgeList(self.expected_edges, msf_graph.weighted_edge_list())
 
     def test_multigraph(self):
         mutligraph = retworkx.PyGraph(multigraph=True)
@@ -109,12 +89,8 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1, 1), (0, 2, 3), (1, 2, 2), (0, 0, -10), (1, 2, 1)]
         )
 
-        mst_graph = retworkx.minimum_spanning_tree(
-            mutligraph, weight_fn=lambda x: x
-        )
-        self.assertEqualEdgeList(
-            [(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list()
-        )
+        mst_graph = retworkx.minimum_spanning_tree(mutligraph, weight_fn=lambda x: x)
+        self.assertEqualEdgeList([(0, 1, 1), (1, 2, 1)], mst_graph.weighted_edge_list())
 
     def test_default_weight(self):
         weightless_graph = retworkx.PyGraph()
@@ -122,12 +98,8 @@ class TestMinimumSpanningTree(unittest.TestCase):
             [(0, 1), (0, 2), (0, 3), (0, 4), (1, 5), (2, 6), (3, 7), (4, 8)]
         )  # MST of the graph is itself
 
-        mst_graph_default_weight = retworkx.minimum_spanning_tree(
-            weightless_graph
-        )
-        mst_graph_weight_2 = retworkx.minimum_spanning_tree(
-            weightless_graph, default_weight=2.0
-        )
+        mst_graph_default_weight = retworkx.minimum_spanning_tree(weightless_graph)
+        mst_graph_weight_2 = retworkx.minimum_spanning_tree(weightless_graph, default_weight=2.0)
 
         self.assertTrue(
             retworkx.is_isomorphic(
@@ -144,9 +116,7 @@ class TestMinimumSpanningTree(unittest.TestCase):
 
     def test_nan_weight(self):
         invalid_graph = retworkx.PyGraph()
-        invalid_graph.extend_from_weighted_edge_list(
-            [(0, 1, 0.5), (0, 2, float("nan"))]
-        )
+        invalid_graph.extend_from_weighted_edge_list([(0, 1, 0.5), (0, 2, float("nan"))])
 
         with self.assertRaises(ValueError):
             retworkx.minimum_spanning_tree(invalid_graph, lambda x: x)

--- a/tests/graph/test_steiner_tree.py
+++ b/tests/graph/test_steiner_tree.py
@@ -114,9 +114,7 @@ class TestSteinerTree(unittest.TestCase):
         self.assertEqual([], closure.weighted_edge_list())
 
     def test_steiner_graph(self):
-        steiner_tree = retworkx.steiner_tree(
-            self.graph, [1, 2, 3, 4, 5], weight_fn=float
-        )
+        steiner_tree = retworkx.steiner_tree(self.graph, [1, 2, 3, 4, 5], weight_fn=float)
         expected_steiner_tree = [
             (1, 2, 10),
             (2, 3, 10),

--- a/tests/graph/test_subgraph.py
+++ b/tests/graph/test_subgraph.py
@@ -57,9 +57,7 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual(
-            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0]["a"] = 4
         self.assertEqual(subgraph[0]["a"], 4)
@@ -72,9 +70,7 @@ class TestSubgraph(unittest.TestCase):
         graph.add_node("d")
         graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
         subgraph = graph.subgraph([0, 1, 3])
-        self.assertEqual(
-            [(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 1), (0, 2, 3), (1, 2, 4)], subgraph.weighted_edge_list())
         self.assertEqual([{"a": 0}, "b", "d"], subgraph.nodes())
         graph[0] = 4
         self.assertEqual(subgraph[0]["a"], 0)
@@ -105,9 +101,7 @@ class TestSubgraph(unittest.TestCase):
         )
         subgraph = graph.edge_subgraph([(0, 1), (1, 2)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
-        self.assertEqual(
-            [(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())
 
     def test_edge_subgraph_empty_list(self):
         graph = retworkx.PyGraph()
@@ -141,6 +135,4 @@ class TestSubgraph(unittest.TestCase):
         # 1->3 isn't an edge in graph
         subgraph = graph.edge_subgraph([(0, 1), (1, 2), (1, 3)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
-        self.assertEqual(
-            [(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list()
-        )
+        self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -20,18 +20,14 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_a = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order))
 
     def test_empty_subgraph_isomorphic(self):
         g_a = retworkx.PyGraph()
         g_b = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_empty_subgraph_isomorphic_compare_nodes(self):
         g_a = retworkx.PyGraph()
@@ -47,14 +43,10 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_subgraph_isomorphic_identical(self):
         g_a = retworkx.PyGraph()
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_a, id_order=id_order))
 
     def test_subgraph_isomorphic_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
@@ -70,14 +62,10 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_subgraph_isomorphic_compare_nodes_mismatch_node_data(self):
         g_a = retworkx.PyGraph()
@@ -93,9 +81,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["b_1", "b_2", "b_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
@@ -118,9 +104,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
@@ -132,9 +116,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_is_subgraph_isomorphic_nodes_compare_raises(self):
         g_a = retworkx.PyGraph()
         nodes = g_a.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_a.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_a.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
 
         def compare_nodes(a, b):
             raise TypeError("Failure")
@@ -159,9 +141,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
@@ -184,9 +164,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b.add_edges_from([(nodes[0], nodes[1], "a_1")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order)
-                )
+                self.assertFalse(retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order))
 
     def test_non_induced_subgraph_isomorphic(self):
         g_a = retworkx.PyGraph()
@@ -202,28 +180,20 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         )
 
         nodes = g_b.add_nodes_from(["a_1", "a_2", "a_3"])
-        g_b.add_edges_from(
-            [(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")]
-        )
+        g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order, induced=True):
                 self.assertFalse(
-                    retworkx.is_subgraph_isomorphic(
-                        g_a, g_b, id_order=id_order, induced=True
-                    )
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order, induced=True)
                 )
             with self.subTest(id_order=id_order, induced=False):
                 self.assertTrue(
-                    retworkx.is_subgraph_isomorphic(
-                        g_a, g_b, id_order=id_order, induced=False
-                    )
+                    retworkx.is_subgraph_isomorphic(g_a, g_b, id_order=id_order, induced=False)
                 )
 
     def test_subgraph_isomorphic_edge_matcher(self):
         first = retworkx.PyGraph()
-        first.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (1, 2, "b"), (2, 0, "c")]
-        )
+        first.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b"), (2, 0, "c")])
         second = retworkx.PyGraph()
         second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
 
@@ -235,13 +205,9 @@ class TestSubgraphIsomorphic(unittest.TestCase):
 
     def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
         first = retworkx.PyGraph()
-        first.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")]
-        )
+        first.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "f"), (1, 2, "b"), (2, 0, "c")])
         second = retworkx.PyGraph()
-        second.extend_from_weighted_edge_list(
-            [(0, 1, "a"), (0, 1, "a"), (1, 2, "b")]
-        )
+        second.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "a"), (1, 2, "b")])
 
         self.assertFalse(
             retworkx.is_subgraph_isomorphic(
@@ -254,12 +220,8 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         first.extend_from_edge_list([(0, 1), (1, 2), (2, 3)])
         second = retworkx.PyGraph()
         second.extend_from_edge_list([(0, 1), (0, 1)])
-        self.assertFalse(
-            retworkx.is_subgraph_isomorphic(first, second, induced=True)
-        )
-        self.assertFalse(
-            retworkx.is_subgraph_isomorphic(first, second, induced=False)
-        )
+        self.assertFalse(retworkx.is_subgraph_isomorphic(first, second, induced=True))
+        self.assertFalse(retworkx.is_subgraph_isomorphic(first, second, induced=False))
 
     def test_non_induced_grid_subgraph_isomorphic(self):
         g_a = retworkx.generators.grid_graph(2, 2)
@@ -267,25 +229,17 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b.add_nodes_from([0, 1, 2, 3])
         g_b.add_edges_from_no_data([(0, 1), (2, 3)])
 
-        self.assertFalse(
-            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True)
-        )
+        self.assertFalse(retworkx.is_subgraph_isomorphic(g_a, g_b, induced=True))
 
-        self.assertTrue(
-            retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False)
-        )
+        self.assertTrue(retworkx.is_subgraph_isomorphic(g_a, g_b, induced=False))
 
     def test_non_induced_subgraph_isomorphic_parallel_edges(self):
         first = retworkx.PyGraph()
         first.extend_from_edge_list([(0, 1), (0, 1), (1, 2), (1, 2)])
         second = retworkx.PyGraph()
         second.extend_from_edge_list([(0, 1), (1, 2), (1, 2)])
-        self.assertFalse(
-            retworkx.is_subgraph_isomorphic(first, second, induced=True)
-        )
-        self.assertTrue(
-            retworkx.is_subgraph_isomorphic(first, second, induced=False)
-        )
+        self.assertFalse(retworkx.is_subgraph_isomorphic(first, second, induced=True))
+        self.assertTrue(retworkx.is_subgraph_isomorphic(first, second, induced=False))
 
     def test_subgraph_vf2_mapping(self):
         graph = retworkx.generators.grid_graph(10, 10)
@@ -296,9 +250,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_subgraph_vf2_all_mappings(self):
         graph = retworkx.generators.path_graph(3)
         second_graph = retworkx.generators.path_graph(2)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=True
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, subgraph=True, id_order=True)
         self.assertEqual(next(mapping), {0: 0, 1: 1})
         self.assertEqual(next(mapping), {0: 1, 1: 0})
         self.assertEqual(next(mapping), {2: 1, 1: 0})
@@ -307,9 +259,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
     def test_subgraph_vf2_mapping_vf2pp(self):
         graph = retworkx.generators.grid_graph(3, 3)
         second_graph = retworkx.generators.grid_graph(2, 2)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=False
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, subgraph=True, id_order=False)
         self.assertEqual(next(mapping), {4: 0, 3: 2, 0: 3, 1: 1})
 
     def test_vf2pp_remapping(self):
@@ -322,9 +272,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         graph.remove_node(dummy)
 
         second_graph = retworkx.generators.grid_graph(2, 2)
-        mapping = retworkx.graph_vf2_mapping(
-            graph, second_graph, subgraph=True, id_order=False
-        )
+        mapping = retworkx.graph_vf2_mapping(graph, second_graph, subgraph=True, id_order=False)
         self.assertEqual(next(mapping), {5: 0, 4: 2, 1: 3, 2: 1})
 
     def test_empty_subgraph_vf2_mapping(self):
@@ -332,9 +280,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         g_b = retworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                mapping = retworkx.graph_vf2_mapping(
-                    g_a, g_b, id_order=id_order, subgraph=True
-                )
+                mapping = retworkx.graph_vf2_mapping(g_a, g_b, id_order=id_order, subgraph=True)
                 self.assertEqual({}, next(mapping))
 
     def test_subgraph_vf2_mapping_out_size(self):

--- a/tests/graph/test_union.py
+++ b/tests/graph/test_union.py
@@ -18,27 +18,19 @@ class TestUnion(unittest.TestCase):
     def setUp(self):
         self.graph = retworkx.PyGraph()
         self.graph.add_nodes_from(["a_1", "a_2", "a_3"])
-        self.graph.extend_from_weighted_edge_list(
-            [(0, 1, "e_1"), (1, 2, "e_2")]
-        )
+        self.graph.extend_from_weighted_edge_list([(0, 1, "e_1"), (1, 2, "e_2")])
 
     def test_union_basic_merge_none(self):
-        final = retworkx.graph_union(
-            self.graph, self.graph, merge_nodes=False, merge_edges=False
-        )
+        final = retworkx.graph_union(self.graph, self.graph, merge_nodes=False, merge_edges=False)
         self.assertTrue(len(final.nodes()) == 6)
         self.assertTrue(len(final.edge_list()) == 4)
 
     def test_union_merge_all(self):
-        final = retworkx.graph_union(
-            self.graph, self.graph, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.graph_union(self.graph, self.graph, merge_nodes=True, merge_edges=True)
         self.assertTrue(retworkx.is_isomorphic(final, self.graph))
 
     def test_union_basic_merge_nodes_only(self):
-        final = retworkx.graph_union(
-            self.graph, self.graph, merge_nodes=True, merge_edges=False
-        )
+        final = retworkx.graph_union(self.graph, self.graph, merge_nodes=True, merge_edges=False)
         self.assertTrue(len(final.edge_list()) == 4)
         self.assertTrue(len(final.get_all_edge_data(0, 1)) == 2)
         self.assertTrue(len(final.nodes()) == 3)
@@ -52,9 +44,7 @@ class TestUnion(unittest.TestCase):
         nodes = second.add_nodes_from([0, 1])
         second.add_edges_from([(nodes[0], nodes[1], "b")])
 
-        final = retworkx.graph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.graph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 1, "b")])
 
     def test_union_node_hole(self):
@@ -68,9 +58,7 @@ class TestUnion(unittest.TestCase):
         second.add_edges_from([(nodes[0], nodes[1], "a")])
         second.remove_node(dummy)
 
-        final = retworkx.graph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.graph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a")])
 
     def test_union_edge_between_merged_and_unmerged_nodes(self):
@@ -82,7 +70,5 @@ class TestUnion(unittest.TestCase):
         nodes = second.add_nodes_from([0, 2])
         second.add_edges_from([(nodes[0], nodes[1], "b")])
 
-        final = retworkx.graph_union(
-            first, second, merge_nodes=True, merge_edges=True
-        )
+        final = retworkx.graph_union(first, second, merge_nodes=True, merge_edges=True)
         self.assertEqual(final.weighted_edge_list(), [(0, 1, "a"), (0, 2, "b")])

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -20,126 +20,90 @@ class TestNetworkxConverter(unittest.TestCase):
         g = networkx.gnm_random_graph(10, 10, seed=42)
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_directed_gnm_graph(self):
         g = networkx.gnm_random_graph(10, 10, seed=42, directed=True)
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyDiGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_graph(self):
         g = networkx.Graph()
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_multigraph(self):
         g = networkx.MultiGraph()
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_graph(self):
         g = networkx.DiGraph()
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyDiGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_empty_directed_multigraph(self):
         g = networkx.MultiDiGraph()
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyDiGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_graph(self):
         g = networkx.cubical_graph(networkx.Graph)
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_cubical_multigraph(self):
         g = networkx.cubical_graph(networkx.MultiGraph)
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_random_k_out_graph(self):
         g = networkx.random_k_out_graph(100, 50, 3.14159, True, 42)
         for keep_attributes in [True, False]:
             with self.subTest(keep_attributes=keep_attributes):
-                out_graph = retworkx.networkx_converter(
-                    g, keep_attributes=keep_attributes
-                )
+                out_graph = retworkx.networkx_converter(g, keep_attributes=keep_attributes)
                 self.assertIsInstance(out_graph, retworkx.PyDiGraph)
                 self.assertEqual(list(out_graph.node_indexes()), list(g.nodes))
-                self.assertEqual(
-                    out_graph.weighted_edge_list(), list(g.edges(data=True))
-                )
+                self.assertEqual(out_graph.weighted_edge_list(), list(g.edges(data=True)))
                 self.assertEqual(out_graph.multigraph, g.is_multigraph())
 
     def test_networkx_graph_attributes_are_converted(self):

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -33,9 +33,7 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["c"])])
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            retworkx.bfs_successors(self.dag, 0) == [("a", ["b"]), ("b", ["c"])]
-        )
+        self.assertFalse(retworkx.bfs_successors(self.dag, 0) == [("a", ["b"]), ("b", ["c"])])
 
     def test__eq__invalid_type(self):
         with self.assertRaises(TypeError):
@@ -51,9 +49,7 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["c"])])
 
     def test__ne__different_length(self):
-        self.assertTrue(
-            retworkx.bfs_successors(self.dag, 0) != [("a", ["b"]), ("b", ["c"])]
-        )
+        self.assertTrue(retworkx.bfs_successors(self.dag, 0) != [("a", ["b"]), ("b", ["c"])])
 
     def test__ne__invalid_type(self):
         with self.assertRaises(TypeError):
@@ -158,24 +154,16 @@ class TestNodesCountMapping(unittest.TestCase):
         self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 1}
-        )
+        self.assertTrue(retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 1})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == {2: 1}
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) == {2: 1})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 2}
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 2})
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 1, 2: 2}
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) == {1: 1, 2: 2})
 
     def test_eq__same_type(self):
         self.assertEqual(
@@ -184,39 +172,25 @@ class TestNodesCountMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == ["a", None]
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) == ["a", None])
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) == {0: "a"}
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) == {0: "a"})
 
     def test__ne__match(self):
-        self.assertFalse(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 1}
-        )
+        self.assertFalse(retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 1})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) != {2: 1}
-        )
+        self.assertTrue(retworkx.num_shortest_paths_unweighted(self.dag, 0) != {2: 1})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 2}
-        )
+        self.assertTrue(retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 2})
 
     def test__ne__different_length(self):
-        self.assertTrue(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 1, 2: 2}
-        )
+        self.assertTrue(retworkx.num_shortest_paths_unweighted(self.dag, 0) != {1: 1, 2: 2})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.num_shortest_paths_unweighted(self.dag, 0) != ["a", None]
-        )
+        self.assertTrue(retworkx.num_shortest_paths_unweighted(self.dag, 0) != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -405,10 +379,7 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         self.assertFalse(self.dag.weighted_edge_list() == [(1, 2, None)])
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            self.dag.weighted_edge_list()
-            == [(0, 1, "Edgy"), (2, 3, "Not Edgy")]
-        )
+        self.assertFalse(self.dag.weighted_edge_list() == [(0, 1, "Edgy"), (2, 3, "Not Edgy")])
 
     def test__eq__invalid_type(self):
         self.assertFalse(self.dag.weighted_edge_list() == ["a", None])
@@ -465,25 +436,16 @@ class TestPathMapping(unittest.TestCase):
         self.dag.add_child(node_a, "b", "Edgy")
 
     def test__eq__match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1]})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {2: [0, 1]})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 2]})
 
     def test__eq__different_length(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0)
-            == {1: [0, 1], 2: [0, 2]}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {1: [0, 1], 2: [0, 2]})
 
     def test_eq__same_type(self):
         self.assertEqual(
@@ -492,40 +454,25 @@ class TestPathMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == ["a", None]
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == ["a", None])
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {"a": None}}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) == {0: {"a": None}})
 
     def test__ne__match(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1]})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {2: [0, 1]})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 2]})
 
     def test__ne__different_length(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0)
-            != {1: [0, 1], 2: [0, 2]}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != {1: [0, 1], 2: [0, 2]})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_paths(self.dag, 0) != ["a", None]
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_paths(self.dag, 0) != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -592,27 +539,17 @@ class TestPathLengthMapping(unittest.TestCase):
         self.fn = lambda _: 1.0
 
     def test__eq__match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == {1: 1.0}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == {2: 1.0}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {2: 1.0})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == {1: 2.0}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 2.0})
 
     def test__eq__different_length(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == {1: 1.0, 2: 2.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {1: 1.0, 2: 2.0}
         )
 
     def test_eq__same_type(self):
@@ -623,51 +560,34 @@ class TestPathLengthMapping(unittest.TestCase):
 
     def test__eq__invalid_type(self):
         self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == ["a", None]
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == ["a", None]
         )
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            == {0: "a"}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) == {0: "a"})
 
     def test__ne__match(self):
-        self.assertFalse(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            != {1: 1.0}
-        )
+        self.assertFalse(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            != {2: 1.0}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {2: 1.0})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            != {1: 2.0}
-        )
+        self.assertTrue(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 2.0})
 
     def test__ne__different_length(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            != {1: 1.0, 2: 2.0}
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != {1: 1.0, 2: 2.0}
         )
 
     def test__ne__invalid_type(self):
         self.assertTrue(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-            != ["a", None]
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) != ["a", None]
         )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) > {
-                1: 1.0
-            }
+            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn) > {1: 1.0}
 
     def test_deepcopy(self):
         paths = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
@@ -681,9 +601,7 @@ class TestPathLengthMapping(unittest.TestCase):
         self.assertEqual(paths, paths_copy)
 
     def test_str(self):
-        res = retworkx.dijkstra_shortest_path_lengths(
-            self.dag, 0, lambda _: 3.14
-        )
+        res = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, lambda _: 3.14)
         self.assertEqual("PathLengthMapping{1: 3.14}", str(res))
 
     def test_hash(self):
@@ -699,27 +617,19 @@ class TestPathLengthMapping(unittest.TestCase):
             res[42]
 
     def test_keys(self):
-        keys = retworkx.dijkstra_shortest_path_lengths(
-            self.dag, 0, self.fn
-        ).keys()
+        keys = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).keys()
         self.assertEqual([1], list(keys))
 
     def test_values(self):
-        values = retworkx.dijkstra_shortest_path_lengths(
-            self.dag, 0, self.fn
-        ).values()
+        values = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).values()
         self.assertEqual([1.0], list(values))
 
     def test_items(self):
-        items = retworkx.dijkstra_shortest_path_lengths(
-            self.dag, 0, self.fn
-        ).items()
+        items = retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn).items()
         self.assertEqual([(1, 1.0)], list(items))
 
     def test_iter(self):
-        mapping_iter = iter(
-            retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn)
-        )
+        mapping_iter = iter(retworkx.dijkstra_shortest_path_lengths(self.dag, 0, self.fn))
         output = list(mapping_iter)
         self.assertEqual(output, [1])
 
@@ -742,14 +652,10 @@ class TestPos2DMapping(unittest.TestCase):
         self.assertTrue(res == {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__eq__not_match_keys(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0}
-        )
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {2: 1.0})
 
     def test__eq__not_match_values(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0}
-        )
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {1: 2.0})
 
     def test__eq__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -762,23 +668,17 @@ class TestPos2DMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.random_layout(self.dag, seed=10244242) == {"a": None}
-        )
+        self.assertFalse(retworkx.random_layout(self.dag, seed=10244242) == {"a": None})
 
     def test__ne__match(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
         self.assertFalse(res != {0: (0.4883489113112722, 0.6545867364101975)})
 
     def test__ne__not_match(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0}
-        )
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {2: 1.0})
 
     def test__ne__not_match_values(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0}
-        )
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != {1: 2.0})
 
     def test__ne__different_length(self):
         res = retworkx.random_layout(self.dag, seed=10244242)
@@ -786,9 +686,7 @@ class TestPos2DMapping(unittest.TestCase):
         self.assertTrue(res != {1: 1.0, 2: 2.0})
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.random_layout(self.dag, seed=10244242) != ["a", None]
-        )
+        self.assertTrue(retworkx.random_layout(self.dag, seed=10244242) != ["a", None])
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
@@ -835,9 +733,7 @@ class TestPos2DMapping(unittest.TestCase):
 
     def test_items(self):
         items = retworkx.random_layout(self.dag, seed=10244242).items()
-        self.assertEqual(
-            [(0, [0.4883489113112722, 0.6545867364101975])], list(items)
-        )
+        self.assertEqual([(0, [0.4883489113112722, 0.6545867364101975])], list(items))
 
     def test_iter(self):
         mapping_iter = iter(retworkx.random_layout(self.dag, seed=10244242))
@@ -973,26 +869,22 @@ class TestAllPairsPathMapping(unittest.TestCase):
 
     def test__eq__match(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {0: {1: [0, 1]}, 1: {}}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {0: {1: [0, 1]}, 1: {}}
         )
 
     def test__eq__not_match_keys(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {2: {2: [0, 1]}, 1: {}}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {2: {2: [0, 1]}, 1: {}}
         )
 
     def test__eq__not_match_values(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {0: {1: [0, 2]}, 1: {}}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {0: {1: [0, 2]}, 1: {}}
         )
 
     def test__eq__different_length(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {1: [0, 1], 2: [0, 2]}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {1: [0, 1], 2: [0, 2]}
         )
 
     def test_eq__same_type(self):
@@ -1002,52 +894,39 @@ class TestAllPairsPathMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {"a": []}
-        )
+        self.assertFalse(retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {"a": []})
 
     def test__eq__invalid_inner_type(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            == {0: {1: None}}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) == {0: {1: None}}
         )
 
     def test__ne__match(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            != {0: {1: [0, 1]}, 1: {}}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) != {0: {1: [0, 1]}, 1: {}}
         )
 
     def test__ne__not_match(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            != {2: [0, 1]}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) != {2: [0, 1]}
         )
 
     def test__ne__not_match_values(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            != {1: [0, 2]}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) != {1: [0, 2]}
         )
 
     def test__ne__different_length(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            != {1: [0, 1], 2: [0, 2]}
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) != {1: [0, 1], 2: [0, 2]}
         )
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-            != {"a": {}}
-        )
+        self.assertTrue(retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) != {"a": {}})
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) > {
-                1: [0, 2]
-            }
+            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn) > {1: [0, 2]}
 
     def test_deepcopy(self):
         paths = retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
@@ -1082,23 +961,17 @@ class TestAllPairsPathMapping(unittest.TestCase):
             res[42]
 
     def test_keys(self):
-        keys = retworkx.all_pairs_dijkstra_shortest_paths(
-            self.dag, self.fn
-        ).keys()
+        keys = retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn).keys()
         self.assertEqual([0, 1], list(sorted(keys)))
 
     def test_values(self):
-        values = retworkx.all_pairs_dijkstra_shortest_paths(
-            self.dag, self.fn
-        ).values()
+        values = retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn).values()
         # Since run in parallel the order is not deterministic
         expected_valid = [[{1: [0, 1]}, {}], [{}, {1: [0, 1]}]]
         self.assertIn(list(values), expected_valid)
 
     def test_items(self):
-        items = retworkx.all_pairs_dijkstra_shortest_paths(
-            self.dag, self.fn
-        ).items()
+        items = retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn).items()
         # Since run in parallel the order is not deterministic
         expected_valid = [
             [(0, {1: [0, 1]}), (1, {})],
@@ -1107,9 +980,7 @@ class TestAllPairsPathMapping(unittest.TestCase):
         self.assertIn(list(items), expected_valid)
 
     def test_iter(self):
-        mapping_iter = iter(
-            retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn)
-        )
+        mapping_iter = iter(retworkx.all_pairs_dijkstra_shortest_paths(self.dag, self.fn))
         output = list(sorted(mapping_iter))
         self.assertEqual(output, [0, 1])
 
@@ -1131,26 +1002,22 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
 
     def test__eq__match(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {0: {1: 1.0}, 1: {}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {0: {1: 1.0}, 1: {}}
         )
 
     def test__eq__not_match_keys(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {1: {2: 1.0}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {1: {2: 1.0}}
         )
 
     def test__eq__not_match_values(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {0: {2: 2.0}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {0: {2: 2.0}}
         )
 
     def test__eq__different_length(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {0: {1: 1.0, 2: 2.0}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {0: {1: 1.0, 2: 2.0}}
         )
 
     def test_eq__same_type(self):
@@ -1160,33 +1027,24 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
         )
 
     def test__eq__invalid_type(self):
-        self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {"a": 2}
-        )
+        self.assertFalse(retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {"a": 2})
 
     def test__eq__invalid_inner_type(self):
-        self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            == {0: "a"}
-        )
+        self.assertFalse(retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) == {0: "a"})
 
     def test__ne__match(self):
         self.assertFalse(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            != {0: {1: 1.0}, 1: {}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) != {0: {1: 1.0}, 1: {}}
         )
 
     def test__ne__not_match(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            != {0: {2: 1.0}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) != {0: {2: 1.0}}
         )
 
     def test__ne__not_match_values(self):
         self.assertTrue(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            != {0: {1: 2.0}}
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) != {0: {1: 2.0}}
         )
 
     def test__ne__different_length(self):
@@ -1196,16 +1054,11 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
         )
 
     def test__ne__invalid_type(self):
-        self.assertTrue(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-            != {1: []}
-        )
+        self.assertTrue(retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) != {1: []})
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) > {
-                1: 1.0
-            }
+            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn) > {1: 1.0}
 
     def test_deepcopy(self):
         paths = retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
@@ -1223,8 +1076,7 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
         # Since all_pairs_dijkstra_path_lengths() is parallel the order of the
         # output is non-determinisitic
         valid_values = [
-            "AllPairsPathLengthMapping{1: PathLengthMapping{}, "
-            "0: PathLengthMapping{1: 3.14}}",
+            "AllPairsPathLengthMapping{1: PathLengthMapping{}, " "0: PathLengthMapping{1: 3.14}}",
             "AllPairsPathLengthMapping{"
             "0: PathLengthMapping{1: 3.14}, "
             "1: PathLengthMapping{}}",
@@ -1244,31 +1096,23 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
             res[42]
 
     def test_keys(self):
-        keys = retworkx.all_pairs_dijkstra_path_lengths(
-            self.dag, self.fn
-        ).keys()
+        keys = retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn).keys()
         self.assertEqual([0, 1], list(sorted((keys))))
 
     def test_values(self):
-        values = retworkx.all_pairs_dijkstra_path_lengths(
-            self.dag, self.fn
-        ).values()
+        values = retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn).values()
         # Since run in parallel the order is not deterministic
         valid_expected = [[{}, {1: 1.0}], [{1: 1.0}, {}]]
         self.assertIn(list(values), valid_expected)
 
     def test_items(self):
-        items = retworkx.all_pairs_dijkstra_path_lengths(
-            self.dag, self.fn
-        ).items()
+        items = retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn).items()
         # Since run in parallel the order is not deterministic
         valid_expected = [[(0, {1: 1.0}), (1, {})], [(1, {}), (0, {1: 1.0})]]
         self.assertIn(list(items), valid_expected)
 
     def test_iter(self):
-        mapping_iter = iter(
-            retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn)
-        )
+        mapping_iter = iter(retworkx.all_pairs_dijkstra_path_lengths(self.dag, self.fn))
         output = list(sorted(mapping_iter))
         self.assertEqual(output, [0, 1])
 
@@ -1289,170 +1133,118 @@ class TestNodeMap(unittest.TestCase):
 
     def test__eq__match(self):
         self.assertTrue(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            == {0: 1}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) == {0: 1}
         )
 
     def test__eq__not_match_keys(self):
         self.assertFalse(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            == {2: 1}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) == {2: 1}
         )
 
     def test__eq__not_match_values(self):
         self.assertFalse(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            == {0: 2}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) == {0: 2}
         )
 
     def test__eq__different_length(self):
         self.assertFalse(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
             == {0: 1, 1: 2}
         )
 
     def test_eq__same_type(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         self.assertEqual(res, res)
 
     def test__ne__match(self):
         self.assertFalse(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            != {0: 1}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) != {0: 1}
         )
 
     def test__ne__not_match(self):
         self.assertTrue(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            != {2: 2}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) != {2: 2}
         )
 
     def test__ne__not_match_values(self):
         self.assertTrue(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
-            != {0: 2}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) != {0: 2}
         )
 
     def test__ne__different_length(self):
         self.assertTrue(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
             != {0: 1, 1: 2}
         )
 
     def test__gt__not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            ) > {1: 2}
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None) > {1: 2}
 
     def test__len__(self):
         in_dag = retworkx.generators.directed_grid_graph(5, 5)
-        node_map = self.dag.substitute_node_with_subgraph(
-            0, in_dag, lambda *args: None
-        )
+        node_map = self.dag.substitute_node_with_subgraph(0, in_dag, lambda *args: None)
         self.assertEqual(25, len(node_map))
 
     def test_deepcopy(self):
-        node_map = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        node_map = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         node_map_copy = copy.deepcopy(node_map)
         self.assertEqual(node_map, node_map_copy)
 
     def test_pickle(self):
-        node_map = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        node_map = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         node_map_pickle = pickle.dumps(node_map)
         node_map_copy = pickle.loads(node_map_pickle)
         self.assertEqual(node_map, node_map_copy)
 
     def test_str(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         self.assertEqual("NodeMap{0: 1}", str(res))
 
     def test_hash(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         hash_res = hash(res)
         self.assertIsInstance(hash_res, int)
         # Assert hash is stable
         self.assertEqual(hash_res, hash(res))
 
     def test_index_error(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         with self.assertRaises(IndexError):
             res[42]
 
     def test_keys(self):
-        keys = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        ).keys()
+        keys = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None).keys()
         self.assertEqual([0], list(keys))
 
     def test_values(self):
-        values = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        ).values()
+        values = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None).values()
         self.assertEqual([1], list(values))
 
     def test_items(self):
-        items = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        ).items()
+        items = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None).items()
         self.assertEqual([(0, 1)], list(items))
 
     def test_iter(self):
         mapping_iter = iter(
-            self.dag.substitute_node_with_subgraph(
-                0, self.in_dag, lambda *args: None
-            )
+            self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         )
         output = list(mapping_iter)
         self.assertEqual(output, [0])
 
     def test_contains(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         self.assertIn(0, res)
 
     def test_not_contains(self):
-        res = self.dag.substitute_node_with_subgraph(
-            0, self.in_dag, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, self.in_dag, lambda *args: None)
         self.assertNotIn(2, res)
 
     def test_iter_stable_for_same_obj(self):
         graph = retworkx.PyDiGraph()
         graph.add_node(0)
         in_graph = retworkx.generators.directed_path_graph(5)
-        res = self.dag.substitute_node_with_subgraph(
-            0, in_graph, lambda *args: None
-        )
+        res = self.dag.substitute_node_with_subgraph(0, in_graph, lambda *args: None)
         first_iter = list(iter(res))
         second_iter = list(iter(res))
         third_iter = list(iter(res))
@@ -1505,9 +1297,7 @@ class TestChainsComparisons(unittest.TestCase):
         self.assertEqual(self.chains, chains_copy)
 
     def test_str(self):
-        self.assertEqual(
-            "Chains[EdgeList[(0, 2), (2, 1), (1, 0)]]", str(self.chains)
-        )
+        self.assertEqual("Chains[EdgeList[(0, 2), (2, 1), (1, 0)]]", str(self.chains))
 
     def test_hash(self):
         hash_res = hash(self.chains)
@@ -1524,9 +1314,7 @@ class TestProductNodeMap(unittest.TestCase):
 
         self.second = retworkx.PyGraph()
         self.second.add_node("b")
-        _, self.node_map = retworkx.graph_cartesian_product(
-            self.first, self.second
-        )
+        _, self.node_map = retworkx.graph_cartesian_product(self.first, self.second)
 
     def test__eq__match(self):
         self.assertTrue(self.node_map == {(0, 0): 0, (1, 0): 1})

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -63,9 +63,7 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertTrue(numpy.array_equal(expected_res, res))
 
     def test_astar_shortest_path(self):
-        res = retworkx.astar_shortest_path(
-            self.graph, 0, lambda _: True, lambda _: 1, lambda _: 1
-        )
+        res = retworkx.astar_shortest_path(self.graph, 0, lambda _: True, lambda _: 1, lambda _: 1)
         self.assertIsInstance(list(res), list)
 
     def test_dijkstra_shortest_paths(self):
@@ -73,9 +71,7 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertIsInstance(res, retworkx.PathMapping)
 
     def test_dijkstra_shortest_path_lengths(self):
-        res = retworkx.dijkstra_shortest_path_lengths(
-            self.graph, 0, lambda _: 1
-        )
+        res = retworkx.dijkstra_shortest_path_lengths(self.graph, 0, lambda _: 1)
         self.assertIsInstance(res, retworkx.PathLengthMapping)
 
     def test_k_shortest_path_lengths(self):
@@ -87,9 +83,7 @@ class TestDispatchPyGraph(unittest.TestCase):
         self.assertIsInstance(list(res), list)
 
     def test_all_pairs_dijkstra_shortest_paths(self):
-        res = retworkx.all_pairs_dijkstra_shortest_paths(
-            self.graph, lambda _: 1
-        )
+        res = retworkx.all_pairs_dijkstra_shortest_paths(self.graph, lambda _: 1)
         self.assertIsInstance(res, retworkx.AllPairsPathMapping)
 
     def test_all_pairs_dijkstra_path_lengthss(self):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -186,9 +186,7 @@ class TestGeometricRandomGraph(unittest.TestCase):
 
     def test_random_geometric_pos_inf_norm(self):
         pos = [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
-        graph = retworkx.random_geometric_graph(
-            3, 0.11, pos=pos, p=float("inf")
-        )
+        graph = retworkx.random_geometric_graph(3, 0.11, pos=pos, p=float("inf"))
         self.assertEqual(set(graph.edge_list()), {(0, 1), (1, 2)})
 
     def test_random_geometric_num_nodes_invalid(self):
@@ -207,9 +205,7 @@ class TestRandomSubGraphIsomorphism(unittest.TestCase):
         subgraph = graph.subgraph(nodes)
 
         self.assertTrue(
-            retworkx.is_subgraph_isomorphic(
-                graph, subgraph, id_order=True, induced=True
-            )
+            retworkx.is_subgraph_isomorphic(graph, subgraph, id_order=True, induced=True)
         )
 
     def test_random_gnm_non_induced_subgraph_isomorphism(self):
@@ -222,7 +218,5 @@ class TestRandomSubGraphIsomorphism(unittest.TestCase):
             subgraph.remove_edge_from_index(idx)
 
         self.assertTrue(
-            retworkx.is_subgraph_isomorphic(
-                graph, subgraph, id_order=True, induced=False
-            )
+            retworkx.is_subgraph_isomorphic(graph, subgraph, id_order=True, induced=False)
         )

--- a/tests/visualization/test_graphviz.py
+++ b/tests/visualization/test_graphviz.py
@@ -39,9 +39,7 @@ def _save_image(image, path):
         image.save(path)
 
 
-@unittest.skipUnless(
-    HAS_PILLOW, "pillow and graphviz are required for running these tests"
-)
+@unittest.skipUnless(HAS_PILLOW, "pillow and graphviz are required for running these tests")
 class TestGraphvizDraw(unittest.TestCase):
     def test_draw_no_args(self):
         graph = retworkx.generators.star_graph(24)
@@ -115,9 +113,7 @@ class TestGraphvizDraw(unittest.TestCase):
         )
         graph.add_edge(0, 1, dict(label="1", name="1"))
         graph_attr = {"bgcolor": "red"}
-        image = graphviz_draw(
-            graph, lambda node: node, lambda edge: edge, graph_attr
-        )
+        image = graphviz_draw(graph, lambda node: node, lambda edge: edge, graph_attr)
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_draw_graph_attr.png")
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ extras =
 basepython = python3
 envdir = .tox/lint
 deps =
-  black==21.5b0
+  black~=22.0
   flake8
   setuptools-rust
 whitelist_externals=cargo
@@ -69,7 +69,7 @@ commands =
 basepython = python3
 envdir = .tox/lint
 deps =
-  black==21.5b0
+  black~=22.0
 commands = black {posargs} '../retworkx' '../tests'
 
 [flake8]
@@ -78,7 +78,7 @@ commands = black {posargs} '../retworkx' '../tests'
 # E129 skipped because it is too limiting when combined with other rules
 # E711 skipped because sqlalchemy filter() requires using == instead of is
 # max-line-length, E203, W503 are added for black compatibility
-max-line-length = 85
+max-line-length = 110
 ignore = E125,E123,E129,E711
 extend-ignore = E203, W503
 exclude = .venv,.git,.tox,dist,doc,*egg,build


### PR DESCRIPTION
Previously we had been setting rustfmt and black to use an 80 character
line length. This was primarily because my personal dev workflow is
setup around 80 character-wide windows. However, as the project has a
growing number of contributors my personal archaic taste in dev workflow
should not be subjected upon everyone. This commit bumps the max line
length in rustfmt and black up to 100 which is a more common default
that will work better in most editors and not needlessly wrap lines
everywhere. Most of this diff is just the auto-formatting adjustments
now that there are an additional 20 characters available for them to
use.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
