### PR TITLE
Add online topological sorter.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -65,6 +65,7 @@ Traversal
    retworkx.collect_runs
    retworkx.collect_bicolor_runs
    retworkx.visit.BFSVisitor
+   retworkx.TopologicalSorter
 
 .. _dag-algorithms:
 

--- a/releasenotes/notes/online-topo-sort-f94bcd2064a5cde7.yaml
+++ b/releasenotes/notes/online-topo-sort-f94bcd2064a5cde7.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new class, :class:`~retworkx.TopologicalSorter`, which
+    provides functionality to topologically sort a directed graph. It gives
+    the ability to process nodes while they are becoming ready and then mark
+    them as done, so more nodes can be freed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod matching;
 mod random_graph;
 mod shortest_path;
 mod steiner_tree;
+mod toposort;
 mod transitivity;
 mod traversal;
 mod tree;
@@ -311,6 +312,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(chain_decomposition))?;
     m.add_class::<digraph::PyDiGraph>()?;
     m.add_class::<graph::PyGraph>()?;
+    m.add_class::<toposort::TopologicalSorter>()?;
     m.add_class::<iterators::BFSSuccessors>()?;
     m.add_class::<iterators::Chains>()?;
     m.add_class::<iterators::NodeIndices>()?;

--- a/src/toposort.rs
+++ b/src/toposort.rs
@@ -1,0 +1,196 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use crate::digraph::PyDiGraph;
+
+use hashbrown::hash_map::Entry;
+use hashbrown::HashMap;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::Python;
+
+use petgraph::stable_graph::NodeIndex;
+use petgraph::visit::IntoNodeIdentifiers;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeState {
+    Ready,
+    Done,
+}
+
+/// Provides functionality to topologically sort a directed graph.
+///
+/// The steps required to perform the sorting of a given graph are as follows:
+///
+/// 1. Create an instance of the TopologicalSorter with an initial graph.
+/// 2. While `is_active()` is True, iterate over the nodes returned by `get_ready()` and process them.
+/// 3. Call `done()` on each node as it finishes processing.
+///
+/// For example:
+///
+/// .. jupyter-execute::
+///
+///   import retworkx
+///
+///   graph = retworkx.generators.directed_path_graph(5)
+///   sorter = retworkx.TopologicalSorter(graph)
+///   while sorter.is_active():
+///       nodes = sorter.get_ready()
+///       print(nodes)
+///       sorter.done(nodes)
+///
+/// The underlying graph can be mutated and `TopologicalSorter` will pick-up the modifications
+/// but it's not recommended doing it as it may result in a logical-error.
+///
+/// :param PyDiGraph graph: The directed graph to be used.
+#[pyclass(module = "retworkx")]
+pub struct TopologicalSorter {
+    dag: Py<PyDiGraph>,
+    ready_nodes: Vec<NodeIndex>,
+    predecessor_count: HashMap<NodeIndex, usize>,
+    node2state: HashMap<NodeIndex, NodeState>,
+    num_passed_out: usize,
+    num_finished: usize,
+}
+
+#[pymethods]
+impl TopologicalSorter {
+    #[new]
+    fn new(dag: Py<PyDiGraph>, py: Python) -> Self {
+        let ready_nodes = {
+            let dag = &dag.borrow(py);
+
+            dag.graph
+                .node_identifiers()
+                .filter(|node| {
+                    dag.graph
+                        .neighbors_directed(
+                            *node,
+                            petgraph::Direction::Incoming,
+                        )
+                        .next()
+                        .is_none()
+                })
+                .collect()
+        };
+
+        TopologicalSorter {
+            dag,
+            ready_nodes,
+            predecessor_count: HashMap::new(),
+            node2state: HashMap::new(),
+            num_passed_out: 0,
+            num_finished: 0,
+        }
+    }
+
+    /// Return ``True`` if more progress can be made and ``False`` otherwise.
+    ///
+    /// Progress can be made if either there are still nodes ready that haven't yet
+    /// been returned by "get_ready" or the number of nodes marked "done" is less than the
+    /// number that have been returned by "get_ready".
+    fn is_active(&self) -> bool {
+        self.num_finished < self.num_passed_out || !self.ready_nodes.is_empty()
+    }
+
+    /// Return a list of all the nodes that are ready.
+    ///
+    /// Initially it returns all nodes with no predecessors; once those are marked
+    /// as processed by calling "done", further calls will return all new nodes that
+    /// have all their predecessors already processed. Once no more progress can be made,
+    /// empty lists are returned.
+    ///
+    /// :returns: A list of node indices of all the ready nodes.
+    /// :rtype: List
+    fn get_ready(&mut self) -> Vec<usize> {
+        let mut out = Vec::with_capacity(self.ready_nodes.len());
+        for nx in &self.ready_nodes {
+            out.push(nx.index());
+            self.node2state.insert(*nx, NodeState::Ready);
+        }
+
+        self.ready_nodes.clear();
+        self.num_passed_out += out.len();
+        out
+    }
+
+    /// Marks a set of nodes returned by "get_ready" as processed.
+    ///
+    /// This method unblocks any successor of each node in *nodes* for being returned
+    /// in the future by a call to "get_ready".
+    ///
+    /// :param list nodes: A list of node indices to marks as done.
+    ///
+    /// :raises `ValueError`: If any node in *nodes* has already been marked as
+    ///     processed by a previous call to this method or node has not yet been returned
+    ///     by "get_ready".
+    fn done(&mut self, py: Python, nodes: Vec<usize>) -> PyResult<()> {
+        let dag = &self.dag.borrow(py);
+        for node in nodes {
+            let node = NodeIndex::new(node);
+            match self.node2state.get_mut(&node) {
+                None => {
+                    return Err(PyValueError::new_err(format!(
+                        "node {} was not passed out (still not ready).",
+                        node.index()
+                    )));
+                }
+                Some(NodeState::Done) => {
+                    return Err(PyValueError::new_err(format!(
+                        "node {} was already marked done.",
+                        node.index()
+                    )));
+                }
+                Some(state) => {
+                    debug_assert_eq!(*state, NodeState::Ready);
+                    *state = NodeState::Done;
+                }
+            }
+
+            for succ in dag
+                .graph
+                .neighbors_directed(node, petgraph::Direction::Outgoing)
+            {
+                match self.predecessor_count.entry(succ) {
+                    Entry::Occupied(mut entry) => {
+                        *entry.get_mut() -= 1;
+                        if *entry.get() == 0 {
+                            self.ready_nodes.push(succ);
+                            entry.remove_entry();
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        let in_degree = dag
+                            .graph
+                            .neighbors_directed(
+                                succ,
+                                petgraph::Direction::Incoming,
+                            )
+                            .count()
+                            - 1;
+
+                        if in_degree == 0 {
+                            self.ready_nodes.push(succ);
+                        } else {
+                            entry.insert(in_degree);
+                        }
+                    }
+                }
+            }
+
+            self.num_finished += 1;
+        }
+
+        Ok(())
+    }
+}

--- a/src/toposort.rs
+++ b/src/toposort.rs
@@ -76,10 +76,16 @@ pub struct TopologicalSorter {
 impl TopologicalSorter {
     #[new]
     #[args(check_cycle = "true")]
-    fn new(py: Python, dag: Py<PyDiGraph>, check_cycle: bool) -> PyResult<Self> {
+    fn new(
+        py: Python,
+        dag: Py<PyDiGraph>,
+        check_cycle: bool,
+    ) -> PyResult<Self> {
         {
             let dag = &dag.borrow(py);
-            if !dag.check_cycle && check_cycle && !is_directed_acyclic_graph(dag)
+            if !dag.check_cycle
+                && check_cycle
+                && !is_directed_acyclic_graph(dag)
             {
                 return Err(DAGHasCycle::new_err(
                     "PyDiGraph object has a cycle",

--- a/tests/digraph/test_toposort.py
+++ b/tests/digraph/test_toposort.py
@@ -64,3 +64,19 @@ class TestTopologicalSorter(unittest.TestCase):
         sorter.done([0])
         with self.assertRaises(ValueError):
             sorter.done([0])
+
+    def test_topo_sort_raises_if_graph_has_cycle(self):
+        graph = retworkx.generators.directed_cycle_graph(5)
+        with self.assertRaises(retworkx.DAGHasCycle):
+            _ = retworkx.TopologicalSorter(graph)
+
+    def test_topo_sort_progress_if_graph_has_cycle_and_cycle_check_disabled(self):
+        graph = retworkx.generators.directed_cycle_graph(5)
+        starting_node = graph.add_node('starting node')
+        graph.add_edge(starting_node, 0, 'starting edge')
+
+        sorter = retworkx.TopologicalSorter(graph, check_cycle=False)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [starting_node])
+        sorter.done(nodes)
+        self.assertFalse(sorter.is_active())

--- a/tests/digraph/test_toposort.py
+++ b/tests/digraph/test_toposort.py
@@ -70,10 +70,12 @@ class TestTopologicalSorter(unittest.TestCase):
         with self.assertRaises(retworkx.DAGHasCycle):
             _ = retworkx.TopologicalSorter(graph)
 
-    def test_topo_sort_progress_if_graph_has_cycle_and_cycle_check_disabled(self):
+    def test_topo_sort_progress_if_graph_has_cycle_and_cycle_check_disabled(
+        self,
+    ):
         graph = retworkx.generators.directed_cycle_graph(5)
-        starting_node = graph.add_node('starting node')
-        graph.add_edge(starting_node, 0, 'starting edge')
+        starting_node = graph.add_node("starting node")
+        graph.add_edge(starting_node, 0, "starting edge")
 
         sorter = retworkx.TopologicalSorter(graph, check_cycle=False)
         nodes = sorter.get_ready()

--- a/tests/digraph/test_toposort.py
+++ b/tests/digraph/test_toposort.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestTopologicalSorter(unittest.TestCase):
+    def setUp(self):
+        self.graph = retworkx.PyDiGraph()
+        self.graph.extend_from_edge_list(
+            [
+                (0, 2),
+                (1, 2),
+                (2, 3),
+                (2, 4),
+                (3, 5),
+            ]
+        )
+
+    def test_topo_sort(self):
+        sorter = retworkx.TopologicalSorter(self.graph)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [0, 1])
+        sorter.done(nodes)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [2])
+        sorter.done(nodes)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [4, 3])
+        sorter.done(nodes)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [5])
+        sorter.done(nodes)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [])
+
+    def test_topo_sort_do_not_emit_if_node_has_undone_preds(self):
+        sorter = retworkx.TopologicalSorter(self.graph)
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [0, 1])
+        sorter.done([0])
+        nodes = sorter.get_ready()
+        self.assertEqual(nodes, [])
+
+    def test_topo_sort_raises_if_node_not_ready(self):
+        sorter = retworkx.TopologicalSorter(self.graph)
+        with self.assertRaises(ValueError):
+            sorter.done([0])
+
+    def test_topo_sort_raises_if_node_already_done(self):
+        sorter = retworkx.TopologicalSorter(self.graph)
+        sorter.get_ready()
+        sorter.done([0])
+        with self.assertRaises(ValueError):
+            sorter.done([0])


### PR DESCRIPTION
### Summary

This PR implements a new class `TopologicalSorter` to topologically sort a directed graph.
It gives the ability to process nodes while they are becoming ready (i.e they have no unprocessed
predecessors) and then mark them as done, so more nodes can be freed.

### Details

`TopologicalSorter` wraps the underlying graph inside a `Py<..>` with GIL-independent lifetime
in order to avoid cloning the graph. The downside is that users may modify the graph while using
a `TopologicalSorter`, we do not guard against it and this might result in wrong outputs.

Closes #495.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
