### PR TITLE
Improve docstring for lexicographical topological sort

### DIFF
--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -311,7 +311,7 @@ pub fn layers(
 /// This function returns a list of nodes data in a graph lexicographically
 /// topologically sorted using the provided key function. A topological sort
 /// is a linear ordering of vertices such that for every directed edge from
-/// node :math:`u` to node :math:`v` that :math:`u` comes before :math:`v`
+/// node :math:`u` to node :math:`v`, :math:`u` comes before :math:`v`
 /// in the ordering.
 ///
 /// This function differs from :func:`~retworkx.topological_sort` because

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -309,12 +309,21 @@ pub fn layers(
 /// Get the lexicographical topological sorted nodes from the provided DAG
 ///
 /// This function returns a list of nodes data in a graph lexicographically
-/// topologically sorted using the provided key function.
+/// topologically sorted using the provided key function. A topological sort
+/// is a linear ordering of vertices such that for every directed edge from
+/// node :math:`u` to node :math:`v` that :math:`u` comes before :math:`v`
+/// in the ordering.
+///
+/// This function differs from :func:`~retworkx.topological_sort` because
+/// when there are ties between nodes in the sort order this function will
+/// use the string returned by the ``key`` argument to determine the output
+/// order used.
 ///
 /// :param PyDiGraph dag: The DAG to get the topological sorted nodes from
 /// :param callable key: key is a python function or other callable that
 ///     gets passed a single argument the node data from the graph and is
-///     expected to return a string which will be used for sorting.
+///     expected to return a string which will be used for resolving ties
+///     in the sorting order.
 ///
 /// :returns: A list of node's data lexicographically topologically sorted.
 /// :rtype: list


### PR DESCRIPTION
As was pointed out in #506 the docstring for the
`lexicographical_topological_sort()` function was not really clear as to
what it was or how it differed from the normal `topological_sort()`
function. This commit expands the docstring for the function to outline
specifically how it behaves.

Fixes #506

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
