### PR TITLE
Fix `PyGraph.degree` if self-loops.

### DIFF
--- a/releasenotes/notes/fix-degree-with-self-loops-5b40c45cc61fcebe.yaml
+++ b/releasenotes/notes/fix-degree-with-self-loops-5b40c45cc61fcebe.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes :meth:`~retworkx.PyGraph.degree` where self-loops should increment
+    by two (and not by one) the degree of a node in a :class:`~retworkx.PyGraph`
+    object.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -945,7 +945,12 @@ impl PyGraph {
     pub fn degree(&self, node: usize) -> usize {
         let index = NodeIndex::new(node);
         let neighbors = self.graph.edges(index);
-        neighbors.count()
+        neighbors.fold(0, |count, edge| {
+            if edge.source() == edge.target() {
+                return count + 2;
+            }
+            count + 1
+        })
     }
 
     /// Generate a new :class:`~retworkx.PyDiGraph` object from this graph

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -224,6 +224,11 @@ class TestEdges(unittest.TestCase):
         graph.add_edge(node_b, node_c, "Super edgy")
         self.assertEqual(2, graph.degree(node_b))
 
+    def test_degree_with_self_loops(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list([(0, 0), (0, 1), (0, 0)])
+        self.assertEqual(5, graph.degree(0))
+
     def test_add_edge_from(self):
         graph = retworkx.PyGraph()
         nodes = list(range(4))


### PR DESCRIPTION
Closes #517.
In an undirected graph, self-loops should increment by two (and not by one)
the degree of a node.
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
