### PR TITLE
Support undirected graphs in connected components.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -126,6 +126,10 @@ Connectivity and Cycles
 .. autosummary::
    :toctree: stubs
 
+   retworkx.number_connected_components
+   retworkx.connected_components
+   retworkx.node_connected_component
+   retworkx.is_connected
    retworkx.strongly_connected_components
    retworkx.number_weakly_connected_components
    retworkx.weakly_connected_components

--- a/releasenotes/notes/connected-components-undirected-graphs-d81d3fb8c844ef83.yaml
+++ b/releasenotes/notes/connected-components-undirected-graphs-d81d3fb8c844ef83.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Adds :func:`~retworkx.connected_components` for finding connected
+    components in an undirected :class:`~retworkx.PyGraph` graph.
+  - |
+    Adds :func:`~retworkx.number_connected_components` for finding the
+    number of connected components in an undirected :class:`~retworkx.PyGraph`
+    graph.
+  - |
+    Adds :func:`~retworkx.node_connected_component` for finding the connected
+    component that a node belongs in an undirected :class:`~retworkx.PyGraph`
+    graph.
+  - |
+    Adds :func:`~retworkx.is_connected` for checking if an undirected
+    :class:`~retworkx.PyGraph` graph is connected.

--- a/src/connectivity/connected_components.rs
+++ b/src/connectivity/connected_components.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use std::collections::{BTreeSet, VecDeque};
+
+use petgraph::visit::{GraphBase, VisitMap, Visitable};
+use petgraph::EdgeType;
+
+use crate::StablePyGraph;
+
+pub fn bfs_undirected<Ty: EdgeType>(
+    graph: &StablePyGraph<Ty>,
+    start: <StablePyGraph<Ty> as GraphBase>::NodeId,
+    discovered: &mut <StablePyGraph<Ty> as Visitable>::Map,
+) -> BTreeSet<usize> {
+    let mut component = BTreeSet::new();
+    component.insert(start.index());
+    let mut stack = VecDeque::new();
+    stack.push_front(start);
+
+    while let Some(node) = stack.pop_front() {
+        for succ in graph.neighbors_undirected(node) {
+            if discovered.visit(succ) {
+                stack.push_back(succ);
+                component.insert(succ.index());
+            }
+        }
+    }
+
+    component
+}
+
+pub fn connected_components<Ty>(
+    graph: &StablePyGraph<Ty>,
+) -> Vec<BTreeSet<usize>>
+where
+    Ty: EdgeType,
+{
+    let mut conn_components = Vec::new();
+    let mut discovered = graph.visit_map();
+
+    for start in graph.node_indices() {
+        if !discovered.visit(start) {
+            continue;
+        }
+
+        let component = bfs_undirected(graph, start, &mut discovered);
+        conn_components.push(component)
+    }
+
+    conn_components
+}
+
+pub fn number_connected_components<Ty>(graph: &StablePyGraph<Ty>) -> usize
+where
+    Ty: EdgeType,
+{
+    let mut num_components = 0;
+
+    let mut discovered = graph.visit_map();
+    for start in graph.node_indices() {
+        if !discovered.visit(start) {
+            continue;
+        }
+
+        num_components += 1;
+        bfs_undirected(graph, start, &mut discovered);
+    }
+
+    num_components
+}

--- a/src/connectivity/connected_components.rs
+++ b/src/connectivity/connected_components.rs
@@ -10,8 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use std::collections::VecDeque;
 use hashbrown::HashSet;
+use std::collections::VecDeque;
 
 use petgraph::visit::{GraphBase, VisitMap, Visitable};
 use petgraph::EdgeType;

--- a/src/connectivity/connected_components.rs
+++ b/src/connectivity/connected_components.rs
@@ -10,7 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::VecDeque;
+use hashbrown::HashSet;
 
 use petgraph::visit::{GraphBase, VisitMap, Visitable};
 use petgraph::EdgeType;
@@ -21,8 +22,8 @@ pub fn bfs_undirected<Ty: EdgeType>(
     graph: &StablePyGraph<Ty>,
     start: <StablePyGraph<Ty> as GraphBase>::NodeId,
     discovered: &mut <StablePyGraph<Ty> as Visitable>::Map,
-) -> BTreeSet<usize> {
-    let mut component = BTreeSet::new();
+) -> HashSet<usize> {
+    let mut component = HashSet::new();
     component.insert(start.index());
     let mut stack = VecDeque::new();
     stack.push_front(start);
@@ -41,7 +42,7 @@ pub fn bfs_undirected<Ty: EdgeType>(
 
 pub fn connected_components<Ty>(
     graph: &StablePyGraph<Ty>,
-) -> Vec<BTreeSet<usize>>
+) -> Vec<HashSet<usize>>
 where
     Ty: EdgeType,
 {

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -252,7 +252,7 @@ fn number_connected_components(graph: &graph::PyGraph) -> usize {
 /// :rtype: list
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
-pub fn connected_components(graph: &graph::PyGraph) -> Vec<BTreeSet<usize>> {
+pub fn connected_components(graph: &graph::PyGraph) -> Vec<HashSet<usize>> {
     connected_components::connected_components(&graph.graph)
 }
 
@@ -270,7 +270,7 @@ pub fn connected_components(graph: &graph::PyGraph) -> Vec<BTreeSet<usize>> {
 pub fn node_connected_component(
     graph: &graph::PyGraph,
     node: usize,
-) -> PyResult<BTreeSet<usize>> {
+) -> PyResult<HashSet<usize>> {
     let node = NodeIndex::new(node);
 
     if !graph.graph.contains_node(node) {

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -21,7 +21,6 @@ use super::{
 };
 
 use hashbrown::{HashMap, HashSet};
-use std::collections::BTreeSet;
 
 use pyo3::prelude::*;
 use pyo3::Python;

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -340,7 +340,7 @@ fn number_weakly_connected_components(graph: &digraph::PyDiGraph) -> usize {
 #[pyo3(text_signature = "(graph, /)")]
 pub fn weakly_connected_components(
     graph: &digraph::PyDiGraph,
-) -> Vec<BTreeSet<usize>> {
+) -> Vec<HashSet<usize>> {
     connected_components::connected_components(&graph.graph)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,10 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(dag_longest_path_length))?;
     m.add_wrapped(wrap_pyfunction!(dag_weighted_longest_path))?;
     m.add_wrapped(wrap_pyfunction!(dag_weighted_longest_path_length))?;
+    m.add_wrapped(wrap_pyfunction!(number_connected_components))?;
+    m.add_wrapped(wrap_pyfunction!(connected_components))?;
+    m.add_wrapped(wrap_pyfunction!(is_connected))?;
+    m.add_wrapped(wrap_pyfunction!(node_connected_component))?;
     m.add_wrapped(wrap_pyfunction!(number_weakly_connected_components))?;
     m.add_wrapped(wrap_pyfunction!(weakly_connected_components))?;
     m.add_wrapped(wrap_pyfunction!(is_weakly_connected))?;

--- a/tests/graph/test_connected_components.py
+++ b/tests/graph/test_connected_components.py
@@ -1,0 +1,82 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import retworkx
+
+
+class TestConnectedComponents(unittest.TestCase):
+    def test_number_connected(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1, 2])
+        graph.add_edge(0, 1, None)
+        self.assertEqual(retworkx.number_connected_components(graph), 2)
+
+    def test_number_connected_node_holes(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from([0, 1, 2])
+        graph.remove_node(1)
+        self.assertEqual(retworkx.number_connected_components(graph), 2)
+
+    def test_connected_components(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
+        components = retworkx.connected_components(graph)
+        self.assertEqual([{0, 1, 2, 3}, {4, 5, 6, 7}], components)
+
+    def test_node_connected_component(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
+        component = retworkx.node_connected_component(graph, 0)
+        self.assertEqual({0, 1, 2, 3}, component)
+
+    def test_node_connected_component_invalid_node(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
+        with self.assertRaises(retworkx.InvalidNode):
+            retworkx.node_connected_component(graph, 10)
+
+    def test_is_connected_false(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(
+            [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        )
+        self.assertFalse(retworkx.is_connected(graph))
+
+    def test_is_connected_true(self):
+        graph = retworkx.PyGraph()
+        graph.extend_from_edge_list(
+            [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (2, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 4),
+            ]
+        )
+        self.assertTrue(retworkx.is_connected(graph))
+
+    def test_is_connected_null_graph(self):
+        graph = retworkx.PyGraph()
+        with self.assertRaises(retworkx.NullGraph):
+            retworkx.is_connected(graph)


### PR DESCRIPTION
### Summary
This PR introduces several functions: `connected_components`, `number_connected_components`,
`node_connected_component` and `is_connected` for finding connected component in an
undirected graph. Previously, only directed graphs were supported.

Closes #514.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
