### PR TITLE
Raise if negative weights in shortest path algos.

### DIFF
--- a/releasenotes/notes/negative-weights-in-shortest-path-algos-b205b63bd12d1a26.yaml
+++ b/releasenotes/notes/negative-weights-in-shortest-path-algos-b205b63bd12d1a26.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes an oversight in shortest path algorithms like:
+    :func:`~retworkx.dijkstra_shortest_paths`,
+    :func:`~retworkx.dijkstra_shortest_path_lengths`,
+    :func:`~retworkx.all_pairs_dijkstra_path_lengths`,
+    :func:`~retworkx.all_pairs_dijkstra_shortest_paths`,
+    :func:`~retworkx.astar_shortest_path`,
+    :func:`~retworkx.k_shortest_path_lengths`, that would previously
+    accept edge weights with negative or NaN values.

--- a/src/shortest_path/all_pairs_dijkstra.rs
+++ b/src/shortest_path/all_pairs_dijkstra.rs
@@ -32,7 +32,7 @@ use crate::iterators::{
     AllPairsPathLengthMapping, AllPairsPathMapping, PathLengthMapping,
     PathMapping,
 };
-use crate::StablePyGraph;
+use crate::{CostFn, StablePyGraph};
 
 pub fn all_pairs_dijkstra_path_lengths<Ty: EdgeType + Sync>(
     py: Python,
@@ -58,18 +58,14 @@ pub fn all_pairs_dijkstra_path_lengths<Ty: EdgeType + Sync>(
                 .collect(),
         });
     }
-    let edge_cost_callable = |a: &PyObject| -> PyResult<f64> {
-        let res = edge_cost_fn.call1(py, (a,))?;
-        let raw = res.to_object(py);
-        raw.extract(py)
-    };
+    let edge_cost_callable = CostFn::from(edge_cost_fn);
     let mut edge_weights: Vec<Option<f64>> =
         Vec::with_capacity(graph.edge_bound());
     for index in 0..=graph.edge_bound() {
         let raw_weight = graph.edge_weight(EdgeIndex::new(index));
         match raw_weight {
             Some(weight) => {
-                edge_weights.push(Some(edge_cost_callable(weight)?))
+                edge_weights.push(Some(edge_cost_callable.call(py, weight)?))
             }
             None => edge_weights.push(None),
         };
@@ -136,18 +132,14 @@ pub fn all_pairs_dijkstra_shortest_paths<Ty: EdgeType + Sync>(
                 .collect(),
         });
     }
-    let edge_cost_callable = |a: &PyObject| -> PyResult<f64> {
-        let res = edge_cost_fn.call1(py, (a,))?;
-        let raw = res.to_object(py);
-        raw.extract(py)
-    };
+    let edge_cost_callable = CostFn::from(edge_cost_fn);
     let mut edge_weights: Vec<Option<f64>> =
         Vec::with_capacity(graph.edge_bound());
     for index in 0..=graph.edge_bound() {
         let raw_weight = graph.edge_weight(EdgeIndex::new(index));
         match raw_weight {
             Some(weight) => {
-                edge_weights.push(Some(edge_cost_callable(weight)?))
+                edge_weights.push(Some(edge_cost_callable.call(py, weight)?))
             }
             None => edge_weights.push(None),
         };

--- a/src/shortest_path/floyd_warshall.rs
+++ b/src/shortest_path/floyd_warshall.rs
@@ -13,8 +13,7 @@
 use hashbrown::HashMap;
 use retworkx_core::dictmap::*;
 
-use super::weight_callable;
-use crate::get_edge_iter_with_weights;
+use crate::{get_edge_iter_with_weights, weight_callable};
 
 use pyo3::prelude::*;
 use pyo3::Python;

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -105,7 +104,7 @@ class TestAstarDigraph(unittest.TestCase):
         a = g.add_node("A")
         b = g.add_node("B")
         g.add_edge(a, b, 7)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.digraph_astar_shortest_path(

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -98,3 +99,19 @@ class TestAstarDigraph(unittest.TestCase):
             retworkx.digraph_astar_shortest_path(
                 g, 0, lambda x: x, lambda y: 1, lambda z: 0
             )
+
+    def test_astar_with_invalid_weights(self):
+        g = retworkx.PyDAG()
+        a = g.add_node("A")
+        b = g.add_node("B")
+        g.add_edge(a, b, 7)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.digraph_astar_shortest_path(
+                        g,
+                        a,
+                        goal_fn=lambda goal: goal == "B",
+                        edge_cost_fn=lambda _: invalid_weight,
+                        estimate_cost_fn=lambda _: 0,
+                    )

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -290,7 +289,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def dijkstra_with_invalid_weights(self):
         graph = retworkx.generators.directed_path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             for as_undirected in [False, True]:
                 with self.subTest(
                     invalid_weight=invalid_weight, as_undirected=as_undirected
@@ -305,7 +304,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def dijkstra_lengths_with_invalid_weights(self):
         graph = retworkx.generators.directed_path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.digraph_dijkstra_shortest_path_lengths(
@@ -314,7 +313,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def all_pairs_dijkstra_with_invalid_weights(self):
         graph = retworkx.generators.directed_path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.digraph_all_pairs_dijkstra_shortest_paths(
@@ -323,7 +322,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
         graph = retworkx.generators.directed_path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.digraph_all_pairs_dijkstra_path_lengths(

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -286,3 +287,45 @@ class TestDijkstraDiGraph(unittest.TestCase):
             expected,
             retworkx.digraph_all_pairs_dijkstra_shortest_paths(graph, float),
         )
+
+    def dijkstra_with_invalid_weights(self):
+        graph = retworkx.generators.directed_path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            for as_undirected in [False, True]:
+                with self.subTest(
+                    invalid_weight=invalid_weight, as_undirected=as_undirected
+                ):
+                    with self.assertRaises(ValueError):
+                        retworkx.digraph_dijkstra_shortest_paths(
+                            graph,
+                            source=0,
+                            weight_fn=lambda _: invalid_weight,
+                            as_undirected=as_undirected,
+                        )
+
+    def dijkstra_lengths_with_invalid_weights(self):
+        graph = retworkx.generators.directed_path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.digraph_dijkstra_shortest_path_lengths(
+                        graph, node=0, edge_cost_fn=lambda _: invalid_weight
+                    )
+
+    def all_pairs_dijkstra_with_invalid_weights(self):
+        graph = retworkx.generators.directed_path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.digraph_all_pairs_dijkstra_shortest_paths(
+                        graph, edge_cost_fn=lambda _: invalid_weight
+                    )
+
+    def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
+        graph = retworkx.generators.directed_path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.digraph_all_pairs_dijkstra_path_lengths(
+                        graph, edge_cost_fn=lambda _: invalid_weight
+                    )

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -73,3 +74,16 @@ class TestKShortestpath(unittest.TestCase):
             graph, start=1, k=1, edge_cost=lambda _: 1, goal=3
         )
         self.assertEqual({3: 2}, res)
+
+    def test_digraph_k_shortest_path_with_invalid_weight(self):
+        graph = retworkx.generators.directed_path_graph(4)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.digraph_k_shortest_path_lengths(
+                        graph,
+                        start=1,
+                        k=1,
+                        edge_cost=lambda _: invalid_weight,
+                        goal=3,
+                    )

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -77,7 +76,7 @@ class TestKShortestpath(unittest.TestCase):
 
     def test_digraph_k_shortest_path_with_invalid_weight(self):
         graph = retworkx.generators.directed_path_graph(4)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.digraph_k_shortest_path_lengths(

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -98,3 +99,19 @@ class TestAstarGraph(unittest.TestCase):
             retworkx.graph_astar_shortest_path(
                 g, 0, lambda x: x, lambda y: 1, lambda z: 0
             )
+
+    def test_astar_with_invalid_weights(self):
+        g = retworkx.PyGraph()
+        a = g.add_node("A")
+        b = g.add_node("B")
+        g.add_edge(a, b, 7)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.graph_astar_shortest_path(
+                        g,
+                        a,
+                        goal_fn=lambda goal: goal == "B",
+                        edge_cost_fn=lambda _: invalid_weight,
+                        estimate_cost_fn=lambda _: 0,
+                    )

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -105,7 +104,7 @@ class TestAstarGraph(unittest.TestCase):
         a = g.add_node("A")
         b = g.add_node("B")
         g.add_edge(a, b, 7)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.graph_astar_shortest_path(

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -210,7 +209,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def dijkstra_with_invalid_weights(self):
         graph = retworkx.generators.path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             for as_undirected in [False, True]:
                 with self.subTest(
                     invalid_weight=invalid_weight, as_undirected=as_undirected
@@ -225,7 +224,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def dijkstra_lengths_with_invalid_weights(self):
         graph = retworkx.generators.path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.graph_dijkstra_shortest_path_lengths(
@@ -234,7 +233,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def all_pairs_dijkstra_with_invalid_weights(self):
         graph = retworkx.generators.path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.graph_all_pairs_dijkstra_shortest_paths(
@@ -243,7 +242,7 @@ class TestDijkstraGraph(unittest.TestCase):
 
     def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
         graph = retworkx.generators.path_graph(2)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.graph_all_pairs_dijkstra_path_lengths(

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -89,14 +90,14 @@ class TestDijkstraGraph(unittest.TestCase):
         self.assertEqual(expected, path)
 
     def test_dijkstra_with_disconnected_nodes(self):
-        g = retworkx.PyDiGraph()
+        g = retworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
         g.add_edge(a, b, 1.2)
         g.add_node("C")
         d = g.add_node("D")
         g.add_edge(b, d, 2.4)
-        path = retworkx.digraph_dijkstra_shortest_path_lengths(
+        path = retworkx.graph_dijkstra_shortest_path_lengths(
             g, a, lambda x: round(x, 1)
         )
         # Computers never work:
@@ -206,3 +207,45 @@ class TestDijkstraGraph(unittest.TestCase):
             expected,
             retworkx.graph_all_pairs_dijkstra_shortest_paths(graph, float),
         )
+
+    def dijkstra_with_invalid_weights(self):
+        graph = retworkx.generators.path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            for as_undirected in [False, True]:
+                with self.subTest(
+                    invalid_weight=invalid_weight, as_undirected=as_undirected
+                ):
+                    with self.assertRaises(ValueError):
+                        retworkx.graph_dijkstra_shortest_paths(
+                            graph,
+                            source=0,
+                            weight_fn=lambda _: invalid_weight,
+                            as_undirected=as_undirected,
+                        )
+
+    def dijkstra_lengths_with_invalid_weights(self):
+        graph = retworkx.generators.path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.graph_dijkstra_shortest_path_lengths(
+                        graph, node=0, edge_cost_fn=lambda _: invalid_weight
+                    )
+
+    def all_pairs_dijkstra_with_invalid_weights(self):
+        graph = retworkx.generators.path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.graph_all_pairs_dijkstra_shortest_paths(
+                        graph, edge_cost_fn=lambda _: invalid_weight
+                    )
+
+    def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
+        graph = retworkx.generators.path_graph(2)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.graph_all_pairs_dijkstra_path_lengths(
+                        graph, edge_cost_fn=lambda _: invalid_weight
+                    )

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import numpy
 
 import retworkx
 
@@ -54,3 +55,16 @@ class TestKShortestpath(unittest.TestCase):
             graph, start=1, k=1, edge_cost=lambda _: 1, goal=3
         )
         self.assertEqual({3: 2}, res)
+
+    def test_graph_k_shortest_path_with_invalid_weight(self):
+        graph = retworkx.generators.path_graph(4)
+        for invalid_weight in [numpy.nan, -1]:
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaises(ValueError):
+                    retworkx.graph_k_shortest_path_lengths(
+                        graph,
+                        start=1,
+                        k=1,
+                        edge_cost=lambda _: invalid_weight,
+                        goal=3,
+                    )

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -11,7 +11,6 @@
 # under the License.
 
 import unittest
-import numpy
 
 import retworkx
 
@@ -58,7 +57,7 @@ class TestKShortestpath(unittest.TestCase):
 
     def test_graph_k_shortest_path_with_invalid_weight(self):
         graph = retworkx.generators.path_graph(4)
-        for invalid_weight in [numpy.nan, -1]:
+        for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):
                 with self.assertRaises(ValueError):
                     retworkx.graph_k_shortest_path_lengths(


### PR DESCRIPTION
### Summary
Some shortest path algorithms, like `dijkstra_shortest_paths`,
`dijkstra_shortest_path_lengths`, `all_pairs_dijkstra_path_lengths`,
`all_pairs_dijkstra_shortest_paths`, `astar_shortest_path`,
`k_shortest_path_lengths` give incorrect results if there are negative
edge weights. This commit adds a check that raises if a user-defined weight
function returns a negative or NaN value.

Closes #525.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
