### PR TITLE
Fix `unweighted_average_shortest_path_length` if disconnected graph.

### DIFF
--- a/releasenotes/notes/average-path-length-disconnected-56b118a964af085a.yaml
+++ b/releasenotes/notes/average-path-length-disconnected-56b118a964af085a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes the way :func:`~unweighted_average_shortest_path_length` handles
+    disconnected graphs. Previously, disconnected pairs of nodes was assumed
+    to have zero distance and this has been changed to an infinite value.
+    In addition, an extra kwarg ``disconnected`` was added where, if set to
+    ``True``, the average is taken only over connected node pairs. By default,
+    it's set to ``False``.

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -180,19 +180,21 @@ def _graph_distance_matrix(graph, parallel_threshold=300, null_value=0.0):
 
 
 @functools.singledispatch
-def unweighted_average_shortest_path_length(graph, parallel_threshold=300):
+def unweighted_average_shortest_path_length(
+    graph, parallel_threshold=300, disconnected=False
+):
     r"""Return the average shortest path length with unweighted edges.
 
     The average shortest path length is calculated as
 
     .. math::
 
-        a =\sum_{s,t \in V} \frac{d(s, t)}{n(n-1)}
+        a =\sum_{s,t \in V, s \ne t} \frac{d(s, t)}{n(n-1)}
 
     where :math:`V` is the set of nodes in ``graph``, :math:`d(s, t)` is the
     shortest path length from :math:`s` to :math:`t`, and :math:`n` is the
-    number of nodes in ``graph``. This also assumes that :math:`d(s, t) = 0`
-    if :math:`t` cannot be reached from :math:`s`.
+    number of nodes in ``graph``. If ``disconnected`` is set to ``True``,
+    the average will be taken only between connected nodes.
 
     This function is also multithreaded and will run in parallel if the number
     of nodes in the graph is above the value of ``parallel_threshold`` (it
@@ -201,17 +203,20 @@ def unweighted_average_shortest_path_length(graph, parallel_threshold=300):
     By default it will use all available CPUs if the environment variable is
     not specified.
 
-    :param PyDiGraph graph: The graph to compute the average shortest path length
-        for
+    :param graph: The graph to compute the average shortest path length for,
+        can be either a :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
     :param int parallel_threshold: The number of nodes to calculate the
         the distance matrix in parallel at. It defaults to 300, but this can
         be tuned to any number of nodes.
     :param bool as_undirected: If set to ``True`` the input directed graph
         will be treated as if each edge was bidirectional/undirected while
         finding the shortest paths. Default: ``False``.
+    :param bool disconnected: If set to ``True`` only connected vertex pairs
+        will be included in the calculation. If ``False``, infinity is returned
+        for disconnected graphs. Default: ``False``.
 
-    :returns: The average shortest path length. If the graph is empty this
-        will return NaN and if there is a single node 0 will be returned.
+    :returns: The average shortest path length. If no vertex pairs can be included
+        in the calculation this will return NaN.
 
     :rtype: float
     """
@@ -220,19 +225,22 @@ def unweighted_average_shortest_path_length(graph, parallel_threshold=300):
 
 @unweighted_average_shortest_path_length.register(PyDiGraph)
 def _digraph_unweighted_average_shortest_path_length(
-    graph, parallel_threshold=300, as_undirected=False
+    graph, parallel_threshold=300, as_undirected=False, disconnected=False
 ):
     return digraph_unweighted_average_shortest_path_length(
         graph,
         parallel_threshold=parallel_threshold,
         as_undirected=as_undirected,
+        disconnected=disconnected,
     )
 
 
 @unweighted_average_shortest_path_length.register(PyGraph)
-def _graph_unweighted_shortest_path_length(graph, parallel_threshold=300):
+def _graph_unweighted_shortest_path_length(
+    graph, parallel_threshold=300, disconnected=False
+):
     return graph_unweighted_average_shortest_path_length(
-        graph, parallel_threshold=parallel_threshold
+        graph, parallel_threshold=parallel_threshold, disconnected=disconnected
     )
 
 

--- a/src/shortest_path/average_length.rs
+++ b/src/shortest_path/average_length.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use hashbrown::{HashMap, HashSet};
+use hashbrown::HashSet;
 
 use petgraph::prelude::*;
 use petgraph::EdgeType;
@@ -23,27 +23,29 @@ pub fn compute_distance_sum<Ty: EdgeType + Sync>(
     graph: &StablePyGraph<Ty>,
     parallel_threshold: usize,
     as_undirected: bool,
-) -> usize {
+) -> (usize, usize) {
     let n = graph.node_count();
-    let bfs_traversal = |start_index: NodeIndex| -> usize {
-        let mut seen: HashMap<NodeIndex, usize> = HashMap::with_capacity(n);
+    let bfs_traversal = |start_index: NodeIndex| -> (usize, usize) {
+        let mut seen: HashSet<NodeIndex> = HashSet::with_capacity(n);
         let mut level = 0;
         let mut next_level: HashSet<NodeIndex> = HashSet::new();
         next_level.insert(start_index);
-        let mut count = 0;
+        let mut count: usize = 0;
+        let mut conn_pairs: usize = 0;
         while !next_level.is_empty() {
             let this_level = next_level;
             next_level = HashSet::new();
             let mut found: Vec<NodeIndex> = Vec::new();
             for v in this_level {
-                if !seen.contains_key(&v) {
-                    seen.insert(v, level);
+                if seen.insert(v) {
                     found.push(v);
                     count += level;
                 }
             }
+
+            conn_pairs += found.len();
             if seen.len() == n {
-                return count;
+                break;
             }
             for node in found {
                 for v in graph
@@ -61,15 +63,18 @@ pub fn compute_distance_sum<Ty: EdgeType + Sync>(
             }
             level += 1
         }
-        count
+        (count, conn_pairs - 1)
     };
     let node_indices: Vec<NodeIndex> = graph.node_indices().collect();
     if n < parallel_threshold {
-        node_indices.iter().map(|index| bfs_traversal(*index)).sum()
+        node_indices
+            .iter()
+            .map(|index| bfs_traversal(*index))
+            .fold((0, 0), |a, b| (a.0 + b.0, a.1 + b.1))
     } else {
         node_indices
             .par_iter()
             .map(|index| bfs_traversal(*index))
-            .sum()
+            .reduce(|| (0, 0), |a, b| (a.0 + b.0, a.1 + b.1))
     }
 }

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -1094,12 +1094,12 @@ pub fn graph_distance_matrix(
 ///
 /// .. math::
 ///
-///     a =\sum_{s,t \in V} \frac{d(s, t)}{n(n-1)}
+///     a =\sum_{s,t \in V, s \ne t} \frac{d(s, t)}{n(n-1)}
 ///
 /// where :math:`V` is the set of nodes in ``graph``, :math:`d(s, t)` is the
 /// shortest path length from :math:`s` to :math:`t`, and :math:`n` is the
-/// number of nodes in ``graph``. This also assumes that
-/// :math:`d(s, t) = 0` if :math:`t` cannot be reached from :math:`s`.
+/// number of nodes in ``graph``. If ``disconnected`` is set to ``True``,
+/// the average will be taken only between connected nodes.
 ///
 /// This function is also multithreaded and will run in parallel if the number
 /// of nodes in the graph is above the value of ``parallel_threshold`` (it
@@ -1116,32 +1116,48 @@ pub fn graph_distance_matrix(
 /// :param bool as_undirected: If set to ``True`` the input directed graph
 ///     will be treated as if each edge was bidirectional/undirected while
 ///     finding the shortest paths. Default: ``False``.
+/// :param bool disconnected: If set to ``True`` only connected vertex pairs
+///     will be included in the calculation. If ``False``, infinity is returned
+///     for disconnected graphs. Default: ``False``.
 ///
-/// :returns: The average shortest path length. If the graph is empty this
-///     will return NaN and if there is a single node 0 will be returned.
+/// :returns: The average shortest path length. If no vertex pairs can be included
+///     in the calculation this will return NaN.
 /// :rtype: float
-#[pyfunction(parallel_threshold = "300", as_undirected = "false")]
+#[pyfunction(
+    parallel_threshold = "300",
+    as_undirected = "false",
+    disconnected = "false"
+)]
 #[pyo3(
-    text_signature = "(graph, /, parallel_threshold=300, as_undirected=False)"
+    text_signature = "(graph, /, parallel_threshold=300, as_undirected=False, disconnected=False)"
 )]
 pub fn digraph_unweighted_average_shortest_path_length(
     graph: &digraph::PyDiGraph,
     parallel_threshold: usize,
     as_undirected: bool,
+    disconnected: bool,
 ) -> f64 {
     let n = graph.node_count();
-    if n == 0 {
+    if n <= 1 {
         return std::f64::NAN;
     }
-    if n == 1 {
-        return 0.0;
-    }
-    let sum = average_length::compute_distance_sum(
+
+    let (sum, conn_pairs) = average_length::compute_distance_sum(
         &graph.graph,
         parallel_threshold,
         as_undirected,
-    ) as f64;
-    sum / (n * (n - 1)) as f64
+    );
+
+    let tot_pairs = n * (n - 1);
+    if disconnected && conn_pairs == 0 {
+        return std::f64::NAN;
+    }
+
+    if !disconnected && conn_pairs < tot_pairs {
+        return std::f64::INFINITY;
+    }
+
+    (sum as f64) / (conn_pairs as f64)
 }
 
 /// Return the average shortest path length for a :class:`~retworkx.PyGraph`
@@ -1151,12 +1167,12 @@ pub fn digraph_unweighted_average_shortest_path_length(
 ///
 /// .. math::
 ///
-///     a =\sum_{s,t \in V} \frac{d(s, t)}{n(n-1)}
+///     a =\sum_{s,t \in V, s \ne t} \frac{d(s, t)}{n(n-1)}
 ///
 /// where :math:`V` is the set of nodes in ``graph``, :math:`d(s, t)` is the
 /// shortest path length from node :math:`s` to node :math:`t`, and :math:`n`
-/// is the number of nodes in ``graph``. This also assumes that
-/// :math:`d(s, t) = 0` if :math:`t` cannot be reached from :math:`s`.
+/// is the number of nodes in ``graph``. If ``disconnected`` is set to ``True``,
+/// the average will be taken only between connected nodes.
 ///
 /// This function is also multithreaded and will run in parallel if the number
 /// of nodes in the graph is above the value of ``parallel_threshold`` (it
@@ -1170,27 +1186,41 @@ pub fn digraph_unweighted_average_shortest_path_length(
 /// :param int parallel_threshold: The number of nodes to calculate the
 ///     the distance matrix in parallel at. It defaults to 300, but this can
 ///     be tuned to any number of nodes.
+/// :param bool disconnected: If set to ``True`` only connected vertex pairs
+///     will be included in the calculation. If ``False``, infinity is returned
+///     for disconnected graphs. Default: ``False``.
 ///
-/// :returns: The average shortest path length. If the graph is empty this
-///     will return NaN and if there is a single node 0 will be returned.
+/// :returns: The average shortest path length. If no vertex pairs can be included
+///     in the calculation this will return NaN.
 /// :rtype: float
-#[pyfunction(parallel_threshold = "300")]
-#[pyo3(text_signature = "(graph, /, parallel_threshold=300)")]
+#[pyfunction(parallel_threshold = "300", disconnected = "false")]
+#[pyo3(
+    text_signature = "(graph, /, parallel_threshold=300, disconnected=False)"
+)]
 pub fn graph_unweighted_average_shortest_path_length(
     graph: &graph::PyGraph,
     parallel_threshold: usize,
+    disconnected: bool,
 ) -> f64 {
     let n = graph.node_count();
-    if n == 0 {
+    if n <= 1 {
         return std::f64::NAN;
     }
-    if n == 1 {
-        return 0.0;
-    }
-    let sum = average_length::compute_distance_sum(
+
+    let (sum, conn_pairs) = average_length::compute_distance_sum(
         &graph.graph,
         parallel_threshold,
         true,
-    ) as f64;
-    sum / (n * (n - 1)) as f64
+    );
+
+    let tot_pairs = n * (n - 1);
+    if disconnected && conn_pairs == 0 {
+        return std::f64::NAN;
+    }
+
+    if !disconnected && conn_pairs < tot_pairs {
+        return std::f64::INFINITY;
+    }
+
+    (sum as f64) / (conn_pairs as f64)
 }

--- a/tests/digraph/test_avg_shortest_path.py
+++ b/tests/digraph/test_avg_shortest_path.py
@@ -18,11 +18,12 @@ import retworkx
 
 class TestAvgShortestPath(unittest.TestCase):
     def test_simple_example(self):
+        # Graph is not strongly connected.
         edge_list = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (3, 6), (6, 7)]
         graph = retworkx.PyDiGraph()
         graph.extend_from_edge_list(edge_list)
         res = retworkx.digraph_unweighted_average_shortest_path_length(graph)
-        self.assertEqual(1.0714285714285714, res)
+        self.assertTrue(math.isinf(res), "Output is not infinity")
 
     def test_cycle_graph(self):
         graph = retworkx.generators.directed_cycle_graph(7)
@@ -30,14 +31,16 @@ class TestAvgShortestPath(unittest.TestCase):
         self.assertAlmostEqual(3.5, res, delta=1e-7)
 
     def test_path_graph(self):
+        # Graph is not strongly connected.
         graph = retworkx.generators.directed_path_graph(5)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertAlmostEqual(1.0, res, delta=1e-7)
+        self.assertTrue(math.isinf(res), "Output is not infinity")
 
     def test_parallel_grid(self):
+        # Graph is not strongly connected.
         graph = retworkx.generators.directed_grid_graph(30, 11)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertAlmostEqual(3.674772036474164, res, delta=1e-7)
+        self.assertTrue(math.isinf(res), "Output is not infinity")
 
     def test_empty(self):
         graph = retworkx.PyDiGraph()
@@ -48,32 +51,44 @@ class TestAvgShortestPath(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         graph.add_node(0)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_single_node_self_edge(self):
         graph = retworkx.PyDiGraph()
         node = graph.add_node(0)
         graph.add_edge(node, node, 0)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_disconnected_graph(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(graph)
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, disconnected=True
+            )
+            self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_partially_connected_graph(self):
         graph = retworkx.generators.directed_cycle_graph(32)
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(graph)
-        s = 15872
-        den = 4032  # n*(n-1)
-        self.assertAlmostEqual(s / den, res, delta=1e-7)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(graph)
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            s = 15872
+            den = 992  # n*(n-1), n=32 (only connected pairs considered)
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, disconnected=True
+            )
+            self.assertAlmostEqual(s / den, res, delta=1e-7)
 
     def test_connected_cycle_graph(self):
-        # Show the difference between a fully connected example compared to
-        # a partially connected example in "test_partially_connected_graph":
         graph = retworkx.generators.directed_cycle_graph(32)
         res = retworkx.unweighted_average_shortest_path_length(graph)
         s = 15872
@@ -125,7 +140,7 @@ class TestAvgShortestPathAsUndirected(unittest.TestCase):
         res = retworkx.unweighted_average_shortest_path_length(
             graph, as_undirected=True
         )
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_single_node_self_edge(self):
         graph = retworkx.PyDiGraph()
@@ -134,29 +149,41 @@ class TestAvgShortestPathAsUndirected(unittest.TestCase):
         res = retworkx.unweighted_average_shortest_path_length(
             graph, as_undirected=True
         )
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_disconnected_graph(self):
         graph = retworkx.PyDiGraph()
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
-        self.assertEqual(0.0, res)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, as_undirected=True
+            )
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, as_undirected=True, disconnected=True
+            )
+            self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_partially_connected_graph(self):
         graph = retworkx.generators.directed_cycle_graph(32)
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(
-            graph, as_undirected=True
-        )
-        s = 8192
-        den = 4032  # n*(n-1)
-        self.assertAlmostEqual(s / den, res, delta=1e-7)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, as_undirected=True
+            )
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            s = 8192
+            den = 992  # n*(n-1), n=32 (only connected pairs considered)
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, as_undirected=True, disconnected=True
+            )
+            self.assertAlmostEqual(s / den, res, delta=1e-7)
 
     def test_connected_cycle_graph(self):
-        # Show the difference between a fully connected example compared to
-        # a partially connected example in "test_partially_connected_graph":
         graph = retworkx.generators.directed_cycle_graph(32)
         res = retworkx.unweighted_average_shortest_path_length(
             graph, as_undirected=True

--- a/tests/graph/test_avg_shortest_path.py
+++ b/tests/graph/test_avg_shortest_path.py
@@ -48,32 +48,44 @@ class TestUnweightedAvgShortestPath(unittest.TestCase):
         graph = retworkx.PyGraph()
         graph.add_node(0)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_single_node_self_edge(self):
         graph = retworkx.PyGraph()
         node = graph.add_node(0)
         graph.add_edge(node, node, 0)
         res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_disconnected_graph(self):
         graph = retworkx.PyGraph()
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(graph)
-        self.assertEqual(0.0, res)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(graph)
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, disconnected=True
+            )
+            self.assertTrue(math.isnan(res), "Output is not NaN")
 
     def test_partially_connected_graph(self):
         graph = retworkx.generators.cycle_graph(32)
         graph.add_nodes_from(list(range(32)))
-        res = retworkx.unweighted_average_shortest_path_length(graph)
-        s = 8192
-        den = 4032  # n*(n-1)
-        self.assertAlmostEqual(s / den, res, delta=1e-7)
+        with self.subTest(disconnected=False):
+            res = retworkx.unweighted_average_shortest_path_length(graph)
+            self.assertTrue(math.isinf(res), "Output is not infinity")
+
+        with self.subTest(disconnected=True):
+            s = 8192
+            den = 992  # n*(n-1), n=32 (only connected pairs considered)
+            res = retworkx.unweighted_average_shortest_path_length(
+                graph, disconnected=True
+            )
+            self.assertAlmostEqual(s / den, res, delta=1e-7)
 
     def test_connected_cycle_graph(self):
-        # Show the difference between a fully connected example compared to
-        # a partially connected example in "test_partially_connected_graph":
         graph = retworkx.generators.cycle_graph(32)
         res = retworkx.unweighted_average_shortest_path_length(graph)
         s = 8192


### PR DESCRIPTION
### Summary

Fixes the way `unweighted_average_shortest_path_length` handles
disconnected graphs. Disconnected pairs of nodes are now assumed
to have an infinite distance. In addition, an extra kwarg ``disconnected``
was added where, if set to ``True``, the average is taken only over
connected node pairs. By default, it's set to ``False``.

Closes #524.
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
