### PR TITLE
Remove pip install setuptools-rust from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ pip install retworkx
 will build retworkx for your local system from the source package and install
 it just as it would if there was a prebuilt binary available.
 
+Note: To build from source you will need to ensure you have a newer version
+of pip installed that supports PEP-517, or that you have manually installed
+`setuptools-rust` prior to running `pip install retworkx`. If you recieve an error
+about `setuptools-rust` not being found you should upgrade pip with
+`pip install -U pip` or manually install `setuptools-rust` with
+`pip install setuptools-rust` and try again.
+
 ### Optional dependencies
 
 If you're planning to use the `retworkx.visualization` module you will need to

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ pip install retworkx
 will build retworkx for your local system from the source package and install
 it just as it would if there was a prebuilt binary available.
 
-Note: To build from source you will need to ensure you have a newer version
-of pip installed that supports PEP-517, or that you have manually installed
-`setuptools-rust` prior to running `pip install retworkx`. If you recieve an error
-about `setuptools-rust` not being found you should upgrade pip with
+Note: To build from source you will need to ensure you have pip >=19.0.0
+installed, which supports PEP-517, or that you have manually installed
+`setuptools-rust` prior to running `pip install retworkx`. If you recieve an
+error about `setuptools-rust` not being found you should upgrade pip with
 `pip install -U pip` or manually install `setuptools-rust` with
 `pip install setuptools-rust` and try again.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "setuptools-rust"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,7 @@
 # that they have been altered from the originals.
 
 from setuptools import setup
-try:
-    from setuptools_rust import Binding, RustExtension
-except ImportError:
-    import sys
-    import subprocess
-
-    subprocess.call([sys.executable, '-m', 'pip', 'install',
-                     'setuptools-rust'])
-    from setuptools_rust import Binding, RustExtension
+from setuptools_rust import Binding, RustExtension
 
 
 def readme():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 2.1
 envlist = py36, py37, py38, py39, py310, lint
+isolated_build = true
 
 [testenv]
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}


### PR DESCRIPTION
The setup.py has long carried around a pip install fallback if
setuptools-rust can't be imported. This was necessary as prior to the
introduction of pep-517 there was no way to express a build-system
requirement in python packaging. There is the setup_requires field in
the setuptools metadata, but this would both trigger the install too
late (as we need to import setuptools-rust prior to running
setuptools.setup()) and also fallback to using easy_install instead of
pip which complicates installation. With pep-517 we list setuptools-rust
as a build system requirement in the pyproject.toml and pip will just
install that prior to trying to run the setup.py in the sdist.

But, for users on older versions of pip, before pep-517 was supported,
this caused a cryptic error as there would just be an import error that
setuptools_rust can't be found. The pip install fallback on import error
was added to try and make installation seamless for those users. However,
pep-517 support has been around in pip for sufficiently long at this
point I think we can safely remove this fallback as it provides more
harm than good now. In it's place the README is updated to document
that you need a newer version of pip or to manually install
setuptools-rust prior to trying to build retworkx from source. This
should hopefully be sufficient for users on older versions of pip where
they still might encounter issues.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
