### PR TITLE
Remove optional dependency on pydot

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ installed with `pip install matplotlib` or when you're installing retworkx with
 function `retworkx.visualization.graphviz_drawer` first you will need to install
 graphviz, instructions for this can be found here:
 https://graphviz.org/download/#executable-packages. Then you
-will need to install the [pydot](https://pypi.org/project/pydot/) and
-[pillow](https://python-pillow.org/) Python libraries. This can be done either
-with `pip install pydot pillow` or when installing retworkx with
-`pip install 'retworkx[graphviz]'`.
+will need to install the [pillow](https://python-pillow.org/) Python library.
+This can be done either with `pip install pillow` or when installing retworkx
+with `pip install 'retworkx[graphviz]'`.
 
 If you would like to install all the optional Python dependencies when you
 install retworkx you can use `pip install 'retworkx[all]'` to do this.

--- a/releasenotes/notes/no-more-pydot-d57c3b0e7456e3d4.yaml
+++ b/releasenotes/notes/no-more-pydot-d57c3b0e7456e3d4.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The optional dependencies for :func:`~retworkx.visualization.graphviz_draw`
+    (as documented by the ``graphviz`` optional extra, which can be installed
+    via ``pip install retworkx[graphviz]``) no longer requires the ``pydot``
+    library. Only the ``pillow`` library is needed now to generate visualizations
+    using graphviz.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def readme():
 
 
 mpl_extras = ['matplotlib>=3.0']
-graphviz_extras = ['pydot>=1.4', 'pillow>=5.4']
+graphviz_extras = ['pillow>=5.4']
 
 
 setup(

--- a/tests/visualization/test_graphviz.py
+++ b/tests/visualization/test_graphviz.py
@@ -122,11 +122,21 @@ class TestGraphvizDraw(unittest.TestCase):
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_draw_image_type.jpg")
 
+    def test_image_type_invalid_type(self):
+        graph = retworkx.directed_gnp_random_graph(50, 0.8)
+        with self.assertRaises(ValueError):
+            graphviz_draw(graph, image_type="raw")
+
     def test_method(self):
         graph = retworkx.directed_gnp_random_graph(50, 0.8)
         image = graphviz_draw(graph, method="sfdp")
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_method.png")
+
+    def test_method_invalid_method(self):
+        graph = retworkx.directed_gnp_random_graph(50, 0.8)
+        with self.assertRaises(ValueError):
+            graphviz_draw(graph, method="special")
 
     def test_filename(self):
         graph = retworkx.generators.grid_graph(20, 20)

--- a/tests/visualization/test_graphviz.py
+++ b/tests/visualization/test_graphviz.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import os
+import subprocess
 import tempfile
 import unittest
 
@@ -18,13 +19,17 @@ import retworkx
 from retworkx.visualization import graphviz_draw
 
 try:
-    import pydot
     import PIL
 
-    pydot.call_graphviz("dot", ["--version"], tempfile.gettempdir())
-    HAS_PYDOT = True
+    subprocess.run(
+        ["dot", "-V"],
+        cwd=tempfile.gettempdir(),
+        check=True,
+        capture_output=True,
+    )
+    HAS_PILLOW = True
 except Exception:
-    HAS_PYDOT = False
+    HAS_PILLOW = False
 
 SAVE_IMAGES = os.getenv("RETWORKX_TEST_PRESERVE_IMAGES", None)
 
@@ -35,7 +40,7 @@ def _save_image(image, path):
 
 
 @unittest.skipUnless(
-    HAS_PYDOT, "pydot and graphviz are required for running these tests"
+    HAS_PILLOW, "pillow and graphviz are required for running these tests"
 )
 class TestGraphvizDraw(unittest.TestCase):
     def test_draw_no_args(self):


### PR DESCRIPTION
Previously we were relying on the pydot library to call graphviz to
generate visualizations. This was done for simplicity since pydot is all
about providing a python API wrapper around graphviz. However, it does
this by parsing the dot files into it's own internal representation of
the graph description to provide a python api for interacting with it
prior to calling out to graphviz. For retworkx this is unnecessary as we
have a native function for generating dot files and we just need to pass
that directly to graphviz. Additionally, this parsing adds a place for
bugs to be introduced as was seen in #526 when a new version of
pyparsing (the dependency pydot uses to parse the dot files) started
causing invalid output to be generated. This commit updates the graphviz
drawer to stop using pydot and instead manually calling graphviz
directly with the retworkx generated dot files. The setup.py's optional
extras are then updated to no longer list pydot as required for the
graphviz drawer. This should hopefully reduce the complexity of the code
path and avoid potential future issues.

Fixes #526

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
