### PR TITLE
Fix cargo fmt call in tox.ini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Test Build
         run: cargo build
       - name: Rust Format
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Black Codestyle Format

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ whitelist_externals=cargo
 commands =
   black --check --diff {posargs} '../retworkx' '../tests'
   flake8 --per-file-ignores='../retworkx/__init__.py:F405,F403' ../setup.py ../retworkx .
-  cargo fmt -- --check
+  cargo fmt --all -- --check
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This commit updates the lint job definition in the tox.ini to work now
that we have workspaces in the rust package. In #459 we added a new
workspace for the dedicated rust package retworkx-core. But having
workspaces means that running cargo fmt outside from the tests/
directory (as we do with tox) means cargo doesn't know which workspace
to run against. To correct this issue this commit adds the --all flag to
the cargo fmt call in the tox job definition to ensure we're able to run
from any directory in the repo and check the formatting on all the rust
files in the project.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
