### PR TITLE
Add edge utility methods to PyGraph and PyDiGraph

### DIFF
--- a/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
+++ b/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
@@ -2,16 +2,22 @@
 features:
   - |
     Added a new method, :meth:`~retworkx.PyGraph.incident_edges`, to the
-    :class:`~retworkx.PyGraph` class. This method returns a list of edge
-    indices for edges incident to a provided node.
+    :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` class. This
+    method returns a list of edge indices for edges incident to a provided node.
   - |
     Added a new method, :meth:`~retworkx.PyGraph.get_edge_data_by_index`,
-    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyGraph` classes.
+    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` classes.
     This method returns the data payload for an edge in the graph from its
     index.
   - |
     Added a new method, :meth:`~retworkx.PyGraph.get_edge_endpoints_by_index`,
-    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyGraph` classes.
+    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` classes.
     This method returns the edge's endpoint tuple for an edge in the graph from
     its index.
+  - |
+    Added two new methods, :meth:`~retworkx.PyGraph.out_edges` and
+    :meth:`~retworkx.PyGraph.in_edges`. These methods are the dual of the
+    :class:`~retworkx.PyDiGraph` methods, :meth:`~retworkx.PyDiGraph.out_edges`
+    and :meth:`~retworkx.PyDiGraph.in_edges` and return a
+    :class:`~retworkx.WeightedEdgeList` of the incident edges for a node.
 

--- a/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
+++ b/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
@@ -5,6 +5,19 @@ features:
     :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` class. This
     method returns a list of edge indices for edges incident to a provided node.
   - |
+    Added a new method, :meth:`~retworkx.PyGraph.incident_edge_index_map`, to the
+    :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` class. This
+    method returns a mapping of edge indices for edges incident to a provided node
+    to the endoint and weight tuple for that edge index. For example:
+
+    .. jupyter-execute::
+
+        import retworkx
+        graph = retworkx.PyGraph()
+        graph.extend_from_weighted_edge_list([(0, 1, "A"), (0, 2, "B")])
+        print(graph.incident_edge_index_map(0))
+
+  - |
     Added a new method, :meth:`~retworkx.PyGraph.get_edge_data_by_index`,
     to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyDiGraph` classes.
     This method returns the data payload for an edge in the graph from its

--- a/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
+++ b/releasenotes/notes/edge-index-methods-427f7301c720f565.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Added a new method, :meth:`~retworkx.PyGraph.incident_edges`, to the
+    :class:`~retworkx.PyGraph` class. This method returns a list of edge
+    indices for edges incident to a provided node.
+  - |
+    Added a new method, :meth:`~retworkx.PyGraph.get_edge_data_by_index`,
+    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyGraph` classes.
+    This method returns the data payload for an edge in the graph from its
+    index.
+  - |
+    Added a new method, :meth:`~retworkx.PyGraph.get_edge_endpoints_by_index`,
+    to the :class:`~retworkx.PyGraph` and :class:`~retworkx.PyGraph` classes.
+    This method returns the edge's endpoint tuple for an edge in the graph from
+    its index.
+

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1554,7 +1554,11 @@ impl PyDiGraph {
         }
     }
 
-    /// Return the list of edge indices incent to a provided node
+    /// Return the list of edge indices incident to a provided node
+    ///
+    /// You can later retrieve the data payload of this edge with
+    /// :meth:`~retworkx.PyDiGraph.get_edge_data_by_index` or its
+    /// endpoints with :meth:`~retworkx.PyDiGraph.get_edge_endpoints_by_index`.
     ///
     /// By default this method will only return the outgoing edges of
     /// the provided ``node``. If you would like to access both the

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -670,7 +670,7 @@ impl PyDiGraph {
     ///
     /// :param int edge_index: The edge index to get the data for
     ///
-    /// :returns: The data object set for the edge
+    /// :returns: The data object for the edge
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
@@ -694,7 +694,8 @@ impl PyDiGraph {
     ///
     /// :param int edge_index: The edge index to get the endpoints for
     ///
-    /// :returns: The data object set for the edge
+    /// :returns: The endpoint tuple for the edge
+    /// :rtype: tuple
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1562,6 +1562,7 @@ impl PyDiGraph {
     ///
     /// :returns: A list of the edge indices incident to a node in the graph
     /// :rtype: EdgeIndices
+    #[pyo3(text_signature = "(self, node, /)")]
     pub fn incident_edges(&self, node: usize) -> EdgeIndices {
         EdgeIndices {
             edges: self

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -666,6 +666,55 @@ impl PyDiGraph {
         Ok(data)
     }
 
+    /// Return the edge data for the edge by it's given index
+    ///
+    /// :param int edge_index: The edge index to get the data for
+    ///
+    /// :returns: The data object set for the edge
+    /// :raises IndexError: when there is no edge present with the provided
+    ///     index
+    #[pyo3(text_signature = "(self, edge_index, /)")]
+    pub fn get_edge_data_by_index(
+        &self,
+        edge_index: usize,
+    ) -> PyResult<&PyObject> {
+        let data = match self.graph.edge_weight(EdgeIndex::new(edge_index)) {
+            Some(data) => data,
+            None => {
+                return Err(PyIndexError::new_err(format!(
+                    "Provided edge index {} is not present in the graph",
+                    edge_index
+                )));
+            }
+        };
+        Ok(data)
+    }
+
+    /// Return the edge endpoints for the edge by it's given index
+    ///
+    /// :param int edge_index: The edge index to get the endpoints for
+    ///
+    /// :returns: The data object set for the edge
+    /// :raises IndexError: when there is no edge present with the provided
+    ///     index
+    #[pyo3(text_signature = "(self, edge_index, /)")]
+    pub fn get_edge_endpoints_by_index(
+        &self,
+        edge_index: usize,
+    ) -> PyResult<(usize, usize)> {
+        let endpoints =
+            match self.graph.edge_endpoints(EdgeIndex::new(edge_index)) {
+                Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
+                None => {
+                    return Err(PyIndexError::new_err(format!(
+                        "Provided edge index {} is not present in the graph",
+                        edge_index
+                    )));
+                }
+            };
+        Ok(endpoints)
+    }
+
     /// Update an edge's weight/payload inplace
     ///
     /// If there are parallel edges in the graph only one edge will be updated.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1552,6 +1552,25 @@ impl PyDiGraph {
                 .collect(),
         }
     }
+
+    /// Return the list of edge indices incent to a provided node
+    ///
+    /// :param int node: The node index to get incident edges from. If
+    ///     this node index is not present in the graph this method will
+    ///     return an empty list and not error.
+    ///
+    /// :returns: A list of the edge indices incident to a node in the graph
+    /// :rtype: EdgeIndices
+    pub fn incident_edges(&self, node: usize) -> EdgeIndices {
+        EdgeIndices {
+            edges: self
+                .graph
+                .edges(NodeIndex::new(node))
+                .map(|e| e.id().index())
+                .collect(),
+        }
+    }
+
     /// Get the index and edge data for all parents of a node.
     ///
     /// This will return a list of tuples with the parent index the node index

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -666,7 +666,7 @@ impl PyDiGraph {
         Ok(data)
     }
 
-    /// Return the edge data for the edge by it's given index
+    /// Return the edge data for the edge by its given index
     ///
     /// :param int edge_index: The edge index to get the data for
     ///
@@ -690,7 +690,7 @@ impl PyDiGraph {
         Ok(data)
     }
 
-    /// Return the edge endpoints for the edge by it's given index
+    /// Return the edge endpoints for the edge by its given index
     ///
     /// :param int edge_index: The edge index to get the endpoints for
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -386,6 +386,7 @@ impl PyGraph {
     ///
     /// :returns: A list of the edge indices incident to a node in the graph
     /// :rtype: EdgeIndices
+    #[pyo3(text_signature = "(self, node, /)")]
     pub fn incident_edges(&self, node: usize) -> EdgeIndices {
         EdgeIndices {
             edges: self
@@ -398,7 +399,7 @@ impl PyGraph {
 
     /// Get the endpoint indices and edge data for all edges of a node.
     ///
-    /// This will return a list of tuples with the parent index the node index
+    /// This will return a list of tuples with the parent index, the node index
     /// and the edge data. This can be used to recreate add_edge() calls. As
     /// :class:`~retworkx.PyGraph` is undirected this will return all edges
     /// with the second endpoint node index always being ``node``.
@@ -421,7 +422,7 @@ impl PyGraph {
 
     /// Get the endpoint indices and edge data for all edges of a node.
     ///
-    /// This will return a list of tuples with the child index the node index
+    /// This will return a list of tuples with the child index, the node index
     /// and the edge data. This can be used to recreate add_edge() calls. As
     /// :class:`~retworkx.PyGraph` is undirected this will return all edges
     /// with the first endpoint node index always being ``node``.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -401,6 +401,40 @@ impl PyGraph {
         }
     }
 
+    /// Return the index map of edges incident to a provided node
+    ///
+    /// :param int node: The node index to get incident edges from. If
+    ///     this node index is not present in the graph this method will
+    ///     return an empty mapping and not error.
+    ///
+    /// :returns: A mapping of incident edge indices to the tuple
+    ///     ``(source, target, data)``
+    /// :rtype: EdgeIndexMap
+    #[pyo3(text_signature = "(self, node, /)")]
+    pub fn incident_edge_index_map(
+        &self,
+        py: Python,
+        node: usize,
+    ) -> EdgeIndexMap {
+        let node_index = NodeIndex::new(node);
+        EdgeIndexMap {
+            edge_map: self
+                .graph
+                .edges(node_index)
+                .map(|edge| {
+                    (
+                        edge.id().index(),
+                        (
+                            edge.source().index(),
+                            edge.target().index(),
+                            edge.weight().clone_ref(py),
+                        ),
+                    )
+                })
+                .collect(),
+        }
+    }
+
     /// Get the endpoint indices and edge data for all edges of a node.
     ///
     /// This will return a list of tuples with the parent index, the node index

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -446,7 +446,7 @@ impl PyGraph {
     ///
     /// :param int edge_index: The edge index to get the data for
     ///
-    /// :returns: The data object set for the edge
+    /// :returns: The data object for the edge
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
@@ -470,7 +470,8 @@ impl PyGraph {
     ///
     /// :param int edge_index: The edge index to get the endpoints for
     ///
-    /// :returns: The data object set for the edge
+    /// :returns: The endpoint tuple for the edge
+    /// :rtype: tuple
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -378,7 +378,11 @@ impl PyGraph {
         Ok(data)
     }
 
-    /// Return the list of edge indices incent to a provided node
+    /// Return the list of edge indices incident to a provided node
+    ///
+    /// You can later retrieve the data payload of this edge with
+    /// :meth:`~retworkx.PyGraph.get_edge_data_by_index` or its
+    /// endpoints with :meth:`~retworkx.PyGraph.get_edge_endpoints_by_index`.
     ///
     /// :param int node: The node index to get incident edges from. If
     ///     this node index is not present in the graph this method will

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -442,7 +442,7 @@ impl PyGraph {
         WeightedEdgeList { edges: out_list }
     }
 
-    /// Return the edge data for the edge by it's given index
+    /// Return the edge data for the edge by its given index
     ///
     /// :param int edge_index: The edge index to get the data for
     ///
@@ -466,7 +466,7 @@ impl PyGraph {
         Ok(data)
     }
 
-    /// Return the edge endpoints for the edge by it's given index
+    /// Return the edge endpoints for the edge by its given index
     ///
     /// :param int edge_index: The edge index to get the endpoints for
     ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -396,6 +396,52 @@ impl PyGraph {
         }
     }
 
+    /// Get the endpoint indices and edge data for all edges of a node.
+    ///
+    /// This will return a list of tuples with the parent index the node index
+    /// and the edge data. This can be used to recreate add_edge() calls. As
+    /// :class:`~retworkx.PyGraph` is undirected this will return all edges
+    /// with the second endpoint node index always being ``node``.
+    ///
+    /// :param int node: The index of the node to get the edges for
+    ///
+    /// :returns: A list of tuples of the form:
+    ///     ``(parent_index, node_index, edge_data)```
+    /// :rtype: WeightedEdgeList
+    #[pyo3(text_signature = "(self, node, /)")]
+    pub fn in_edges(&self, py: Python, node: usize) -> WeightedEdgeList {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Incoming;
+        let raw_edges = self.graph.edges_directed(index, dir);
+        let out_list: Vec<(usize, usize, PyObject)> = raw_edges
+            .map(|x| (x.source().index(), node, x.weight().clone_ref(py)))
+            .collect();
+        WeightedEdgeList { edges: out_list }
+    }
+
+    /// Get the endpoint indices and edge data for all edges of a node.
+    ///
+    /// This will return a list of tuples with the child index the node index
+    /// and the edge data. This can be used to recreate add_edge() calls. As
+    /// :class:`~retworkx.PyGraph` is undirected this will return all edges
+    /// with the first endpoint node index always being ``node``.
+    ///
+    /// :param int node: The index of the node to get the edges for
+    ///
+    /// :returns out_edges: A list of tuples of the form:
+    ///     ```(node_index, child_index, edge_data)```
+    /// :rtype: WeightedEdgeList
+    #[pyo3(text_signature = "(self, node, /)")]
+    pub fn out_edges(&self, py: Python, node: usize) -> WeightedEdgeList {
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Outgoing;
+        let raw_edges = self.graph.edges_directed(index, dir);
+        let out_list: Vec<(usize, usize, PyObject)> = raw_edges
+            .map(|x| (node, x.target().index(), x.weight().clone_ref(py)))
+            .collect();
+        WeightedEdgeList { edges: out_list }
+    }
+
     /// Return the edge data for the edge by it's given index
     ///
     /// :param int edge_index: The edge index to get the data for

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -378,6 +378,73 @@ impl PyGraph {
         Ok(data)
     }
 
+    /// Return the list of edge indices incent to a provided node
+    ///
+    /// :param int node: The node index to get incident edges from. If
+    ///     this node index is not present in the graph this method will
+    ///     return an empty list and not error.
+    ///
+    /// :returns: A list of the edge indices incident to a node in the graph
+    /// :rtype: EdgeIndices
+    pub fn incident_edges(&self, node: usize) -> EdgeIndices {
+        EdgeIndices {
+            edges: self
+                .graph
+                .edges(NodeIndex::new(node))
+                .map(|e| e.id().index())
+                .collect(),
+        }
+    }
+
+    /// Return the edge data for the edge by it's given index
+    ///
+    /// :param int edge_index: The edge index to get the data for
+    ///
+    /// :returns: The data object set for the edge
+    /// :raises IndexError: when there is no edge present with the provided
+    ///     index
+    #[pyo3(text_signature = "(self, edge_index, /)")]
+    pub fn get_edge_data_by_index(
+        &self,
+        edge_index: usize,
+    ) -> PyResult<&PyObject> {
+        let data = match self.graph.edge_weight(EdgeIndex::new(edge_index)) {
+            Some(data) => data,
+            None => {
+                return Err(PyIndexError::new_err(format!(
+                    "Provided edge index {} is not present in the graph",
+                    edge_index
+                )));
+            }
+        };
+        Ok(data)
+    }
+
+    /// Return the edge endpoints for the edge by it's given index
+    ///
+    /// :param int edge_index: The edge index to get the endpoints for
+    ///
+    /// :returns: The data object set for the edge
+    /// :raises IndexError: when there is no edge present with the provided
+    ///     index
+    #[pyo3(text_signature = "(self, edge_index, /)")]
+    pub fn get_edge_endpoints_by_index(
+        &self,
+        edge_index: usize,
+    ) -> PyResult<(usize, usize)> {
+        let endpoints =
+            match self.graph.edge_endpoints(EdgeIndex::new(edge_index)) {
+                Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
+                None => {
+                    return Err(PyIndexError::new_err(format!(
+                        "Provided edge index {} is not present in the graph",
+                        edge_index
+                    )));
+                }
+            };
+        Ok(endpoints)
+    }
+
     /// Update an edge's weight/payload in place
     ///
     /// If there are parallel edges in the graph only one edge will be updated.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -408,7 +408,10 @@ impl PyGraph {
     ///     return an empty mapping and not error.
     ///
     /// :returns: A mapping of incident edge indices to the tuple
-    ///     ``(source, target, data)``
+    ///     ``(source, target, data)``. The source endpoint node index in
+    ///     this tuple will always be ``node`` to ensure you can easily
+    ///     identify that the neighbor node is the second element in the
+    ///     tuple for a given edge index.
     /// :rtype: EdgeIndexMap
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn incident_edge_index_map(
@@ -420,7 +423,7 @@ impl PyGraph {
         EdgeIndexMap {
             edge_map: self
                 .graph
-                .edges(node_index)
+                .edges_directed(node_index, petgraph::Direction::Outgoing)
                 .map(|edge| {
                     (
                         edge.id().index(),

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -718,6 +718,35 @@ class TestEdges(unittest.TestCase):
         res = graph.incident_edges(node_d, all_edges=True)
         self.assertEqual([2, 1], res)
 
+    def test_incident_edge_index_map(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_d, node_c, "edge c")
+        res = graph.incident_edge_index_map(node_d)
+        self.assertEqual({2: (3, 2, "edge c")}, res)
+
+    def test_incident_edge_index_map_invalid_node(self):
+        graph = retworkx.PyDiGraph()
+        res = graph.incident_edge_index_map(42)
+        self.assertEqual([], res)
+
+    def test_incident_edge_index_map_all_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_d, node_c, "edge c")
+        res = graph.incident_edge_index_map(node_d, all_edges=True)
+        self.assertEqual({2: (3, 2, "edge c"), 1: (1, 3, "edge_b")}, res)
+
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_multigraph_attr(self):

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -649,6 +649,46 @@ class TestEdges(unittest.TestCase):
         graph = retworkx.PyDiGraph()
         self.assertFalse(graph.has_parallel_edges())
 
+    def test_get_edge_data_by_index(self):
+        graph = retworkx.PyDiGraph()
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
+        graph.extend_from_weighted_edge_list(edge_list)
+        res = graph.get_edge_data_by_index(2)
+        self.assertEqual("c", res)
+
+    def test_get_edge_data_by_index_invalid_index(self):
+        graph = retworkx.PyDiGraph()
+        with self.assertRaisesRegex(
+            IndexError, "Provided edge index 2 is not present in the graph"
+        ):
+            graph.get_edge_data_by_index(2)
+
+    def test_get_edge_endpoints_by_index(self):
+        graph = retworkx.PyDiGraph()
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
+        graph.extend_from_weighted_edge_list(edge_list)
+        res = graph.get_edge_endpoints_by_index(2)
+        self.assertEqual((0, 2), res)
+
+    def test_get_edge_endpoints_by_index_invalid_index(self):
+        graph = retworkx.PyDiGraph()
+        with self.assertRaisesRegex(
+            IndexError, "Provided edge index 2 is not present in the graph"
+        ):
+            graph.get_edge_endpoints_by_index(2)
+
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_multigraph_attr(self):

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -706,6 +706,18 @@ class TestEdges(unittest.TestCase):
         res = graph.incident_edges(42)
         self.assertEqual([], res)
 
+    def test_incident_edges_all_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_d, node_c, "edge c")
+        res = graph.incident_edges(node_d, all_edges=True)
+        self.assertEqual([2, 1], res)
+
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_multigraph_attr(self):

--- a/tests/digraph/test_edges.py
+++ b/tests/digraph/test_edges.py
@@ -689,6 +689,23 @@ class TestEdges(unittest.TestCase):
         ):
             graph.get_edge_endpoints_by_index(2)
 
+    def test_incident_edges(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_d, node_c, "edge c")
+        res = graph.incident_edges(node_d)
+        self.assertEqual([2], res)
+
+    def test_incident_edges_invalid_node(self):
+        graph = retworkx.PyDiGraph()
+        res = graph.incident_edges(42)
+        self.assertEqual([], res)
+
 
 class TestEdgesMultigraphFalse(unittest.TestCase):
     def test_multigraph_attr(self):

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -457,6 +457,34 @@ class TestEdges(unittest.TestCase):
         res = graph.incident_edges(42)
         self.assertEqual([], res)
 
+    def test_single_neighbor_out_edges(self):
+        g = retworkx.PyGraph()
+        node_a = g.add_node("a")
+        node_b = g.add_node("b")
+        g.add_edge(node_a, node_b, {"a": 1})
+        node_c = g.add_node("c")
+        g.add_edge(node_a, node_c, {"a": 2})
+        res = g.out_edges(node_a)
+        self.assertEqual(
+            [(node_a, node_c, {"a": 2}), (node_a, node_b, {"a": 1})], res
+        )
+
+    def test_neighbor_surrounded_in_out_edges(self):
+        g = retworkx.PyGraph()
+        node_a = g.add_node("a")
+        node_b = g.add_node("b")
+        node_c = g.add_node("c")
+        g.add_edge(node_a, node_b, {"a": 1})
+        g.add_edge(node_b, node_c, {"a": 2})
+        res = g.out_edges(node_b)
+        self.assertEqual(
+            [(node_b, node_c, {"a": 2}), (node_b, node_a, {"a": 1})], res
+        )
+        res = g.in_edges(node_b)
+        self.assertEqual(
+            [(node_c, node_b, {"a": 2}), (node_a, node_b, {"a": 1})], res
+        )
+
     def test_edge_index_map_empty(self):
         graph = retworkx.PyGraph()
         self.assertEqual({}, graph.edge_index_map())

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -440,9 +440,66 @@ class TestEdges(unittest.TestCase):
             graph.edge_index_map(),
         )
 
+    def test_incident_edges(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_c, node_d, "edge c")
+        res = graph.incident_edges(node_d)
+        self.assertEqual({1, 2}, set(res))
+
+    def test_incident_edges_invalid_node(self):
+        graph = retworkx.PyGraph()
+        res = graph.incident_edges(42)
+        self.assertEqual([], res)
+
     def test_edge_index_map_empty(self):
-        graph = retworkx.PyDiGraph()
+        graph = retworkx.PyGraph()
         self.assertEqual({}, graph.edge_index_map())
+
+    def test_get_edge_data_by_index(self):
+        graph = retworkx.PyGraph()
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
+        graph.extend_from_weighted_edge_list(edge_list)
+        res = graph.get_edge_data_by_index(2)
+        self.assertEqual("c", res)
+
+    def test_get_edge_data_by_index_invalid_index(self):
+        graph = retworkx.PyGraph()
+        with self.assertRaisesRegex(
+            IndexError, "Provided edge index 2 is not present in the graph"
+        ):
+            graph.get_edge_data_by_index(2)
+
+    def test_get_edge_endpoints_by_index(self):
+        graph = retworkx.PyGraph()
+        edge_list = [
+            (0, 1, "a"),
+            (1, 2, "b"),
+            (0, 2, "c"),
+            (2, 3, "d"),
+            (0, 3, "e"),
+        ]
+        graph.extend_from_weighted_edge_list(edge_list)
+        res = graph.get_edge_endpoints_by_index(2)
+        self.assertEqual((0, 2), res)
+
+    def test_get_edge_endpoints_by_index_invalid_index(self):
+        graph = retworkx.PyGraph()
+        with self.assertRaisesRegex(
+            IndexError, "Provided edge index 2 is not present in the graph"
+        ):
+            graph.get_edge_endpoints_by_index(2)
 
 
 class TestEdgesMultigraphFalse(unittest.TestCase):

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -457,6 +457,23 @@ class TestEdges(unittest.TestCase):
         res = graph.incident_edges(42)
         self.assertEqual([], res)
 
+    def test_incident_edge_index_map(self):
+        graph = retworkx.PyGraph()
+        node_a = graph.add_node(0)
+        node_b = graph.add_node(1)
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        graph.add_edge(node_a, node_c, "edge a")
+        graph.add_edge(node_b, node_d, "edge_b")
+        graph.add_edge(node_c, node_d, "edge c")
+        res = graph.incident_edge_index_map(node_d)
+        self.assertEqual({2: (3, 2, "edge c"), 1: (3, 1, "edge_b")}, res)
+
+    def test_incident_edge_index_map_invalid_node(self):
+        graph = retworkx.PyGraph()
+        res = graph.incident_edge_index_map(42)
+        self.assertEqual({}, res)
+
     def test_single_neighbor_out_edges(self):
         g = retworkx.PyGraph()
         node_a = g.add_node("a")


### PR DESCRIPTION
There were some gaps in working with edges in the graph class API.
Mainly when working with indices there was no method to acquire the
edge's data payload or endpoints easily. Additionally for the PyGraph
class didn't have a simple method to find incident edges directly
instead a user had to rely on neighbors() and get the edges from that
directly. This commit adds methods to fill these API gaps to make
working with edges a bit easier.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
