### PR TITLE
Fix future clippy errors

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2485,8 +2485,7 @@ impl PyDiGraph {
 
         let nodes: HashSet<NodeIndex> = edges
             .iter()
-            .map(|x| x.iter())
-            .flatten()
+            .flat_map(|x| x.iter())
             .copied()
             .map(NodeIndex::new)
             .collect();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1627,8 +1627,7 @@ impl PyGraph {
 
         let nodes: HashSet<NodeIndex> = edges
             .iter()
-            .map(|x| x.iter())
-            .flatten()
+            .flat_map(|x| x.iter())
             .copied()
             .map(NodeIndex::new)
             .collect();

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -557,11 +557,10 @@ where
     fn next_candidate(
         st: &mut [Vf2State<Ty>; 2],
     ) -> Option<(NodeIndex, NodeIndex, OpenList)> {
-        let mut to_index;
+        // Try the out list
+        let mut to_index = st[1].next_out_index(0);
         let mut from_index = None;
         let mut open_list = OpenList::Out;
-        // Try the out list
-        to_index = st[1].next_out_index(0);
 
         if to_index.is_some() {
             from_index = st[0].next_out_index(0);

--- a/src/steiner_tree.rs
+++ b/src/steiner_tree.rs
@@ -305,8 +305,7 @@ pub fn steiner_tree(
     // Generate the output graph from the MST
     let out_edge_list: Vec<[usize; 2]> = mst_edges
         .into_iter()
-        .map(|edge| pairwise(edge.path))
-        .flatten()
+        .flat_map(|edge| pairwise(edge.path))
         .filter_map(|x| x.0.map(|a| [a, x.1]))
         .collect();
     let out_edges: HashSet<(usize, usize)> =
@@ -314,8 +313,7 @@ pub fn steiner_tree(
     let mut out_graph = graph.clone();
     let out_nodes: HashSet<NodeIndex> = out_edge_list
         .iter()
-        .map(|x| x.iter())
-        .flatten()
+        .flat_map(|x| x.iter())
         .copied()
         .map(NodeIndex::new)
         .collect();


### PR DESCRIPTION
Nightly rust, for 1.59, has added a couple of new clippy rules (or changed
existing rules) that will start causing an error in CI when rust 1.59 is
released. This commit fixes the issues identified by running nightly
clippy. These errors fall into 2 categories, replacing map().flatten()
with flat_map() and an unecessary late initialization.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
