### PR TITLE
Start migration from node_indexes -> node_indices

### DIFF
--- a/releasenotes/notes/add-node-indices-3c7c37ed4ea75a2c.yaml
+++ b/releasenotes/notes/add-node-indices-3c7c37ed4ea75a2c.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added a new method, :meth:`~retworkx.PyDiGraph.node_indices`, to the
+    :class:`~retworkx.PyDigraph` and :class:`~retworkx.PyGraph` classes.
+    This method is identical to the previously existing
+    :meth:`~retworkx.PyDiGraph.node_indexes` method but changes the name
+    to be consistent with the use of "indices" throughout the rest of
+    retworkx. The :meth:`~retworkx.PyDiGraph.node_indexes` will likely
+    be deprecated in a future release prior to it's removal in an eventual
+    1.0 release.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -68,9 +68,9 @@ use petgraph::visit::{
 ///        graph.add_nodes_from(list(range(5)))
 ///        graph.add_nodes_from(list(range(2)))
 ///        graph.remove_node(2)
-///        print("After deletion:", graph.node_indexes())
+///        print("After deletion:", graph.node_indices())
 ///        res_manual = graph.add_node(None)
-///        print("After adding a new node:", graph.node_indexes())
+///        print("After adding a new node:", graph.node_indices())
 ///
 /// Additionally, each node and edge contains an arbitrary Python object as a
 /// weight/data payload. You can use the index for access to the data payload
@@ -320,15 +320,30 @@ impl PyGraph {
             .collect()
     }
 
-    /// Return a list of all node indexes.
+    /// Return a list of all node indices.
     ///
-    /// :returns: A list of all the node indexes in the graph
+    /// :returns: A list of all the node indices in the graph
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self)")]
-    pub fn node_indexes(&self) -> NodeIndices {
+    pub fn node_indices(&self) -> NodeIndices {
         NodeIndices {
             nodes: self.graph.node_indices().map(|node| node.index()).collect(),
         }
+    }
+
+    /// Return a list of all node indices.
+    ///
+    /// .. note::
+    ///
+    ///     This is identical to :meth:`.node_indices()`, which is the
+    ///     preferred method to get the node indices in the graph. This
+    ///     exists for backwards compatibility with earlier releases.
+    ///
+    /// :returns: A list of all the node indices in the graph
+    /// :rtype: NodeIndices
+    #[pyo3(text_signature = "(self)")]
+    pub fn node_indexes(&self) -> NodeIndices {
+        self.node_indices()
     }
 
     /// Return True if there is an edge between node_a to node_b.
@@ -602,7 +617,7 @@ impl PyGraph {
     ///
     /// :param list obj_list: A list of tuples of the form
     ///     ``(node_a, node_b, obj)`` to attach to the graph. ``node_a`` and
-    ///     ``node_b`` are integer indexes describing where an edge should be
+    ///     ``node_b`` are integer indices describing where an edge should be
     ///     added, and ``obj`` is the python object for the edge data.
     ///
     /// If :attr:`~retworkx.PyGraph.multigraph` is ``False`` and an edge already
@@ -642,7 +657,7 @@ impl PyGraph {
     ///
     /// :param list obj_list: A list of tuples of the form
     ///     ``(parent, child)`` to attach to the graph. ``parent`` and
-    ///     ``child`` are integer indexes describing where an edge should be
+    ///     ``child`` are integer indices describing where an edge should be
     ///     added. Unlike :meth:`add_edges_from` there is no data payload and
     ///     when the edge is created None will be used.
     ///
@@ -894,7 +909,7 @@ impl PyGraph {
 
     /// Get the index and data for the neighbors of a node.
     ///
-    /// This will return a dictionary where the keys are the node indexes of
+    /// This will return a dictionary where the keys are the node indices of
     /// the adjacent nodes (inbound or outbound) and the value is the edge data
     /// objects between that adjacent node and the provided node. Note, that
     /// in the case of multigraphs only a single edge data object will be
@@ -902,7 +917,7 @@ impl PyGraph {
     ///
     /// :param int node: The index of the node to get the neighbors
     ///
-    /// :returns neighbors: A dictionary where the keys are node indexes and
+    /// :returns neighbors: A dictionary where the keys are node indices and
     ///     the value is the edge data object for all nodes that share an
     ///     edge with the specified node.
     /// :rtype: dict
@@ -1369,8 +1384,8 @@ impl PyGraph {
     ///
     /// :param PyGraph other: The other PyGraph object to add onto this
     ///     graph.
-    /// :param dict node_map: A dictionary mapping node indexes from this
-    ///     PyGraph object to node indexes in the other PyGraph object.
+    /// :param dict node_map: A dictionary mapping node indices from this
+    ///     PyGraph object to node indices in the other PyGraph object.
     ///     The keys are a node index in this graph and the value is a tuple
     ///     of the node index in the other graph to add an edge to and the
     ///     weight of that edge. For example::

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -24,10 +24,17 @@ class TestNodes(unittest.TestCase):
         self.assertEqual(["a", "b"], res)
         self.assertEqual([0, 1], dag.node_indexes())
 
+    def test_node_indices(self):
+        graph = retworkx.PyDiGraph()
+        node_a = graph.add_node("a")
+        graph.add_child(node_a, "b", "Edgy")
+        self.assertEqual([0, 1], graph.node_indices())
+
     def test_no_nodes(self):
         dag = retworkx.PyDAG()
         self.assertEqual([], dag.nodes())
         self.assertEqual([], dag.node_indexes())
+        self.assertEqual([], dag.node_indices())
 
     def test_remove_node(self):
         dag = retworkx.PyDAG()

--- a/tests/graph/test_nodes.py
+++ b/tests/graph/test_nodes.py
@@ -24,10 +24,17 @@ class TestNodes(unittest.TestCase):
         self.assertEqual(["a", "b"], res)
         self.assertEqual([0, 1], graph.node_indexes())
 
+    def test_node_indices(self):
+        graph = retworkx.PyGraph()
+        graph.add_node("a")
+        graph.add_node("b")
+        self.assertEqual([0, 1], graph.node_indices())
+
     def test_no_nodes(self):
         graph = retworkx.PyGraph()
         self.assertEqual([], graph.nodes())
         self.assertEqual([], graph.node_indexes())
+        self.assertEqual([], graph.node_indices())
 
     def test_remove_node(self):
         graph = retworkx.PyGraph()


### PR DESCRIPTION
Since the earliest retworkx releases the method to return the list of
node indices in the graph was named "node_indexes". However as the
retworkx api evolved we standardized on the use of "indices" everywhere
else in the API. For backwards compatibility we kept the "node_indexes"
method name. This commit starts the process of migrating away from
"node_indexes" a new method "node_indices" is being added. The
"node_indexes" method is now just a backwards compatibility alias for
node_indices. In a future release when we start preparing for the
retworkx 1.0.0 release we will start emitting a deprecation warning
from node_indexes prior to its eventual removal in the 1.0.0 release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
