### PR TITLE
Document cycle_basis() doesn't work with multigraphs

### DIFF
--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -47,6 +47,12 @@ use retworkx_core::connectivity;
 ///
 /// This is adapted from algorithm CACM 491 [1]_.
 ///
+/// .. note::
+///
+///     The function implicitly assumes that there are no parallel edges.
+///     It may produce incorrect/unexpected results if the input graph has
+///     parallel edges.
+///
 /// :param PyGraph graph: The graph to find the cycle basis in
 /// :param int root: Optional index for starting node for basis
 ///


### PR DESCRIPTION
As was pointed out in #505 the cycle_basis() function doesn't work with
multigraphs, but this was missing in the documentation. This commit adds
a note to the docstring that it won't work correctly if a multigraph is
used with it.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
