### PR TITLE
Use an iterative dfs-search in `chain_decomposition`.

### DIFF
--- a/retworkx-core/src/connectivity/chain.rs
+++ b/retworkx-core/src/connectivity/chain.rs
@@ -16,10 +16,12 @@ use std::hash::Hash;
 use hashbrown::HashMap;
 
 use petgraph::visit::{
-    depth_first_search, DfsEvent, GraphProp, IntoNeighbors,
-    IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable,
+    GraphProp, IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable,
+    VisitMap, Visitable,
 };
 use petgraph::Undirected;
+
+use crate::traversal::{depth_first_search, DfsEvent};
 
 fn _build_chain<G, VM: VisitMap<G::NodeId>>(
     graph: G,
@@ -115,7 +117,7 @@ pub fn chain_decomposition<G>(
 ) -> Vec<Vec<(G::NodeId, G::NodeId)>>
 where
     G: IntoNodeIdentifiers
-        + IntoNeighbors
+        + IntoEdges
         + Visitable
         + NodeIndexable
         + NodeCount
@@ -136,12 +138,12 @@ where
         DfsEvent::Discover(u, _) => {
             nodes.push(u);
         }
-        DfsEvent::TreeEdge(u, v) => {
+        DfsEvent::TreeEdge(u, v, _) => {
             let u = graph.to_index(u);
             let v = graph.to_index(v);
             parent[v] = u;
         }
-        DfsEvent::BackEdge(u_id, v_id) => {
+        DfsEvent::BackEdge(u_id, v_id, _) => {
             let u = graph.to_index(u_id);
             let v = graph.to_index(v_id);
 

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -735,8 +735,7 @@ pub fn digraph_core_number(
 ///
 ///     The function implicitly assumes that there are no parallel edges
 ///     or self loops. It may produce incorrect/unexpected results if the
-///     input graph has self loops or parallel edges. It's also a recursive
-///     implementation and might run out of memory in large graphs.
+///     input graph has self loops or parallel edges.
 ///
 /// :param PyGraph: The undirected graph to be used
 /// :param int source: An optional node index in the graph. If specified,


### PR DESCRIPTION
### Summary
This commit replaces the use of petgraph's recursive `depth_first_search`
in `chain_decomposition` with the iterative implementation we added in retworkx-core.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
