### PR TITLE
Add attribution comment to introduction tutorial

### DIFF
--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -1,3 +1,7 @@
+.. This document was adapted from and heavily based on the similar
+   introductutorial in  NetworkX's documentation which can be found here:
+   https://networkx.org/documentation/networkx-2.6.2/tutorial.html
+
 ########################
 Introduction to retworkx
 ########################

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -1,5 +1,5 @@
 .. This document was adapted from and heavily based on the similar
-   introductutorial in  NetworkX's documentation which can be found here:
+   introduction tutorial in  NetworkX's documentation which can be found here:
    https://networkx.org/documentation/networkx-2.6.2/tutorial.html
 
 ########################

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -1,4 +1,4 @@
-.. This document was adapted from and heavily based on the similar
+.. This document was adapted from and originally modeled on the similar
    introduction tutorial in  NetworkX's documentation which can be found here:
    https://networkx.org/documentation/networkx-2.6.2/tutorial.html
 


### PR DESCRIPTION
In #537 we added the tutorials to the retworkx documentation. The
introduction tutorial was heavily based (and used some phrases
verbatim from that document) from the similar tutorial in NetworkX.
While the final result is different as it's specific to retworkx the
basic outline and some of the high level details are the same so we
should provide credit to the original source. I noticed reviewing the
published documentation for the 0.11.0 that I neglected to provide
proper attribution of that as part of #537. This corrects that oversight
and adds a comment to the top of the documentation source to link to the
original networkx document which it was based off of.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
