### PR TITLE
Replace most occurrences of "indexes" with "indices"

### DIFF
--- a/docs/source/networkx.rst
+++ b/docs/source/networkx.rst
@@ -51,7 +51,7 @@ from the above retworkx example::
     assert 'my_node_a' == graph[node_a]
     assert 'my_node_b' == graph[node_b]
 
-The use of integer indexes for everything is normally the biggest difference that
+The use of integer indices for everything is normally the biggest difference that
 existing networkx users have to adapt to when migrating to retworkx.
 
 Similarly when there are algorithm functions that operate on a node or edge

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -42,9 +42,9 @@ class PyDAG(PyDiGraph):
         graph.add_nodes_from(list(range(5)))
         graph.add_nodes_from(list(range(2)))
         graph.remove_node(2)
-        print("After deletion:", graph.node_indexes())
+        print("After deletion:", graph.node_indices())
         res_manual = graph.add_parent(6, None, None)
-        print("After adding a new node:", graph.node_indexes())
+        print("After adding a new node:", graph.node_indices())
 
     Additionally, each node and edge contains an arbitrary Python object as a
     weight/data payload.
@@ -1358,7 +1358,7 @@ def bipartite_layout(
 
     :param graph: The graph to generate the layout for. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`
-    :param set first_nodes: The set of node indexes on the left (or top if
+    :param set first_nodes: The set of node indices on the left (or top if
         horitontal is true)
     :param bool horizontal: An optional bool specifying the orientation of the
         layout
@@ -1445,7 +1445,7 @@ def shell_layout(graph, nlist=None, rotate=None, scale=1, center=None):
 
     :param graph: The graph to generate the layout for. Can either be a
         :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`
-    :param list nlist: The list of lists of indexes which represents each shell
+    :param list nlist: The list of lists of indices which represents each shell
     :param float rotate: Angle (in radians) by which to rotate the starting
         position of each shell relative to the starting position of the
         previous shell

--- a/retworkx/visualization/matplotlib.py
+++ b/retworkx/visualization/matplotlib.py
@@ -333,7 +333,7 @@ def draw_graph(graph, pos=None, arrows=True, with_labels=False, **kwds):
 
     label_fn = kwds.pop("labels", None)
     if label_fn:
-        kwds["labels"] = {x: label_fn(graph[x]) for x in graph.node_indexes()}
+        kwds["labels"] = {x: label_fn(graph[x]) for x in graph.node_indices()}
     edge_label_fn = kwds.pop("edge_labels", None)
     if edge_label_fn:
         kwds["edge_labels"] = {
@@ -450,7 +450,7 @@ def draw_nodes(
         ax = plt.gca()
 
     if node_list is None:
-        node_list = graph.node_indexes()
+        node_list = graph.node_indices()
 
     # empty node_list, no drawing
     if len(node_list) == 0:
@@ -578,7 +578,7 @@ def draw_edges(
         Size of nodes. Though the nodes are not drawn with this function, the
         node size is used in determining edge positioning.
 
-    node_list : list, optional (default=graph.node_indexes())
+    node_list : list, optional (default=graph.node_indices())
        This provides the node order for the `node_size` array (if it is an
        array).
 
@@ -639,7 +639,7 @@ def draw_edges(
         return []
 
     if node_list is None:
-        node_list = list(graph.node_indexes())
+        node_list = list(graph.node_indices())
 
     # FancyArrowPatch handles color=None different from LineCollection
     if edge_color is None:
@@ -882,7 +882,7 @@ def draw_labels(
         ax = plt.gca()
 
     if labels is None:
-        labels = {n: n for n in graph.node_indexes()}
+        labels = {n: n for n in graph.node_indices()}
 
     text_items = {}  # there is no text collection so we'll fake one
     for n, label in labels.items():

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -499,7 +499,7 @@ pub fn graph_complement(
     py: Python,
     graph: &graph::PyGraph,
 ) -> PyResult<graph::PyGraph> {
-    let mut complement_graph = graph.clone(); // keep same node indexes
+    let mut complement_graph = graph.clone(); // keep same node indices
     complement_graph.graph.clear_edges();
 
     for node_a in graph.graph.node_indices() {
@@ -542,7 +542,7 @@ pub fn digraph_complement(
     py: Python,
     graph: &digraph::PyDiGraph,
 ) -> PyResult<digraph::PyDiGraph> {
-    let mut complement_graph = graph.clone(); // keep same node indexes
+    let mut complement_graph = graph.clone(); // keep same node indices
     complement_graph.graph.clear_edges();
 
     for node_a in graph.graph.node_indices() {

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -267,13 +267,13 @@ pub fn layers(
             let children = dag
                 .graph
                 .neighbors_directed(*node, petgraph::Direction::Outgoing);
-            let mut used_indexes: HashSet<NodeIndex> = HashSet::new();
+            let mut used_indices: HashSet<NodeIndex> = HashSet::new();
             for succ in children {
                 // Skip duplicate successors
-                if used_indexes.contains(&succ) {
+                if used_indices.contains(&succ) {
                     continue;
                 }
-                used_indexes.insert(succ);
+                used_indices.insert(succ);
                 let mut multiplicity: usize = 0;
                 let raw_edges = dag
                     .graph
@@ -403,7 +403,7 @@ fn lexicographical_topological_sort(
     Ok(PyList::new(py, out_list).into())
 }
 
-/// Return the topological sort of node indexes from the provided graph
+/// Return the topological sort of node indices from the provided graph
 ///
 /// :param PyDiGraph graph: The DAG to get the topological sort on
 ///

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -524,7 +524,7 @@ custom_vec_iter_impl!(
     bfs_successors,
     (PyObject, Vec<PyObject>),
     "A custom class for the return from :func:`retworkx.bfs_successors`
-    
+
     The class can is a read-only sequence of tuples of the form::
 
         [(node, [successor_a, successor_b])]
@@ -592,7 +592,7 @@ custom_vec_iter_impl!(
         import retworkx
 
         graph = retworkx.generators.directed_path_graph(5)
-        nodes = retworkx.node_indexes(0)
+        nodes = retworkx.node_indices(0)
         # Index based access
         third_element = nodes[2]
         # Use as iterator
@@ -700,7 +700,7 @@ custom_vec_iter_impl!(
     "A custom class for the return of edge indices
 
     The class is a read only sequence of integer edge indices.
-    
+
     This class is a container class for the results of functions that
     return a list of edge indices. It implements the Python sequence
     protocol. So you can treat the return as a read-only sequence/list
@@ -987,7 +987,7 @@ custom_hash_map_iter_impl!(
     This class is equivalent to having a read only dict of the form::
 
         {1: (0, 1, 'weight'), 3: (2, 3, 1.2)}
-    
+
     It is used to efficiently represent an edge index map for a retworkx
     graph. It behaves as a drop in replacement for a readonly ``dict``.
     "
@@ -1268,9 +1268,9 @@ custom_hash_map_iter_impl!(
     order.
 
     For example::
-    
+
         import retworkx
-    
+
         graph = retworkx.generators.directed_path_graph(5)
         edges = retworkx.num_shortest_paths_unweighted(0)
         # Target node access

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -234,7 +234,7 @@ pub fn digraph_random_layout(
 /// Generate a bipartite layout of the graph
 ///
 /// :param PyGraph graph: The graph to generate the layout for
-/// :param set first_nodes: The set of node indexes on the left (or top if
+/// :param set first_nodes: The set of node indices on the left (or top if
 ///     horitontal is true)
 /// :param bool horizontal: An optional bool specifying the orientation of the
 ///     layout
@@ -270,7 +270,7 @@ pub fn graph_bipartite_layout(
 /// Generate a bipartite layout of the graph
 ///
 /// :param PyDiGraph graph: The graph to generate the layout for
-/// :param set first_nodes: The set of node indexes on the left (or top if
+/// :param set first_nodes: The set of node indices on the left (or top if
 ///     horizontal is true)
 /// :param bool horizontal: An optional bool specifying the orientation of the
 ///     layout
@@ -344,7 +344,7 @@ pub fn digraph_circular_layout(
 /// Generate a shell layout of the graph
 ///
 /// :param PyGraph graph: The graph to generate the layout for
-/// :param list nlist: The list of lists of indexes which represents each shell
+/// :param list nlist: The list of lists of indices which represents each shell
 /// :param float rotate: Angle (in radians) by which to rotate the starting
 ///     position of each shell relative to the starting position of the
 ///     previous shell
@@ -371,7 +371,7 @@ pub fn graph_shell_layout(
 /// Generate a shell layout of the graph
 ///
 /// :param PyDiGraph graph: The graph to generate the layout for
-/// :param list nlist: The list of lists of indexes which represents each shell
+/// :param list nlist: The list of lists of indices which represents each shell
 /// :param float rotate: Angle by which to rotate the starting position of each shell
 ///     relative to the starting position of the previous shell (in radians)
 /// :param float scale: An optional scaling factor to scale positions

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -180,7 +180,7 @@ fn bfs_successors(
 /// :param PyDiGraph graph: The graph to get the ancestors from.
 /// :param int node: The index of the graph node to get the ancestors for
 ///
-/// :returns: A set of node indexes of ancestors of provided node.
+/// :returns: A set of node indices of ancestors of provided node.
 /// :rtype: set
 #[pyfunction]
 #[pyo3(text_signature = "(graph, node, /)")]
@@ -207,7 +207,7 @@ fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 /// :param PyDiGraph graph: The graph to get the descendants from
 /// :param int node: The index of the graph node to get the descendants for
 ///
-/// :returns: A set of node indexes of descendants of provided node.
+/// :returns: A set of node indices of descendants of provided node.
 /// :rtype: set
 #[pyfunction]
 #[pyo3(text_signature = "(graph, node, /)")]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -115,7 +115,7 @@ pub fn minimum_spanning_edges(
 ///
 /// .. note::
 ///
-///     The new graph will keep the same node indexes, but edge indexes might differ.
+///     The new graph will keep the same node indices, but edge indices might differ.
 #[pyfunction(weight_fn = "None", default_weight = "1.0")]
 #[pyo3(text_signature = "(graph, weight_fn=None, default_weight=1.0)")]
 pub fn minimum_spanning_tree(


### PR DESCRIPTION
This PR removes most occurrences of "indexes" with "indices" in code, comments, and docs.

* Nothing in ./tests was changed. Perhaps all tests should be changed to use `node_indices` since this just wraps `node_indexes`.

* The two methods `node_indexes` that will likely be deprecated were, of course, not changed.

* release notes mentioning the addition of `node_indexes` were, of course, not changed.