### PR TITLE
Change style of footnote in DAG tutorial

### DIFF
--- a/docs/source/tutorial/dags.rst
+++ b/docs/source/tutorial/dags.rst
@@ -71,8 +71,10 @@ overhead by using :meth:`.PyDiGraph.add_parent` and
 :meth:`.PyDiGraph.add_child` as both add a new node and edge simultaneously and
 neither can introduce a cycle.
 
-.. [#] A trail is a sequence of nodes and edges on the graph where each edge
-   is distinct in the walk.
+.. note::
+
+    .. [#] A trail is a sequence of nodes and edges on the graph where each edge
+       is distinct in the walk.
 
 Applications of DAGs
 ====================


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Minor detail from #537 

Changes the style of the footnote in the DAG tutorial. Previously, the footnote was mixed with text and was hard to differentiate. This commit wraps it inside a note so it is more explicit the footnote is separate from the main text.