### PR TITLE
Bump package version, raise MSRV to 1.48 and drop Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
@@ -63,7 +63,7 @@ jobs:
         ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.41.1
+          - rust: 1.48.0
             python-version: 3.8
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: pp* *win32
+          CIBW_SKIP: cp36-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -99,7 +99,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: pp* *win32
+          CIBW_SKIP: cp36-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -144,7 +144,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp39-* cp310-* pp* *win32
+          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -234,7 +234,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp39-* cp310-* pp* *win32
+          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -344,7 +344,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_SKIP: pp* *amd64
+          CIBW_SKIP: cp36-* pp* *amd64
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "retworkx"
 description = "A python graph library implemented in Rust"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://img.shields.io/github/release/Qiskit/retworkx.svg?style=popout-square)](https://github.com/Qiskit/retworkx/releases)
 [![](https://img.shields.io/pypi/dm/retworkx.svg?style=popout-square)](https://pypi.org/project/retworkx/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/retworkx/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/retworkx?branch=main)
-[![Minimum rustc 1.41.1](https://img.shields.io/badge/rustc-1.41.1+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.48.0](https://img.shields.io/badge/rustc-1.48.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![arXiv](https://img.shields.io/badge/arXiv-2110.15221-b31b1b.svg)](https://arxiv.org/abs/2110.15221)
 
   - You can see the full rendered docs at:
@@ -39,7 +39,7 @@ environment.
 
 If there are no precompiled binaries published for your system you'll have to
 build the package from source. However, to be able able to build the package
-from the published source package you need to have rust >=1.41.1 installed (and
+from the published source package you need to have rust >=1.48.0 installed (and
 also [cargo](https://doc.rust-lang.org/cargo/) which is normally included with
 rust) You can use [rustup](https://rustup.rs/) (a cross platform installer for
 rust) to make this simpler, or rely on

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2021, retworkx Contributors'
 
 
 # The short X.Y version.
-version = '0.11.0'
+version = '0.12.0'
 # The full version, including alpha/beta/rc tags.
-release = '0.11.0'
+release = '0.12.0'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/releasenotes/notes/raise-msrv-and-mspv-7ad10b4e66f1383f.yaml
+++ b/releasenotes/notes/raise-msrv-and-mspv-7ad10b4e66f1383f.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    The minimum supported Rust version for building retworkx has been raised from
+    1.41 to 1.48. To compile retworkx from source you will need to ensure you have
+    at Rustc >=1.48 installed.
+  - |
+    The minimum supported Python version for using retworkx has been raised to Python 3.7.
+    To use retworkx you will need to ensure you are using Python >=3.7.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ graphviz_extras = ['pillow>=5.4']
 
 setup(
     name="retworkx",
-    version="0.11.0",
+    version="0.12.0",
     description="A python graph library implemented in Rust",
     long_description=readme(),
     long_description_content_type='text/markdown',
@@ -34,7 +34,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Programming Language :: Rust",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -55,7 +54,7 @@ setup(
     include_package_data=True,
     packages=["retworkx", "retworkx.visualization"],
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=['numpy>=1.16.0'],
     extras_require={
         'mpl': mpl_extras,


### PR DESCRIPTION
Now that the 0.11.0 release is out the door this commit prepares the
main branch for development of the next minor version release, 0.12.0.
To do this it makes three changes, the first is to bump the package
version strings to the new version. This is primarily to differentiate
the development branch against the released 0.11.0. Second, this raises
the minimum supported rust version (MSRV) to 1.48. As was documented in
the release notes the 0.11.0 release was the last version to have an
MSRV of 1.41. Moving forward we'll support an MSRV of 1.48. This version
was chosen because it's what the latest version of Debian stable
currently packages, and we need to ensure that Debian can compile
retworkx for our userbase on raspberry pi (the raspberry pi python
package index, piwheels.org, uses the debian packaged rustc to build
their wheels). Lastly, the minimum support python version is raised to
Python 3.7. This was also documented in the 0.11.0 release notes, and
since Python 3.6 is now end of life and is no longer recieving
any updates we should drop support for it.

Fixes #498

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
