### PR TITLE
Run CI on stable branches too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@
 name: CI Jobs
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'stable/*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'stable/*' ]
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This commit fixes an oversight in our ci configuration. Starting after the
0.11.0 release we started maintaining a stable branch in parallel to our
main development branch. This branch is used to backport bugfixes from
main so that we can push out bugfix releases independently of our main
development branch. This reduces the pressure pressure to release as
frequently just to get bug or compatibility fixes out and we can develop
new features on our main branch and release when it's ready. However,
as part of this migration we neglected to updated the ci configuration
to run on the new stable branches. This commit fixes this oversight so
that we will run ci on backports in addition to our main development
branch.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
