### PR TITLE
Make mapping containers explicitly not sequences

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -150,7 +150,7 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///     ``PyDiGraph`` object will not be a multigraph. When ``False`` if a
 ///     method call is made that would add parallel edges the the weight/weight
 ///     from that method call will be used to update the existing edge in place.
-#[pyclass(module = "retworkx", subclass)]
+#[pyclass(mapping, module = "retworkx", subclass)]
 #[pyo3(text_signature = "(/, check_cycle=False, multigraph=True)")]
 #[derive(Clone)]
 pub struct PyDiGraph {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -113,7 +113,7 @@ use petgraph::visit::{
 ///     object will not be a multigraph. When ``False`` if a method call is
 ///     made that would add parallel edges the the weight/weight from that
 ///     method call will be used to update the existing edge in place.
-#[pyclass(module = "retworkx", subclass)]
+#[pyclass(mapping, module = "retworkx", subclass)]
 #[pyo3(text_signature = "(/, multigraph=True)")]
 #[derive(Clone)]
 pub struct PyGraph {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -782,7 +782,7 @@ macro_rules! custom_hash_map_iter_impl {
         $K:ty, $V:ty, $doc:literal
     ) => {
         #[doc = $doc]
-        #[pyclass(module = "retworkx")]
+        #[pyclass(mapping, module = "retworkx")]
         #[derive(Clone)]
         pub struct $name {
             pub $data: DictMap<$K, $V>,
@@ -980,7 +980,7 @@ impl PyGCProtocol for EdgeIndexMap {
 ///     second_target = next(edges_iter)
 ///     second_path = edges[second_target]
 ///
-#[pyclass(module = "retworkx")]
+#[pyclass(mapping, module = "retworkx")]
 #[derive(Clone)]
 pub struct PathMapping {
     pub paths: DictMap<usize, Vec<usize>>,


### PR DESCRIPTION
In PyO3 0.16.x the Python protocol interface was reworked to be more
pythonic and deprecated the pyproto macro and the distinct traits for
implementing different python protocols. As a side effect of that the
overlapping methods for the Python mapping and sequence protocols (they
both have getitem, len, etc). In the 0.16.3 release a pyclass macro
option was added to explicitly mark a container class as a mapping. In
retworkx we have several mapping containers which are not sequences. Now
that we're using PyO3 0.16.3 for retworkx, to make this distinction clear
this commit leverages the new mapping argument to the pyclass for
container classes which are just mappings.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
