### PR TITLE
Update coverage job to use stable rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,19 +101,19 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-31
+          toolchain: stable
           override: true
           profile: default
           components: llvm-tools-preview
       - name: Download grcov
-        run: curl -L https://github.com/mozilla/grcov/releases/download/v0.6.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
+        run: curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Install deps
         run: pip install -U setuptools-rust networkx testtools fixtures
       - name: Build retworkx
         run: python setup.py develop
         env:
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "retworkx-%p-%m.profraw"
       - name: Run tests
         run: cd tests && python -m unittest discover . && cd ..


### PR DESCRIPTION
In the recent Rust 1.60.0 release the instrument-coverage compiler flag
was stabilized. This means it no longer requires a nightly build of the
rust compiler to use it. This commit updates our coverage CI job to use
stable rust so we don't have to rely on a nightly build anymore.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
