### PR TITLE
Simplify and deduplicate multigraph handling in PyGraph

### DIFF
--- a/releasenotes/notes/edgeindices-pygraph-523ed0feac553c18.yaml
+++ b/releasenotes/notes/edgeindices-pygraph-523ed0feac553c18.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    The return type for the :class:`~.PyGraph` method
+    :meth:`~.PyGraph.add_edges_from` and
+    :meth:`~.PyGraph.add_edges_from_no_data` has changed from a ``list`` of
+    integer edge indices to an :class:`~.EdgeIndices` object. The
+    :class:`~.EdgeIndices` class is a read-only sequence type of integer
+    edge indices. For the most part this should be fully compatible
+    except if you were mutating the output list or were explicitly type
+    checking the return. In these cases you can simply cast the
+    :class:`~.EdgeIndices` object with ``list()``.

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -477,7 +477,7 @@ pub fn graph_complement(py: Python, graph: &graph::PyGraph) -> PyResult<graph::P
                     || !complement_graph.has_edge(node_a.index(), node_b.index()))
             {
                 // avoid creating parallel edges in multigraph
-                complement_graph.add_edge(node_a.index(), node_b.index(), py.None())?;
+                complement_graph.add_edge(node_a.index(), node_b.index(), py.None());
             }
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -130,7 +130,7 @@ pub fn minimum_spanning_tree(
         .edges
         .iter()
     {
-        spanning_tree.add_edge(edge.0, edge.1, edge.2.clone_ref(py))?;
+        spanning_tree.add_edge(edge.0, edge.1, edge.2.clone_ref(py));
     }
 
     Ok(spanning_tree)

--- a/tests/graph/test_edges.py
+++ b/tests/graph/test_edges.py
@@ -545,6 +545,32 @@ class TestEdgesMultigraphFalse(unittest.TestCase):
         graph.add_edge(1, 0, 0)
         self.assertFalse(graph.has_parallel_edges())
 
+    def test_parallel_edges_not_in_edge_list(self):
+        graph = retworkx.PyGraph(multigraph=False)
+        edge_list = [
+            (8, 6),
+            (6, 5),
+            (6, 5),
+            (4, 5),
+            (5, 4),
+            (4, 5),
+            (3, 4),
+            (4, 3),
+            (3, 4),
+            (2, 3),
+            (0, 2),
+            (2, 0),
+            (0, 2),
+            (2, 3),
+        ]
+        graph.extend_from_edge_list(edge_list)
+        graph_edge_list = graph.edge_list()
+        expected_edges = [(6, 8), (5, 6), (4, 5), (3, 4), (2, 3), (0, 2)]
+        self.assertEqual(len(graph_edge_list), len(expected_edges))
+        for edge in expected_edges:
+            if edge not in graph_edge_list and (edge[1], edge[0]) not in graph_edge_list:
+                self.fail(f"{edge} not found in graph edge list {graph_edge_list}")
+
     def test_get_edge_data(self):
         graph = retworkx.PyGraph(False)
         node_a = graph.add_node("a")


### PR DESCRIPTION
This commit simplifies and deduplicates the PyGraph method definitions
that add edges to the graph object. When reviewing the multigraph=False
path to debug an issue I found that the PyGraph code around edge
handling was duplicated between every method that adds edges and also
was needlessly returning a PyResult<T>. This commit abstracts the edge
adding to an inner private method that does the multigraph flag handling
and also drops the PyResult return as these functions can't raise an
error. The return type for the functions which add multiple edges is
also updated to be an EdgeIndices object for a faster return time.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
