### PR TITLE
Update workspace configuration to be tied to specific versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "retworkx-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = "1.5"
 num-traits = "0.2"
 num-bigint = "0.4"
 num-complex = "0.4"
-retworkx-core = { path = "./retworkx-core" }
+retworkx-core = { path = "retworkx-core", version = "=0.12.0" }
 
 [dependencies.pyo3]
 version = "0.16.3"

--- a/retworkx-core/Cargo.toml
+++ b/retworkx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retworkx-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2018"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "Rust APIs used for retworkx algorithms"


### PR DESCRIPTION
This commit updates the retworkx-core crate dependency to have a fixed
version which matches the retworkx crates version. We're not going to be
in a situation where we we release retworkx-core separately from the
main retworkx crate we only want to support the main crate with the core
crate at the same version. This commit makes this relationship
explicitly. At the same time it fixes the version string in the
retworkx-core crate as it wasn't updated in #560 like it should have
been.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
