### PR TITLE
Add support for slice inputs to custom sequence return types

### DIFF
--- a/releasenotes/notes/slices-for-sequences-a3b31c70f5d896b4.yaml
+++ b/releasenotes/notes/slices-for-sequences-a3b31c70f5d896b4.yaml
@@ -1,0 +1,21 @@
+---
+fixes:
+  - |
+    The custom sequence return classes:
+
+     * :class:`~.BFSSSuccessors`
+     * :class:`~.NodeIndices`
+     * :class:`~.EdgeList`
+     * :class:`~WeightedEdgeList`
+     * :class:`~EdgeIndices`
+     * :class:`~Chains`
+
+    now correctly handle slice inputs to ``__getitem__``. Previously if you
+    tried to access a slice from one of these objects it would raise a
+    ``TypeError. For example, if you had a :class:`~.NodeIndices` object named
+    ``nodes`` containing ``[0, 1, 3, 4, 5]`` if you did something like::
+
+        nodes[0:3]
+
+    it would return a new :class:`~.NodeIndices` object containing ``[0, 1, 3]``
+    Fixed `#590 <https://github.com/Qiskit/retworkx/issues/590>`__

--- a/releasenotes/notes/slices-for-sequences-a3b31c70f5d896b4.yaml
+++ b/releasenotes/notes/slices-for-sequences-a3b31c70f5d896b4.yaml
@@ -12,7 +12,7 @@ fixes:
 
     now correctly handle slice inputs to ``__getitem__``. Previously if you
     tried to access a slice from one of these objects it would raise a
-    ``TypeError. For example, if you had a :class:`~.NodeIndices` object named
+    ``TypeError``. For example, if you had a :class:`~.NodeIndices` object named
     ``nodes`` containing ``[0, 1, 3, 4, 5]`` if you did something like::
 
         nodes[0:3]

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -495,7 +495,8 @@ macro_rules! custom_vec_iter_impl {
                         Ok(return_vec.into_py(py))
                     }
                     SliceOrInt::Int(idx) => {
-                        if idx.abs() >= self.$data.len().try_into().unwrap() {
+                        let len = self.$data.len() as isize;
+                        if idx >= len || idx < -len {
                             Err(PyIndexError::new_err(format!("Invalid index, {}", idx)))
                         } else if idx < 0 {
                             let len = self.$data.len();

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -481,7 +481,7 @@ macro_rules! custom_vec_iter_impl {
             fn __getitem__(&self, py: Python, idx: SliceOrInt) -> PyResult<PyObject> {
                 match idx {
                     SliceOrInt::Slice(slc) => {
-                        let len: i64 = self.$data.len().try_into().unwrap();
+                        let len = self.$data.len().try_into().unwrap();
                         let indices = slc.indices(len)?;
                         let start: usize = indices.start.try_into().unwrap();
                         let stop: usize = indices.stop.try_into().unwrap();

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -168,7 +168,6 @@ class TestNodeIndicesComparisons(unittest.TestCase):
         slice_return = indices[-1:-3:-1]
         self.assertEqual([4, 3], slice_return)
         slice_return = indices[3:1:-2]
-        print(slice_return)
         self.assertEqual([3], slice_return)
         slice_return = indices[-3:-1]
         self.assertEqual([2, 3], slice_return)

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -20,8 +20,8 @@ import retworkx
 class TestBFSSuccessorsComparisons(unittest.TestCase):
     def setUp(self):
         self.dag = retworkx.PyDAG()
-        node_a = self.dag.add_node("a")
-        self.dag.add_child(node_a, "b", "Edgy")
+        self.node_a = self.dag.add_node("a")
+        self.node_b = self.dag.add_child(self.node_a, "b", "Edgy")
 
     def test__eq__match(self):
         self.assertTrue(retworkx.bfs_successors(self.dag, 0) == [("a", ["b"])])
@@ -87,6 +87,13 @@ class TestBFSSuccessorsComparisons(unittest.TestCase):
         with self.assertRaises(TypeError):
             hash(res)
 
+    def test_slices(self):
+        self.dag.add_child(self.node_a, "c", "New edge")
+        self.dag.add_child(self.node_b, "d", "New edge to d")
+        successors = retworkx.bfs_successors(self.dag, 0)
+        slice_return = successors[0:3:2]
+        self.assertEqual([("a", ["c", "b"])], slice_return)
+
 
 class TestNodeIndicesComparisons(unittest.TestCase):
     def setUp(self):
@@ -145,6 +152,14 @@ class TestNodeIndicesComparisons(unittest.TestCase):
         self.assertIsInstance(hash_res, int)
         # Assert hash is stable
         self.assertEqual(hash_res, hash(res))
+
+    def test_slices(self):
+        self.dag.add_node("new")
+        self.dag.add_node("fun")
+        nodes = self.dag.node_indices()
+        slice_return = nodes[0:3:2]
+        self.assertEqual([0, 2], slice_return)
+        self.assertEqual(nodes[0:-1], [0, 1, 2])
 
 
 class TestNodesCountMapping(unittest.TestCase):
@@ -308,6 +323,12 @@ class TestEdgeIndicesComparisons(unittest.TestCase):
         # Assert hash is stable
         self.assertEqual(hash_res, hash(res))
 
+    def test_slices(self):
+        self.dag.add_edge(0, 1, None)
+        edges = self.dag.edge_indices()
+        slice_return = edges[0:-1]
+        self.assertEqual([0, 1], slice_return)
+
 
 class TestEdgeListComparisons(unittest.TestCase):
     def setUp(self):
@@ -364,6 +385,13 @@ class TestEdgeListComparisons(unittest.TestCase):
         self.assertIsInstance(hash_res, int)
         # Assert hash is stable
         self.assertEqual(hash_res, hash(res))
+
+    def test_slice(self):
+        self.dag.add_edge(0, 1, None)
+        self.dag.add_edge(0, 1, None)
+        edges = self.dag.edge_list()
+        slice_return = edges[0:3:2]
+        self.assertEqual([(0, 1), (0, 1)], slice_return)
 
 
 class TestWeightedEdgeListComparisons(unittest.TestCase):
@@ -427,6 +455,13 @@ class TestWeightedEdgeListComparisons(unittest.TestCase):
         res = self.dag.weighted_edge_list()
         with self.assertRaises(TypeError):
             hash(res)
+
+    def test_slice(self):
+        self.dag.add_edge(0, 1, None)
+        self.dag.add_edge(0, 1, None)
+        edges = self.dag.weighted_edge_list()
+        slice_return = edges[0:3:2]
+        self.assertEqual([(0, 1, "Edgy"), (0, 1, None)], slice_return)
 
 
 class TestPathMapping(unittest.TestCase):

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -161,6 +161,19 @@ class TestNodeIndicesComparisons(unittest.TestCase):
         self.assertEqual([0, 2], slice_return)
         self.assertEqual(nodes[0:-1], [0, 1, 2])
 
+    def test_slices_negatives(self):
+        graph = retworkx.PyGraph()
+        graph.add_nodes_from(range(5))
+        indices = graph.node_indices()
+        slice_return = indices[-1:-3:-1]
+        self.assertEqual([4, 3], slice_return)
+        slice_return = indices[3:1:-2]
+        print(slice_return)
+        self.assertEqual([3], slice_return)
+        slice_return = indices[-3:-1]
+        self.assertEqual([2, 3], slice_return)
+        self.assertEqual([], indices[-1:-2])
+
 
 class TestNodesCountMapping(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This commit adds support for dealing with slice inputs to custom
sequence return types such as ``NodeIndices``. Previously, if a slice
was requested from a custom return type it would have raised a
``TypeError``. With this commit now it will return a new container object
with a copy of the data from the requested slice.

Fixes #590

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
