### PR TITLE
Fix stray reference to old autosummary dir

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -155,7 +155,7 @@ Graph Operations
 ----------------
 
 .. autosummary::
-   :toctree: stubs
+   :toctree: apiref
 
    retworkx.complement
    retworkx.union


### PR DESCRIPTION
In #544 we updated the autosummary directives output directory from
'stubs' to 'apiref' so that the urls of the hosted documentation made
more sense. Then a redirect was added to ensure that stale links to
stubs were redirected to the new location. However, as part of this
migration one autosummary directory was missed causing it to still
publish to 'stubs'. With the redirects in place this means that the
documentation is not actually reachable anymore. This commit fixes this
oversight by fixing the autosummary directory so the documentation is
built in the correct location.

Fixes #594

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
