### PR TITLE
Fix implementation of tensor product for undirected graphs

### DIFF
--- a/src/tensor_product.rs
+++ b/src/tensor_product.rs
@@ -70,6 +70,12 @@ fn tensor_product<Ty: EdgeType>(
     if undirected {
         for edge_first in first.edge_references() {
             for edge_second in second.edge_references() {
+                if edge_first.source() == edge_first.target()
+                    || edge_second.source() == edge_second.target()
+                {
+                    continue;
+                }
+
                 let source = hash_nodes
                     .get(&(edge_first.source(), edge_second.target()))
                     .unwrap();

--- a/src/tensor_product.rs
+++ b/src/tensor_product.rs
@@ -65,14 +65,25 @@ fn tensor_product<Ty: EdgeType>(
                 )
                     .into_py(py),
             );
+        }
+    }
+    if undirected {
+        for edge_first in first.edge_references() {
+            for edge_second in second.edge_references() {
+                let source = hash_nodes
+                    .get(&(edge_first.source(), edge_second.target()))
+                    .unwrap();
 
-            if undirected {
+                let target = hash_nodes
+                    .get(&(edge_first.target(), edge_second.source()))
+                    .unwrap();
+
                 final_graph.add_edge(
-                    *target,
                     *source,
+                    *target,
                     (
-                        edge_second.weight().clone_ref(py),
                         edge_first.weight().clone_ref(py),
+                        edge_second.weight().clone_ref(py),
                     )
                         .into_py(py),
                 );

--- a/tests/digraph/test_tensor_product.py
+++ b/tests/digraph/test_tensor_product.py
@@ -68,3 +68,43 @@ class TestTensorProduct(unittest.TestCase):
 
         graph_product, _ = retworkx.digraph_tensor_product(graph_1, graph_2)
         self.assertEqual([("w_1", "w_2")], graph_product.edges())
+
+    def test_multi_graph_1(self):
+        graph_1 = retworkx.generators.directed_path_graph(2)
+        graph_1.add_edge(0, 1, None)
+        graph_2 = retworkx.generators.directed_path_graph(2)
+
+        graph_product, _ = retworkx.digraph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 3)]
+        self.assertEqual(graph_product.num_edges(), 2)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_2(self):
+        graph_1 = retworkx.generators.directed_path_graph(2)
+        graph_1.add_edge(0, 0, None)
+        graph_2 = retworkx.generators.directed_path_graph(2)
+
+        graph_product, _ = retworkx.digraph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 1)]
+        self.assertEqual(graph_product.num_edges(), 2)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_3(self):
+        graph_1 = retworkx.generators.directed_path_graph(2)
+        graph_2 = retworkx.generators.directed_path_graph(2)
+        graph_2.add_edge(0, 1, None)
+
+        graph_product, _ = retworkx.digraph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 3)]
+        self.assertEqual(graph_product.num_edges(), 2)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_4(self):
+        graph_1 = retworkx.generators.directed_path_graph(2)
+        graph_2 = retworkx.generators.directed_path_graph(2)
+        graph_2.add_edge(0, 0, None)
+
+        graph_product, _ = retworkx.digraph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 2)]
+        self.assertEqual(graph_product.num_edges(), 2)
+        self.assertEqual(graph_product.edge_list(), expected_edges)

--- a/tests/graph/test_tensor_product.py
+++ b/tests/graph/test_tensor_product.py
@@ -70,3 +70,43 @@ class TestTensorProduct(unittest.TestCase):
 
         graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
         self.assertEqual([("w_1", "w_2"), ("w_1", "w_2")], graph_product.edges())
+
+    def test_multi_graph_1(self):
+        graph_1 = retworkx.generators.path_graph(2)
+        graph_1.add_edge(0, 1, None)
+        graph_2 = retworkx.generators.path_graph(2)
+
+        graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 3), (1, 2), (1, 2)]
+        self.assertEqual(graph_product.num_edges(), 4)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_2(self):
+        graph_1 = retworkx.generators.path_graph(2)
+        graph_1.add_edge(0, 0, None)
+        graph_2 = retworkx.generators.path_graph(2)
+
+        graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 1), (1, 2)]
+        self.assertEqual(graph_product.num_edges(), 3)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_3(self):
+        graph_1 = retworkx.generators.path_graph(2)
+        graph_2 = retworkx.generators.path_graph(2)
+        graph_2.add_edge(0, 1, None)
+
+        graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 3), (1, 2), (1, 2)]
+        self.assertEqual(graph_product.num_edges(), 4)
+        self.assertEqual(graph_product.edge_list(), expected_edges)
+
+    def test_multi_graph_4(self):
+        graph_1 = retworkx.generators.path_graph(2)
+        graph_2 = retworkx.generators.path_graph(2)
+        graph_2.add_edge(0, 0, None)
+
+        graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
+        expected_edges = [(0, 3), (0, 2), (1, 2)]
+        self.assertEqual(graph_product.num_edges(), 3)
+        self.assertEqual(graph_product.edge_list(), expected_edges)

--- a/tests/graph/test_tensor_product.py
+++ b/tests/graph/test_tensor_product.py
@@ -32,7 +32,7 @@ class TestTensorProduct(unittest.TestCase):
         expected_node_map = {(0, 0): 0, (0, 1): 1, (1, 0): 2, (1, 1): 3}
         self.assertEqual(node_map, expected_node_map)
 
-        expected_edges = [(0, 3), (3, 0)]
+        expected_edges = [(0, 3), (1, 2)]
         self.assertEqual(graph_product.num_nodes(), 4)
         self.assertEqual(graph_product.num_edges(), 2)
         self.assertEqual(graph_product.edge_list(), expected_edges)
@@ -45,7 +45,7 @@ class TestTensorProduct(unittest.TestCase):
         expected_node_map = {(0, 1): 1, (1, 0): 3, (0, 0): 0, (1, 2): 5, (0, 2): 2, (1, 1): 4}
         self.assertEqual(dict(node_map), expected_node_map)
 
-        expected_edges = [(0, 4), (4, 0), (1, 5), (5, 1)]
+        expected_edges = [(0, 4), (1, 5), (1, 3), (2, 4)]
         self.assertEqual(graph_product.num_nodes(), 6)
         self.assertEqual(graph_product.num_edges(), 4)
         self.assertEqual(graph_product.edge_list(), expected_edges)
@@ -69,4 +69,4 @@ class TestTensorProduct(unittest.TestCase):
         graph_2.add_edge(0, 1, "w_2")
 
         graph_product, _ = retworkx.graph_tensor_product(graph_1, graph_2)
-        self.assertEqual([("w_1", "w_2"), ("w_2", "w_1")], graph_product.edges())
+        self.assertEqual([("w_1", "w_2"), ("w_1", "w_2")], graph_product.edges())


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This PR fixes the implementation of tensor product for undirected graphs.

Example: 

``` Python
import networkx as nx

g = nx.path_graph(2)
h = nx.path_graph(2)
r = nx.tensor_product(g, h)

r.edges() # [((0, 0), (1, 1)), ((0, 1), (1, 0))]
```

However, this calculation in retworkx outputs `[((0, 0), (1, 1)), ((1, 1), (0, 0))]`.
I fixed the tensor product in retworkx to output the same result as networkx.


