### PR TITLE
Temporarily disable typehints in function signatures

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ master_doc = 'index'
 autosummary_generate = True
 autosummary_generate_overwrite = False
 autoclass_content = 'both'
+autodoc_typehints = 'none' # disabled until https://github.com/Qiskit/qiskit_sphinx_theme/issues/21 is fixed
 
 # Intersphinx configuration
 intersphinx_mapping = {


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #504 

Temporarily disables the typehints in functions signatures until https://github.com/Qiskit/qiskit_sphinx_theme/issues/21 is fixed.

Currently, the hints only appear on the functions with single dispatch and only appear for the graph argument. Because we already document that those functions accept both `PyGraph` and `PyDiGraph`, I argue that we do not lose much by disabling the hints.

Here is what the documentation looks like after the PR is applied:

![example_doc](https://user-images.githubusercontent.com/8753214/167238948-36ce12f8-540b-47e5-9109-e2fb7a94100a.png)

We still get a repetition of the signatures, but without them being obscured