### PR TITLE
Add graph attributes to PyGraph and PyDiGraph

### DIFF
--- a/docs/source/networkx.rst
+++ b/docs/source/networkx.rst
@@ -137,11 +137,39 @@ networkx has a concept of
 `graph <https://networkx.org/documentation/stable/tutorial.html#graph-attributes>`__,
 `node <https://networkx.org/documentation/stable/tutorial.html#node-attributes>`__,
 and `edge attributes <https://networkx.org/documentation/stable/tutorial.html#edge-attributes>`__
-in addition to the hashable object used for a node's payload. Retworkx
-has no analogous concept. Instead, the payloads for nodes and edges are any 
-python object (hashable or not). This enables you to build similar structures 
-to the attributes concept, but also use alternative structures specific to 
-your use case.
+in addition to the hashable object used for a node's payload. Retworkx has
+graph attributes similar to NetworkX however instead of being treated like
+a dictionary on the graph object itself they're accessible from a dedicated
+:class:`~.PyGraph.attrs` attribute. This attribute can be any Python object
+so you can use it to have different containers than a dictionary. For example,
+something like::
+
+    import networkx as nx
+
+    graph = nx.Graph(day="Friday")
+    graph['day'] = "Monday"
+
+can be done in retworkx with::
+
+    import retworkx as rx
+
+    graph = rx.PyGraph(attrs=dict(day="Friday"))
+    graph.attrs['day'] = "Monday"
+
+Additionally you could use a custom class with retworkx like::
+
+    class Day:
+
+        def __init__(self, day):
+            self.day = day
+
+    graph = rx.PyGraph(attrs=Day("Friday"))
+    graph.attrs = Day("Monday")
+
+But for nodes and edges retworkx has no analogous concept. Instead, the payloads
+for nodes and edges are any python object (hashable or not). This enables you to
+build similar structures to the attributes concept, but also use alternative
+structures specific to your use case.
 
 For example, something like::
 

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -298,6 +298,32 @@ method:
 
 which returns the node indices of any neighbors of node ``2``.
 
+
+Graph Attributes
+================
+
+Graphs in retworkx have an attributes attribute which can be used to assign
+metadata to a graph object. This can be assigned at object creation or
+accessed and modified after creation with the :attr:`~.PyGraph.attrs` attribute.
+This attribute can be any Python object and defaults to being ``None`` if not
+specified at graph object creation time. For example::
+
+    import retworkx as rx
+
+    graph = rx.PyGraph(attrs=dict(day="Friday"))
+    graph.attrs['day'] = "Monday"
+
+Or, you could use a custom class like::
+
+    class Day:
+
+        def __init__(self, day):
+            self.day = day
+
+    graph = rx.PyGraph(attrs=Day("Friday"))
+    graph.attrs = Day("Monday")
+
+
 Directed Graphs
 ===============
 

--- a/releasenotes/notes/graph-attributes-2064dabbfd92793a.yaml
+++ b/releasenotes/notes/graph-attributes-2064dabbfd92793a.yaml
@@ -1,0 +1,31 @@
+---
+features:
+  - |
+    Added a concept of graph attributes to the :class:`~.PyDiGraph` and
+    :class:`~.PyGraph` classes. The attributes are accessible via the
+    :attr:`~.PyDiGraph.attrs` attribute of the graph objects and can be modified
+    in place. Additionally, they can be set initially when creating the object
+    via the constructor. For example::
+
+        import retworkx as rx
+
+        graph = rx.PyGraph(attrs=dict(day="Friday"))
+        graph.attrs['day'] = "Monday"
+
+    The attributes can contain any Python object, not just a dictionary. For
+    example::
+
+        class Day:
+
+            def __init__(self, day):
+                self.day = day
+
+        graph = rx.PyGraph(attrs=Day("Friday"))
+        graph.attrs = Day("Monday")
+
+    If :attr:`~.PyDiGraph.attrs` is not set it will default to ``None``.
+  - |
+    The :meth:`.PyGraph.subgraph` and :meth:`.PyDiGraph.subgraph` methods have a
+    new keyword argument ``preserve_attributes`` which can be set to ``True``
+    to copy by reference the contents of the ``attrs`` attribute from the
+    graph to the subgraph's ``attrs`` attribute.

--- a/src/cartesian_product.rs
+++ b/src/cartesian_product.rs
@@ -112,6 +112,7 @@ pub fn graph_cartesian_product(
             graph: out_graph,
             multigraph: true,
             node_removed: false,
+            attrs: py.None(),
         },
         out_node_map,
     )
@@ -163,6 +164,7 @@ pub fn digraph_cartesian_product(
             check_cycle: false,
             node_removed: false,
             multigraph: true,
+            attrs: py.None(),
         },
         out_node_map,
     )

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -144,14 +144,30 @@ use super::dag_algo::is_directed_acyclic_graph;
 /// if a method call is made that would add a parallel edge it will instead
 /// update the existing edge's weight/data payload.
 ///
+/// Each ``PyGraph`` object has an :attr:`~.PyGraph.attrs` attribute which is
+/// used to contain additional attributes/metadata of the graph instance. By
+/// default this is set to ``None`` but can optionally be specified by using the
+/// ``attrs` keyword argument when constructing a new graph::
+///
+///     graph = retworkx.PyGraph(attrs=dict(source_path='/tmp/graph.csv'))
+///
+/// This attribute can be set to any Python object. Additionally, you can access
+/// and modify this attribute after creating an object. For example::
+///
+///     source_path = graph.attrs
+///     graph.attrs = {'new_path': '/tmp/new.csv', 'old_path': source_path}
+///
 /// :param bool check_cycle: When this is set to ``True`` the created
 ///     ``PyDiGraph`` has runtime cycle detection enabled.
 /// :param bool multgraph: When this is set to ``False`` the created
 ///     ``PyDiGraph`` object will not be a multigraph. When ``False`` if a
 ///     method call is made that would add parallel edges the the weight/weight
 ///     from that method call will be used to update the existing edge in place.
+/// :param attrs: An optional attributes payload to assign to the
+///     :attrs:`~.PyGraph.attrs` attribute. This can be any Python object. If
+///     it is not specified :attrs:`~.PyGraph.attrs` will be set to ``None``.
 #[pyclass(mapping, module = "retworkx", subclass)]
-#[pyo3(text_signature = "(/, check_cycle=False, multigraph=True)")]
+#[pyo3(text_signature = "(/, check_cycle=False, multigraph=True, attrs=None)")]
 #[derive(Clone)]
 pub struct PyDiGraph {
     pub graph: StablePyGraph<Directed>,
@@ -159,6 +175,8 @@ pub struct PyDiGraph {
     pub check_cycle: bool,
     pub node_removed: bool,
     pub multigraph: bool,
+    #[pyo3(get, set)]
+    pub attrs: PyObject,
 }
 
 impl GraphBase for PyDiGraph {
@@ -262,13 +280,18 @@ impl PyDiGraph {
 impl PyDiGraph {
     #[new]
     #[args(check_cycle = "false", multigraph = "true")]
-    fn new(check_cycle: bool, multigraph: bool) -> Self {
+    fn new(py: Python, check_cycle: bool, multigraph: bool, attrs: Option<PyObject>) -> Self {
+        let graph_attrs = match attrs {
+            Some(g_attr) => g_attr,
+            None => py.None(),
+        };
         PyDiGraph {
             graph: StablePyGraph::<Directed>::new(),
             cycle_state: algo::DfsSpace::default(),
             check_cycle,
             node_removed: false,
             multigraph,
+            attrs: graph_attrs,
         }
     }
 
@@ -279,6 +302,7 @@ impl PyDiGraph {
         out_dict.set_item("nodes", node_dict)?;
         out_dict.set_item("nodes_removed", self.node_removed)?;
         out_dict.set_item("multigraph", self.multigraph)?;
+        out_dict.set_item("attrs", self.attrs.clone_ref(py))?;
         let dir = petgraph::Direction::Incoming;
         for node_index in self.graph.node_indices() {
             let node_data = self.graph.node_weight(node_index).unwrap();
@@ -310,6 +334,11 @@ impl PyDiGraph {
             .unwrap()
             .downcast::<PyBool>()?;
         self.multigraph = multigraph_raw.extract()?;
+        let attrs = match dict_state.get_item("attrs") {
+            Some(attr) => attr.into(),
+            None => py.None(),
+        };
+        self.attrs = attrs;
         let mut node_indices: Vec<usize> = Vec::new();
         for raw_index in nodes_dict.keys() {
             let tmp_index = raw_index.downcast::<PyLong>()?;
@@ -1892,6 +1921,7 @@ impl PyDiGraph {
             check_cycle: false,
             node_removed: false,
             multigraph: true,
+            attrs: py.None(),
         })
     }
 
@@ -2417,6 +2447,10 @@ impl PyDiGraph {
     /// :param list nodes: A list of node indices to generate the subgraph
     ///     from. If a node index is included that is not present in the graph
     ///     it will silently be ignored.
+    /// :param preserve_attrs: If set to the True the attributes of the PyGraph
+    ///     will be copied by reference to be the attributes of the output
+    ///     subgraph. By default this is set to False and the :attr:`~.PyGraph.attrs`
+    ///     attribute will be ``None`` in the subgraph.
     ///
     /// :returns: A new PyDiGraph object representing a subgraph of this graph.
     ///     It is worth noting that node and edge weight/data payloads are
@@ -2425,8 +2459,9 @@ impl PyDiGraph {
     ///     the other.
     /// :rtype: PyGraph
     ///
-    #[pyo3(text_signature = "(self, nodes, /)")]
-    pub fn subgraph(&self, py: Python, nodes: Vec<usize>) -> PyDiGraph {
+    #[args(preserve_attrs = "false")]
+    #[pyo3(text_signature = "(self, nodes, /, preserve_attrs=False)")]
+    pub fn subgraph(&self, py: Python, nodes: Vec<usize>, preserve_attrs: bool) -> PyDiGraph {
         let node_set: HashSet<usize> = nodes.iter().cloned().collect();
         let mut node_map: HashMap<NodeIndex, NodeIndex> = HashMap::with_capacity(nodes.len());
         let node_filter = |node: NodeIndex| -> bool { node_set.contains(&node.index()) };
@@ -2441,12 +2476,18 @@ impl PyDiGraph {
             let new_target = *node_map.get(&edge.target()).unwrap();
             out_graph.add_edge(new_source, new_target, edge.weight().clone_ref(py));
         }
+        let attrs = if preserve_attrs {
+            self.attrs.clone_ref(py)
+        } else {
+            py.None()
+        };
         PyDiGraph {
             graph: out_graph,
             node_removed: false,
             cycle_state: algo::DfsSpace::default(),
             check_cycle: self.check_cycle,
             multigraph: self.multigraph,
+            attrs,
         }
     }
 
@@ -2626,6 +2667,7 @@ impl PyDiGraph {
             graph: new_graph,
             node_removed: false,
             multigraph,
+            attrs: py.None(),
         })
     }
 
@@ -2688,6 +2730,7 @@ impl PyDiGraph {
         {
             visit.call(edge)?;
         }
+        visit.call(&self.attrs)?;
         Ok(())
     }
 
@@ -2697,9 +2740,10 @@ impl PyDiGraph {
     //
     // ]1] https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_clear
     // [2] https://pyo3.rs/v0.12.4/class/protocols.html#garbage-collector-integration
-    fn __clear__(&mut self) {
+    fn __clear__(&mut self, py: Python) {
         self.graph = StablePyGraph::<Directed>::new();
         self.node_removed = false;
+        self.attrs = py.None();
     }
 }
 
@@ -2771,5 +2815,6 @@ where
         check_cycle: false,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     }
 }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -117,6 +117,7 @@ pub fn directed_cycle_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -190,6 +191,7 @@ pub fn cycle_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -265,6 +267,7 @@ pub fn directed_path_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -330,6 +333,7 @@ pub fn path_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -419,6 +423,7 @@ pub fn directed_star_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -481,6 +486,7 @@ pub fn star_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -546,6 +552,7 @@ pub fn mesh_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -613,6 +620,7 @@ pub fn directed_mesh_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -714,6 +722,7 @@ pub fn grid_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -834,6 +843,7 @@ pub fn directed_grid_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -927,6 +937,7 @@ pub fn binomial_tree_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1005,6 +1016,7 @@ pub fn full_rary_tree(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1113,6 +1125,7 @@ pub fn directed_binomial_tree_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1194,6 +1207,7 @@ pub fn heavy_square_graph(py: Python, d: usize, multigraph: bool) -> PyResult<gr
             graph,
             node_removed: false,
             multigraph,
+            attrs: py.None(),
         });
     }
 
@@ -1257,6 +1271,7 @@ pub fn heavy_square_graph(py: Python, d: usize, multigraph: bool) -> PyResult<gr
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1342,6 +1357,7 @@ pub fn directed_heavy_square_graph(
             check_cycle: false,
             cycle_state: algo::DfsSpace::default(),
             multigraph,
+            attrs: py.None(),
         });
     }
 
@@ -1435,6 +1451,7 @@ pub fn directed_heavy_square_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1524,6 +1541,7 @@ pub fn heavy_hex_graph(py: Python, d: usize, multigraph: bool) -> PyResult<graph
             graph,
             node_removed: false,
             multigraph,
+            attrs: py.None(),
         });
     }
 
@@ -1595,6 +1613,7 @@ pub fn heavy_hex_graph(py: Python, d: usize, multigraph: bool) -> PyResult<graph
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1691,6 +1710,7 @@ pub fn directed_heavy_hex_graph(
             check_cycle: false,
             cycle_state: algo::DfsSpace::default(),
             multigraph,
+            attrs: py.None(),
         });
     }
 
@@ -1800,6 +1820,7 @@ pub fn directed_heavy_hex_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -1841,6 +1862,7 @@ pub fn hexagonal_lattice_graph(
             graph,
             node_removed: false,
             multigraph,
+            attrs: py.None(),
         };
     }
 
@@ -1906,6 +1928,7 @@ pub fn hexagonal_lattice_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     }
 }
 
@@ -1953,6 +1976,7 @@ pub fn directed_hexagonal_lattice_graph(
             check_cycle: false,
             cycle_state: algo::DfsSpace::default(),
             multigraph,
+            attrs: py.None(),
         };
     }
 
@@ -2050,6 +2074,7 @@ pub fn directed_hexagonal_lattice_graph(
         check_cycle: false,
         cycle_state: algo::DfsSpace::default(),
         multigraph,
+        attrs: py.None(),
     }
 }
 
@@ -2222,6 +2247,7 @@ pub fn generalized_petersen_graph(
         graph,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 
@@ -2321,6 +2347,7 @@ pub fn barbell_graph(
         graph: left_mesh,
         node_removed: false,
         multigraph,
+        attrs: py.None(),
     })
 }
 

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -300,6 +300,8 @@ impl IntoPy<PyObject> for Graph {
                     graph,
                     node_removed: false,
                     multigraph: true,
+                    // TODO: Add graph attributes here
+                    attrs: py.None(),
                 };
 
                 out.into_py(py)
@@ -315,6 +317,8 @@ impl IntoPy<PyObject> for Graph {
                     check_cycle: false,
                     node_removed: false,
                     multigraph: true,
+                    // TODO: Add graph attributes here
+                    attrs: py.None(),
                 };
 
                 out.into_py(py)

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -131,6 +131,7 @@ pub fn directed_gnp_random_graph(
         check_cycle: false,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     };
     Ok(graph)
 }
@@ -225,6 +226,7 @@ pub fn undirected_gnp_random_graph(
         graph: inner_graph,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     };
     Ok(graph)
 }
@@ -306,6 +308,7 @@ pub fn directed_gnm_random_graph(
         check_cycle: false,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     };
     Ok(graph)
 }
@@ -382,6 +385,7 @@ pub fn undirected_gnm_random_graph(
         graph: inner_graph,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     };
     Ok(graph)
 }
@@ -485,6 +489,7 @@ pub fn random_geometric_graph(
         graph: inner_graph,
         node_removed: false,
         multigraph: true,
+        attrs: py.None(),
     };
     Ok(graph)
 }

--- a/src/tensor_product.rs
+++ b/src/tensor_product.rs
@@ -150,6 +150,7 @@ pub fn graph_tensor_product(
             graph: out_graph,
             multigraph: true,
             node_removed: false,
+            attrs: py.None(),
         },
         out_node_map,
     )
@@ -200,6 +201,7 @@ pub fn digraph_tensor_product(
             check_cycle: false,
             node_removed: false,
             multigraph: true,
+            attrs: py.None(),
         },
         out_node_map,
     )

--- a/src/union.rs
+++ b/src/union.rs
@@ -139,6 +139,7 @@ pub fn graph_union(
         graph: out_graph,
         node_removed: first.node_removed,
         multigraph: true,
+        attrs: py.None(),
     })
 }
 
@@ -189,5 +190,6 @@ pub fn digraph_union(
         check_cycle: false,
         node_removed: first.node_removed,
         multigraph: true,
+        attrs: py.None(),
     })
 }

--- a/tests/digraph/test_deepcopy.py
+++ b/tests/digraph/test_deepcopy.py
@@ -41,3 +41,8 @@ class TestDeepcopy(unittest.TestCase):
         dag = retworkx.PyDAG()
         empty_copy = copy.deepcopy(dag)
         self.assertEqual(len(empty_copy), 0)
+
+    def test_deepcopy_attrs(self):
+        graph = retworkx.PyDiGraph(attrs="abc")
+        graph_copy = copy.deepcopy(graph)
+        self.assertEqual(graph.attrs, graph_copy.attrs)

--- a/tests/digraph/test_subgraph.py
+++ b/tests/digraph/test_subgraph.py
@@ -136,3 +136,15 @@ class TestSubgraph(unittest.TestCase):
         subgraph = graph.edge_subgraph([(0, 1), (1, 2), (1, 3)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
         self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+
+    def test_preserve_attrs(self):
+        graph = retworkx.PyGraph(attrs="My attribute")
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
+        graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
+        subgraph = graph.subgraph([1, 3], preserve_attrs=True)
+        self.assertEqual([(0, 1, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(["b", "d"], subgraph.nodes())
+        self.assertEqual(graph.attrs, subgraph.attrs)

--- a/tests/graph/test_deepcopy.py
+++ b/tests/graph/test_deepcopy.py
@@ -43,3 +43,8 @@ class TestDeepcopy(unittest.TestCase):
         dag = retworkx.PyGraph()
         empty_copy = copy.deepcopy(dag)
         self.assertEqual(len(empty_copy), 0)
+
+    def test_deepcopy_attrs(self):
+        graph = retworkx.PyGraph(attrs="abc")
+        graph_copy = copy.deepcopy(graph)
+        self.assertEqual(graph.attrs, graph_copy.attrs)

--- a/tests/graph/test_subgraph.py
+++ b/tests/graph/test_subgraph.py
@@ -136,3 +136,15 @@ class TestSubgraph(unittest.TestCase):
         subgraph = graph.edge_subgraph([(0, 1), (1, 2), (1, 3)])
         self.assertEqual([0, 1, 2], subgraph.nodes())
         self.assertEqual([(0, 1, 2), (0, 1, 3), (1, 2, 4)], subgraph.weighted_edge_list())
+
+    def test_preserve_attrs(self):
+        graph = retworkx.PyGraph(attrs="My attribute")
+        graph.add_node("a")
+        graph.add_node("b")
+        graph.add_node("c")
+        graph.add_node("d")
+        graph.add_edges_from([(0, 1, 1), (0, 2, 2), (0, 3, 3), (1, 3, 4)])
+        subgraph = graph.subgraph([1, 3], preserve_attrs=True)
+        self.assertEqual([(0, 1, 4)], subgraph.weighted_edge_list())
+        self.assertEqual(["b", "d"], subgraph.nodes())
+        self.assertEqual(graph.attrs, subgraph.attrs)


### PR DESCRIPTION
This commit adds graph attributes to the retworkx graph classes. This is
done with a new object attribute, ``attrs``, which can contain any
Python object. This enables users to specify any python object for
storing metadata associated with the graph attribute.

Part of #607

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
