### PR TITLE
Add eigenvector centrality function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -54,6 +54,7 @@ Centrality
    :toctree: apiref
 
    retworkx.betweenness_centrality
+   retworkx.eigenvector_centrality
 
 .. _traversal:
 
@@ -311,6 +312,7 @@ the functions from the explicitly typed based on the data type.
    retworkx.digraph_spring_layout
    retworkx.digraph_num_shortest_paths_unweighted
    retworkx.digraph_betweenness_centrality
+   retworkx.digraph_eigenvector_centrality
    retworkx.digraph_unweighted_average_shortest_path_length
    retworkx.digraph_bfs_search
    retworkx.digraph_dijkstra_search
@@ -363,6 +365,7 @@ typed API based on the data type.
    retworkx.graph_spring_layout
    retworkx.graph_num_shortest_paths_unweighted
    retworkx.graph_betweenness_centrality
+   retworkx.graph_eigenvector_centrality
    retworkx.graph_unweighted_average_shortest_path_length
    retworkx.graph_bfs_search
    retworkx.graph_dijkstra_search

--- a/releasenotes/notes/add-eigenvector-centrality-e8ca30e31738a666.yaml
+++ b/releasenotes/notes/add-eigenvector-centrality-e8ca30e31738a666.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added a new function, :func:`~.eigenvector_centrality()` which is used to
+    compute the eigenvector centrality for all nodes in a given graph.
+  - |
+    Added a new function to retworkx-core ``eigenvector_centrality`` which is
+    used to compute the eigenvector centrality for all nodes in a given graph.
+

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -373,7 +373,9 @@ where
         if norm == 0. {
             return Ok(None);
         }
-        x = x.iter().map(|v| v / norm).collect();
+        for v in x.iter_mut() {
+            *v /= norm;
+        }
         if (0..x.len())
             .map(|node| (x[node] - x_last[node]).abs())
             .sum::<f64>()

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -377,7 +377,7 @@ where
                 *x.get_mut(&neighbor).unwrap() += x_last[node] * w;
             }
         }
-        let mut norm: f64 = x.values().map(|val| val.powi(2)).sum::<f64>().sqrt();
+        let norm: f64 = x.values().map(|val| val.powi(2)).sum::<f64>().sqrt();
         if norm == 0. {
             return Ok(None);
         }

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -323,13 +323,13 @@ where
 /// Arguments:
 ///
 /// * `graph` - The graph object to run the algorithm on
-/// * `weight_fn` - An input callable that will be pased the `EdgeRef` for
+/// * `weight_fn` - An input callable that will be passed the `EdgeRef` for
 ///     an edge in the graph and is expected to return a `Result<f64>` of
 ///     the weight of that edge.
 /// * `max_iter` - The maximum number of iterations in the power method. If
 ///     set to `None` a default value of 100 is used.
 /// * `tol` - The error tolerance used when checking for convergence in the
-///     power method. If set to `None` a dfault value of 1e-6 is used.
+///     power method. If set to `None` a default value of 1e-6 is used.
 ///
 /// # Example
 /// ```rust
@@ -343,7 +343,7 @@ where
 /// let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[
 ///     (0, 1), (1, 2)
 /// ]);
-/// // Calculate the betweeness centrality
+/// // Calculate the eigenvector centrality
 /// let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
 ///     eigenvector_centrality(&g, |_| {Ok(1.)}, None, None);
 /// ```
@@ -354,13 +354,8 @@ pub fn eigenvector_centrality<G, F, E>(
     tol: Option<f64>,
 ) -> Result<Option<HashMap<G::NodeId, f64>>, E>
 where
-    G: NodeIndexable
-        + IntoNodeIdentifiers
-        + IntoNeighbors
-        + IntoEdges
-        + NodeCount
-        + GraphProp
-        + GraphBase<NodeId = NodeIndex>,
+    G: NodeIndexable + IntoNodeIdentifiers + IntoNeighbors + IntoEdges + NodeCount,
+    G::NodeId: Eq + std::hash::Hash,
     F: FnMut(G::EdgeRef) -> Result<f64, E>,
 {
     let tol: f64 = tol.unwrap_or(1e-6);

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -333,8 +333,6 @@ where
 ///
 /// # Example
 /// ```rust
-/// use hashbrown::HashMap;
-///
 /// use retworkx_core::Result;
 /// use retworkx_core::petgraph;
 /// use retworkx_core::petgraph::visit::{IntoEdges, IntoNodeIdentifiers};
@@ -344,8 +342,7 @@ where
 ///     (0, 1), (1, 2)
 /// ]);
 /// // Calculate the eigenvector centrality
-/// let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
-///     eigenvector_centrality(&g, |_| {Ok(1.)}, None, None);
+/// let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| {Ok(1.)}, None, None);
 /// ```
 pub fn eigenvector_centrality<G, F, E>(
     graph: G,
@@ -397,8 +394,6 @@ where
 #[cfg(test)]
 mod test_eigenvector_centrality {
 
-    use hashbrown::HashMap;
-
     use crate::centrality::eigenvector_centrality;
     use crate::petgraph;
     use crate::Result;
@@ -413,7 +408,7 @@ mod test_eigenvector_centrality {
     #[test]
     fn test_no_convergence() {
         let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
-        let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
+        let output: Result<Option<Vec<f64>>> =
             eigenvector_centrality(&g, |_| Ok(1.), Some(0), None);
         let result = output.unwrap();
         assert_eq!(None, result);
@@ -433,27 +428,23 @@ mod test_eigenvector_centrality {
             (2, 4),
             (3, 4),
         ]);
-        let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
-            eigenvector_centrality(&g, |_| Ok(1.), None, None);
+        let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| Ok(1.), None, None);
         let result = output.unwrap().unwrap();
         let expected_value: f64 = (1_f64 / 5_f64).sqrt();
         let expected_values: Vec<f64> = vec![expected_value; 5];
         for i in 0..5 {
-            let index = petgraph::graph::NodeIndex::new(i);
-            assert_almost_equal!(expected_values[i], result[&index], 1e-4);
+            assert_almost_equal!(expected_values[i], result[i], 1e-4);
         }
     }
 
     #[test]
     fn test_undirected_path_graph() {
         let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
-        let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
-            eigenvector_centrality(&g, |_| Ok(1.), None, None);
+        let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| Ok(1.), None, None);
         let result = output.unwrap().unwrap();
         let expected_values: Vec<f64> = vec![0.5, 0.7071, 0.5];
         for i in 0..3 {
-            let index = petgraph::graph::NodeIndex::new(i);
-            assert_almost_equal!(expected_values[i], result[&index], 1e-4);
+            assert_almost_equal!(expected_values[i], result[i], 1e-4);
         }
     }
 
@@ -478,16 +469,14 @@ mod test_eigenvector_centrality {
             (7, 5),
             (7, 6),
         ]);
-        let output: Result<Option<HashMap<petgraph::graph::NodeIndex, f64>>> =
-            eigenvector_centrality(&g, |_| Ok(2.), None, None);
+        let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| Ok(2.), None, None);
         let result = output.unwrap().unwrap();
         let expected_values: Vec<f64> = vec![
             0.25368793, 0.19576478, 0.32817092, 0.40430835, 0.48199885, 0.15724483, 0.51346196,
             0.32475403,
         ];
         for i in 0..8 {
-            let index = petgraph::graph::NodeIndex::new(i);
-            assert_almost_equal!(expected_values[i], result[&index], 1e-4);
+            assert_almost_equal!(expected_values[i], result[i], 1e-4);
         }
     }
 }

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -359,7 +359,7 @@ where
     F: FnMut(G::EdgeRef) -> Result<f64, E>,
 {
     let tol: f64 = tol.unwrap_or(1e-6);
-    let max_iter = max_iter.unwrap_or(50);
+    let max_iter = max_iter.unwrap_or(100);
     let n_start: HashMap<G::NodeId, f64> = graph.node_identifiers().map(|n| (n, 1.)).collect();
     let n_start_sum: f64 = n_start.len() as f64;
     let mut x: HashMap<G::NodeId, f64> =

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -360,10 +360,7 @@ where
 {
     let tol: f64 = tol.unwrap_or(1e-6);
     let max_iter = max_iter.unwrap_or(100);
-    let n_start: HashMap<G::NodeId, f64> = graph.node_identifiers().map(|n| (n, 1.)).collect();
-    let n_start_sum: f64 = n_start.len() as f64;
-    let mut x: HashMap<G::NodeId, f64> =
-        n_start.iter().map(|(k, v)| (*k, v / n_start_sum)).collect();
+    let mut x: HashMap<G::NodeId, f64> = graph.node_identifiers().map(|n| (n, 1.)).collect();
     let node_count = graph.node_count();
     for _ in 0..max_iter {
         let x_last = x.clone();
@@ -382,7 +379,7 @@ where
         }
         let mut norm: f64 = x.values().map(|val| val.powi(2)).sum::<f64>().sqrt();
         if norm == 0. {
-            norm = 1.;
+            return Ok(None);
         }
         x = x.iter().map(|(k, v)| (*k, v / norm)).collect();
         if x.keys()

--- a/retworkx-core/src/centrality.rs
+++ b/retworkx-core/src/centrality.rs
@@ -363,15 +363,9 @@ where
         let x_last = x.clone();
         for node_index in graph.node_identifiers() {
             let node = graph.to_index(node_index);
-            for neighbor in graph.neighbors(node_index) {
-                let w_vec: Vec<G::EdgeRef> = graph
-                    .edges(node_index)
-                    .filter(|edge| edge.target() == neighbor)
-                    .collect();
-                let mut w = 0.;
-                for edge in w_vec {
-                    w += weight_fn(edge)?;
-                }
+            for edge in graph.edges(node_index) {
+                let w = weight_fn(edge)?;
+                let neighbor = edge.target();
                 x[graph.to_index(neighbor)] += x_last[node] * w;
             }
         }

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -1593,6 +1593,63 @@ def _graph_betweenness_centrality(graph, normalized=True, endpoints=False, paral
 
 
 @functools.singledispatch
+def eigenvector_centrality(graph, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6):
+    """Compute the eigenvector centrality of a :class:`~PyGraph`.
+
+    For details on the eigenvector centrality refer to:
+
+    Phillip Bonacich. “Power and Centrality: A Family of Measures.”
+    American Journal of Sociology 92(5):1170–1182, 1986
+    <https://doi.org/10.1086/228631>
+
+    This function uses a power iteration method to compute the eigenvector
+    and convergence is not guaranteed. The function will stop when `max_iter`
+    iterations is reached or when the computed vector between two iterations
+    is smaller than the error tolerance multiplied by the number of nodes.
+    The implementation of this algorithm is based on the NetworkX
+    `eigenvector_centrality() <https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.eigenvector_centrality.html>`__
+    function.
+
+    In the case of multigraphs the weights of any parallel edges will be
+    summed when computing the eigenvector centrality.
+
+    :param PyDigraph graph: The graph object to run the algorithm on
+    :param weight_fn: An optional input callable that will be pased the edge's
+        payload object and is expected to return a `float` weight for that edge.
+        If this is not specified ``default_weight`` will be used as the weight
+        for every edge in ``graph``
+    :param float default_weight: If ``weight_fn`` is not set the default weight
+        value to use for the weight of all edges
+    :param int max_iter: The maximum number of iterations in the power method. If
+        not specified a default value of 100 is used.
+    :param float tol: The error tolerance used when checking for convergence in the
+        power method. If this is not specified default value of 1e-6 is used.
+
+    :returns: a read-only dict-like object whose keys are the node indices and values are the
+         centrality score for that node.
+    :rtype: CentralityMapping
+    """
+
+
+@eigenvector_centrality.register(PyDiGraph)
+def _digraph_eigenvector_centrality(
+    graph, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6
+):
+    return digraph_eigenvector_centrality(
+        graph, weight_fn=weight_fn, default_weight=default_weight, max_iter=max_iter, tol=tol
+    )
+
+
+@eigenvector_centrality.register(PyGraph)
+def _graph_eigenvector_centrality(
+    graph, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6
+):
+    return graph_eigenvector_centrality(
+        graph, weight_fn=weight_fn, default_weight=default_weight, max_iter=max_iter, tol=tol
+    )
+
+
+@functools.singledispatch
 def vf2_mapping(
     first,
     second,

--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -1594,7 +1594,7 @@ def _graph_betweenness_centrality(graph, normalized=True, endpoints=False, paral
 
 @functools.singledispatch
 def eigenvector_centrality(graph, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6):
-    """Compute the eigenvector centrality of a :class:`~PyGraph`.
+    """Compute the eigenvector centrality of a graph.
 
     For details on the eigenvector centrality refer to:
 
@@ -1613,8 +1613,9 @@ def eigenvector_centrality(graph, weight_fn=None, default_weight=1.0, max_iter=1
     In the case of multigraphs the weights of any parallel edges will be
     summed when computing the eigenvector centrality.
 
-    :param PyDigraph graph: The graph object to run the algorithm on
-    :param weight_fn: An optional input callable that will be pased the edge's
+    :param graph: Graph to be used. Can either be a
+        :class:`~retworkx.PyGraph` or :class:`~retworkx.PyDiGraph`.
+    :param weight_fn: An optional input callable that will be passed the edge's
         payload object and is expected to return a `float` weight for that edge.
         If this is not specified ``default_weight`` will be used as the weight
         for every edge in ``graph``

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -155,8 +155,8 @@ pub fn digraph_betweenness_centrality(
 /// In the case of multigraphs the weights of any parallel edges will be
 /// summed when computing the eigenvector centrality.
 ///
-/// :param PyDigraph graph: The graph object to run the algorithm on
-/// :param weight_fn: An optional input callable that will be pased the edge's
+/// :param PyGraph graph: The graph object to run the algorithm on
+/// :param weight_fn: An optional input callable that will be passed the edge's
 ///     payload object and is expected to return a `float` weight for that edge.
 ///     If this is not specified ``default_weight`` will be used as the weight
 ///     for every edge in ``graph``
@@ -217,8 +217,8 @@ pub fn graph_eigenvector_centrality(
 /// In the case of multigraphs the weights of any parallel edges will be
 /// summed when computing the eigenvector centrality.
 ///
-/// :param PyDigraph graph: The graph object to run the algorithm on
-/// :param weight_fn: An optional input callable that will be pased the edge's
+/// :param PyDiGraph graph: The graph object to run the algorithm on
+/// :param weight_fn: An optional input callable that will be passed the edge's
 ///     payload object and is expected to return a `float` weight for that edge.
 ///     If this is not specified ``default_weight`` will be used as the weight
 ///     for every edge in ``graph``

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -10,10 +10,13 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use crate::iterators::CentralityMapping;
+use std::convert::TryFrom;
 
 use crate::digraph;
 use crate::graph;
+use crate::iterators::CentralityMapping;
+use crate::CostFn;
+use crate::FailedToConverge;
 
 use pyo3::prelude::*;
 
@@ -130,5 +133,129 @@ pub fn digraph_betweenness_centrality(
             .enumerate()
             .filter_map(|(i, v)| v.map(|x| (i, x)))
             .collect(),
+    }
+}
+
+/// Compute the eigenvector centrality of a :class:`~PyGraph`.
+///
+/// For details on the eigenvector centrality refer to:
+///
+/// Phillip Bonacich. “Power and Centrality: A Family of Measures.”
+/// American Journal of Sociology 92(5):1170–1182, 1986
+/// <https://doi.org/10.1086/228631>
+///
+/// This function uses a power iteration method to compute the eigenvector
+/// and convergence is not guaranteed. The function will stop when `max_iter`
+/// iterations is reached or when the computed vector between two iterations
+/// is smaller than the error tolerance multiplied by the number of nodes.
+/// The implementation of this algorithm is based on the NetworkX
+/// `eigenvector_centrality() <https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.eigenvector_centrality.html>`__
+/// function.
+///
+/// In the case of multigraphs the weights of any parallel edges will be
+/// summed when computing the eigenvector centrality.
+///
+/// :param PyDigraph graph: The graph object to run the algorithm on
+/// :param weight_fn: An optional input callable that will be pased the edge's
+///     payload object and is expected to return a `float` weight for that edge.
+///     If this is not specified ``default_weight`` will be used as the weight
+///     for every edge in ``graph``
+/// :param float default_weight: If ``weight_fn`` is not set the default weight
+///     value to use for the weight of all edges
+/// :param int max_iter: The maximum number of iterations in the power method. If
+///     not specified a default value of 100 is used.
+/// :param float tol: The error tolerance used when checking for convergence in the
+///     power method. If this is not specified default value of 1e-6 is used.
+///
+/// :returns: a read-only dict-like object whose keys are the node indices and values are the
+///      centrality score for that node.
+/// :rtype: CentralityMapping
+#[pyfunction(default_weight = "1.0", max_iter = "100", tol = "1e-6")]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6)")]
+pub fn graph_eigenvector_centrality(
+    py: Python,
+    graph: &graph::PyGraph,
+    weight_fn: Option<PyObject>,
+    default_weight: f64,
+    max_iter: usize,
+    tol: f64,
+) -> PyResult<CentralityMapping> {
+    let cost_fn = CostFn::try_from((weight_fn, default_weight))?;
+    let ev_centrality = centrality::eigenvector_centrality(
+        &graph.graph,
+        |e| cost_fn.call(py, e.weight()),
+        Some(max_iter),
+        Some(tol),
+    )?;
+    match ev_centrality {
+        Some(centrality) => Ok(CentralityMapping {
+            centralities: centrality.iter().map(|(k, v)| (k.index(), *v)).collect(),
+        }),
+        None => Err(FailedToConverge::new_err(format!(
+            "Function failed to converge on a solution in {} iterations",
+            max_iter
+        ))),
+    }
+}
+
+/// Compute the eigenvector centrality of a :class:`~PyDiGraph`.
+///
+/// For details on the eigenvector centrality refer to:
+///
+/// Phillip Bonacich. “Power and Centrality: A Family of Measures.”
+/// American Journal of Sociology 92(5):1170–1182, 1986
+/// <https://doi.org/10.1086/228631>
+///
+/// This function uses a power iteration method to compute the eigenvector
+/// and convergence is not guaranteed. The function will stop when `max_iter`
+/// iterations is reached or when the computed vector between two iterations
+/// is smaller than the error tolerance multiplied by the number of nodes.
+/// The implementation of this algorithm is based on the NetworkX
+/// `eigenvector_centrality() <https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.centrality.eigenvector_centrality.html>`__
+/// function.
+///
+/// In the case of multigraphs the weights of any parallel edges will be
+/// summed when computing the eigenvector centrality.
+///
+/// :param PyDigraph graph: The graph object to run the algorithm on
+/// :param weight_fn: An optional input callable that will be pased the edge's
+///     payload object and is expected to return a `float` weight for that edge.
+///     If this is not specified ``default_weight`` will be used as the weight
+///     for every edge in ``graph``
+/// :param float default_weight: If ``weight_fn`` is not set the default weight
+///     value to use for the weight of all edges
+/// :param int max_iter: The maximum number of iterations in the power method. If
+///     not specified a default value of 100 is used.
+/// :param float tol: The error tolerance used when checking for convergence in the
+///     power method. If this is not specified default value of 1e-6 is used.
+///
+/// :returns: a read-only dict-like object whose keys are the node indices and values are the
+///      centrality score for that node.
+/// :rtype: CentralityMapping
+#[pyfunction(default_weight = "1.0", max_iter = "100", tol = "1e-6")]
+#[pyo3(text_signature = "(graph, /, weight_fn=None, default_weight=1.0, max_iter=100, tol=1e-6)")]
+pub fn digraph_eigenvector_centrality(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    weight_fn: Option<PyObject>,
+    default_weight: f64,
+    max_iter: usize,
+    tol: f64,
+) -> PyResult<CentralityMapping> {
+    let cost_fn = CostFn::try_from((weight_fn, default_weight))?;
+    let ev_centrality = centrality::eigenvector_centrality(
+        &graph.graph,
+        |e| cost_fn.call(py, e.weight()),
+        Some(max_iter),
+        Some(tol),
+    )?;
+    match ev_centrality {
+        Some(centrality) => Ok(CentralityMapping {
+            centralities: centrality.iter().map(|(k, v)| (k.index(), *v)).collect(),
+        }),
+        None => Err(FailedToConverge::new_err(format!(
+            "Function failed to converge on a solution in {} iterations",
+            max_iter
+        ))),
     }
 }

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -282,7 +282,7 @@ pub fn digraph_eigenvector_centrality(
                 .iter()
                 .enumerate()
                 .filter_map(|(k, v)| {
-                    if graph.graph.node_weight(NodeIndex::new(k)).is_some() {
+                    if graph.graph.contains_node(NodeIndex::new(k)) {
                         Some((k, *v))
                     } else {
                         None

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -18,8 +18,8 @@ use crate::iterators::CentralityMapping;
 use crate::CostFn;
 use crate::FailedToConverge;
 
+use petgraph::graph::NodeIndex;
 use pyo3::prelude::*;
-
 use retworkx_core::centrality;
 
 /// Compute the betweenness centrality of all nodes in a PyGraph.
@@ -189,7 +189,17 @@ pub fn graph_eigenvector_centrality(
     )?;
     match ev_centrality {
         Some(centrality) => Ok(CentralityMapping {
-            centralities: centrality.iter().map(|(k, v)| (k.index(), *v)).collect(),
+            centralities: centrality
+                .iter()
+                .enumerate()
+                .filter_map(|(k, v)| {
+                    if graph.graph.node_weight(NodeIndex::new(k)).is_some() {
+                        Some((k, *v))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
             "Function failed to converge on a solution in {} iterations",
@@ -251,7 +261,17 @@ pub fn digraph_eigenvector_centrality(
     )?;
     match ev_centrality {
         Some(centrality) => Ok(CentralityMapping {
-            centralities: centrality.iter().map(|(k, v)| (k.index(), *v)).collect(),
+            centralities: centrality
+                .iter()
+                .enumerate()
+                .filter_map(|(k, v)| {
+                    if graph.graph.node_weight(NodeIndex::new(k)).is_some() {
+                        Some((k, *v))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
             "Function failed to converge on a solution in {} iterations",

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -202,7 +202,7 @@ pub fn graph_eigenvector_centrality(
                 .iter()
                 .enumerate()
                 .filter_map(|(k, v)| {
-                    if graph.graph.node_weight(NodeIndex::new(k)).is_some() {
+                    if graph.graph.contains_node(NodeIndex::new(k)) {
                         Some((k, *v))
                     } else {
                         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,8 @@ import_exception!(retworkx.visit, PruneSearch);
 import_exception!(retworkx.visit, StopSearch);
 // Negative Cycle found on shortest-path algorithm
 create_exception!(retworkx, NegativeCycle, PyException);
+// Failed to Converge on a solution
+create_exception!(retworkx, FailedToConverge, PyException);
 
 #[pymodule]
 fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -328,6 +330,7 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add("NoPathFound", py.get_type::<NoPathFound>())?;
     m.add("NullGraph", py.get_type::<NullGraph>())?;
     m.add("NegativeCycle", py.get_type::<NegativeCycle>())?;
+    m.add("FailedToConverge", py.get_type::<FailedToConverge>())?;
     m.add_wrapped(wrap_pyfunction!(bfs_successors))?;
     m.add_wrapped(wrap_pyfunction!(graph_bfs_search))?;
     m.add_wrapped(wrap_pyfunction!(digraph_bfs_search))?;
@@ -400,6 +403,8 @@ fn retworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     ))?;
     m.add_wrapped(wrap_pyfunction!(graph_betweenness_centrality))?;
     m.add_wrapped(wrap_pyfunction!(digraph_betweenness_centrality))?;
+    m.add_wrapped(wrap_pyfunction!(graph_eigenvector_centrality))?;
+    m.add_wrapped(wrap_pyfunction!(digraph_eigenvector_centrality))?;
     m.add_wrapped(wrap_pyfunction!(graph_astar_shortest_path))?;
     m.add_wrapped(wrap_pyfunction!(digraph_astar_shortest_path))?;
     m.add_wrapped(wrap_pyfunction!(graph_greedy_color))?;

--- a/tests/digraph/test_centrality.py
+++ b/tests/digraph/test_centrality.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import math
 import unittest
 
 import retworkx
@@ -128,3 +129,24 @@ class TestCentralityDiGraphDeletedNode(unittest.TestCase):
         )
         expected = {0: 0.0, 1: 2.0, 2: 2.0, 4: 0.0}
         self.assertEqual(expected, betweenness)
+
+
+class TestEigenvectorCentrality(unittest.TestCase):
+    def test_complete_graph(self):
+        graph = retworkx.generators.directed_mesh_graph(5)
+        centrality = retworkx.eigenvector_centrality(graph)
+        expected_value = math.sqrt(1.0 / 5.0)
+        for value in centrality.values():
+            self.assertAlmostEqual(value, expected_value)
+
+    def test_path_graph(self):
+        graph = retworkx.generators.directed_path_graph(3, bidirectional=True)
+        centrality = retworkx.eigenvector_centrality(graph)
+        expected = [0.5, 0.7071, 0.5]
+        for k, v in centrality.items():
+            self.assertAlmostEqual(v, expected[k], 4)
+
+    def test_no_convergence(self):
+        graph = retworkx.PyDiGraph()
+        with self.assertRaises(retworkx.FailedToConverge):
+            retworkx.eigenvector_centrality(graph, max_iter=0)

--- a/tests/graph/test_centrality.py
+++ b/tests/graph/test_centrality.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import math
 import unittest
 
 import retworkx
@@ -99,3 +100,24 @@ class TestCentralityGraphDeletedNode(unittest.TestCase):
         )
         expected = {0: 0.0, 1: 2.0, 2: 2.0, 4: 0.0}
         self.assertEqual(expected, betweenness)
+
+
+class TestEigenvectorCentrality(unittest.TestCase):
+    def test_complete_graph(self):
+        graph = retworkx.generators.mesh_graph(5)
+        centrality = retworkx.eigenvector_centrality(graph)
+        expected_value = math.sqrt(1.0 / 5.0)
+        for value in centrality.values():
+            self.assertAlmostEqual(value, expected_value)
+
+    def test_path_graph(self):
+        graph = retworkx.generators.path_graph(3)
+        centrality = retworkx.eigenvector_centrality(graph)
+        expected = [0.5, 0.7071, 0.5]
+        for k, v in centrality.items():
+            self.assertAlmostEqual(v, expected[k], 4)
+
+    def test_no_convergence(self):
+        graph = retworkx.PyGraph()
+        with self.assertRaises(retworkx.FailedToConverge):
+            retworkx.eigenvector_centrality(graph, max_iter=0)


### PR DESCRIPTION
This commit adds a new function eigenvector_centrality() to compute the
eigenvector centrality of a graph. It uses the same power function
approach that the NetworkX function eigenvector_centrality() [1]
function uses. This is for two reasons, the first is that a more
traditional eigenvector linear algebra/BLAS function would either
require us to link against BLAS at build time (which is a big change
in the build system and a large requirement) or to call out to numpy
via python both of which seemed less than ideal. The second reason was
to make handling holes in node indices bit easier. Using this approach
also enabled us to put the implementation in retworkx-core so it can be
reused with any petgraph graph.

Part of #441

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
