### PR TITLE
Optimize performance of some generator functions

### DIFF
--- a/src/generators.rs
+++ b/src/generators.rs
@@ -92,29 +92,25 @@ pub fn directed_cycle_graph(
     };
     let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
 
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             for weight in weights {
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
             }
-            node_list
         }
-        None => (0..num_nodes.unwrap())
-            .map(|_| graph.add_node(py.None()))
-            .collect(),
+        None => {
+            (0..node_len).for_each(|_| {
+                graph.add_node(py.None());
+            });
+        }
     };
-    for (node_a, node_b) in pairwise(nodes) {
-        match node_a {
-            Some(node_a) => {
-                if bidirectional {
-                    graph.add_edge(node_b, node_a, py.None());
-                }
-                graph.add_edge(node_a, node_b, py.None());
-            }
-            None => continue,
-        };
+    for a in 0..node_len - 1 {
+        let node_b = NodeIndex::new(a + 1);
+        let node_a = NodeIndex::new(a);
+        graph.add_edge(node_a, node_b, py.None());
+        if bidirectional {
+            graph.add_edge(node_b, node_a, py.None());
+        }
     }
     let last_node_index = NodeIndex::new(node_len - 1);
     let first_node_index = NodeIndex::new(0);
@@ -172,24 +168,21 @@ pub fn cycle_graph(
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, node_len);
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             for weight in weights {
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
             }
-            node_list
         }
-        None => (0..num_nodes.unwrap())
-            .map(|_| graph.add_node(py.None()))
-            .collect(),
+        None => {
+            (0..node_len).for_each(|_| {
+                graph.add_node(py.None());
+            });
+        }
     };
-    for (node_a, node_b) in pairwise(nodes) {
-        match node_a {
-            Some(node_a) => graph.add_edge(node_a, node_b, py.None()),
-            None => continue,
-        };
+    for node_a in 0..node_len - 1 {
+        let node_b = node_a + 1;
+        graph.add_edge(NodeIndex::new(node_a), NodeIndex::new(node_b), py.None());
     }
     let last_node_index = NodeIndex::new(node_len - 1);
     let first_node_index = NodeIndex::new(0);
@@ -251,29 +244,23 @@ pub fn directed_path_graph(
     };
     let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
 
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             for weight in weights {
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
             }
-            node_list
         }
-        None => (0..num_nodes.unwrap())
-            .map(|_| graph.add_node(py.None()))
-            .collect(),
+        None => (0..node_len).for_each(|_| {
+            graph.add_node(py.None());
+        }),
     };
-    for (node_a, node_b) in pairwise(nodes) {
-        match node_a {
-            Some(node_a) => {
-                graph.add_edge(node_a, node_b, py.None());
-                if bidirectional {
-                    graph.add_edge(node_b, node_a, py.None());
-                }
-            }
-            None => continue,
-        };
+    for a in 0..node_len - 1 {
+        let node_b = NodeIndex::new(a + 1);
+        let node_a = NodeIndex::new(a);
+        graph.add_edge(node_a, node_b, py.None());
+        if bidirectional {
+            graph.add_edge(node_b, node_a, py.None());
+        }
     }
     Ok(digraph::PyDiGraph {
         graph,
@@ -325,24 +312,19 @@ pub fn path_graph(
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, node_len);
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             for weight in weights {
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
             }
-            node_list
         }
-        None => (0..num_nodes.unwrap())
-            .map(|_| graph.add_node(py.None()))
-            .collect(),
+        None => (0..node_len).for_each(|_| {
+            graph.add_node(py.None());
+        }),
     };
-    for (node_a, node_b) in pairwise(nodes) {
-        match node_a {
-            Some(node_a) => graph.add_edge(node_a, node_b, py.None()),
-            None => continue,
-        };
+    for node_a in 0..node_len - 1 {
+        let node_b = NodeIndex::new(node_a + 1);
+        graph.add_edge(NodeIndex::new(node_a), node_b, py.None());
     }
     Ok(graph::PyGraph {
         graph,
@@ -421,7 +403,7 @@ pub fn directed_star_graph(
             }
         }
         None => {
-            (0..num_nodes.unwrap()).for_each(|_| {
+            (0..node_len).for_each(|_| {
                 graph.add_node(py.None());
             });
         }
@@ -496,7 +478,7 @@ pub fn star_graph(
             }
         }
         None => {
-            (0..num_nodes.unwrap()).for_each(|_| {
+            (0..node_len).for_each(|_| {
                 graph.add_node(py.None());
             });
         }
@@ -560,7 +542,7 @@ pub fn mesh_graph(
             }
         }
         None => {
-            (0..num_nodes.unwrap()).for_each(|_| {
+            (0..node_len).for_each(|_| {
                 graph.add_node(py.None());
             });
         }
@@ -628,7 +610,7 @@ pub fn directed_mesh_graph(
             }
         }
         None => {
-            (0..num_nodes.unwrap()).for_each(|_| {
+            (0..node_len).for_each(|_| {
                 graph.add_node(py.None());
             });
         }
@@ -692,7 +674,6 @@ pub fn grid_graph(
     weights: Option<Vec<PyObject>>,
     multigraph: bool,
 ) -> PyResult<graph::PyGraph> {
-    let mut graph = StablePyGraph::<Undirected>::default();
     if weights.is_none() && (rows.is_none() || cols.is_none()) {
         return Err(PyIndexError::new_err(
             "dimensions and weights list not specified",
@@ -702,10 +683,11 @@ pub fn grid_graph(
     let mut rowlen = rows.unwrap_or(0);
     let mut collen = cols.unwrap_or(0);
     let mut num_nodes = rowlen * collen;
+    let num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    let mut graph = StablePyGraph::<Undirected>::with_capacity(num_nodes, num_edges);
 
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             if num_nodes < weights.len() && rowlen == 0 {
                 collen = weights.len();
                 rowlen = 1;
@@ -718,30 +700,35 @@ pub fn grid_graph(
                 if node_cnt == 0 {
                     break;
                 }
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
                 node_cnt -= 1;
             }
             for _i in 0..node_cnt {
-                let index = graph.add_node(py.None());
-                node_list.push(index);
+                graph.add_node(py.None());
             }
-            node_list
         }
-        None => (0..num_nodes).map(|_| graph.add_node(py.None())).collect(),
+        None => {
+            (0..num_nodes).for_each(|_| {
+                graph.add_node(py.None());
+            });
+        }
     };
 
     for i in 0..rowlen {
         for j in 0..collen {
             if i + 1 < rowlen {
                 graph.add_edge(
-                    nodes[i * collen + j],
-                    nodes[(i + 1) * collen + j],
+                    NodeIndex::new(i * collen + j),
+                    NodeIndex::new((i + 1) * collen + j),
                     py.None(),
                 );
             }
             if j + 1 < collen {
-                graph.add_edge(nodes[i * collen + j], nodes[i * collen + j + 1], py.None());
+                graph.add_edge(
+                    NodeIndex::new(i * collen + j),
+                    NodeIndex::new(i * collen + j + 1),
+                    py.None(),
+                );
             }
         }
     }
@@ -800,7 +787,6 @@ pub fn directed_grid_graph(
     bidirectional: bool,
     multigraph: bool,
 ) -> PyResult<digraph::PyDiGraph> {
-    let mut graph = StablePyGraph::<Directed>::default();
     if weights.is_none() && (rows.is_none() || cols.is_none()) {
         return Err(PyIndexError::new_err(
             "dimensions and weights list not specified",
@@ -810,10 +796,14 @@ pub fn directed_grid_graph(
     let mut rowlen = rows.unwrap_or(0);
     let mut collen = cols.unwrap_or(0);
     let mut num_nodes = rowlen * collen;
+    let mut num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    if bidirectional {
+        num_edges *= 2;
+    }
+    let mut graph = StablePyGraph::<Directed>::with_capacity(num_nodes, num_edges);
 
-    let nodes: Vec<NodeIndex> = match weights {
+    match weights {
         Some(weights) => {
-            let mut node_list: Vec<NodeIndex> = Vec::new();
             if num_nodes < weights.len() && rowlen == 0 {
                 collen = weights.len();
                 rowlen = 1;
@@ -826,40 +816,49 @@ pub fn directed_grid_graph(
                 if node_cnt == 0 {
                     break;
                 }
-                let index = graph.add_node(weight);
-                node_list.push(index);
+                graph.add_node(weight);
                 node_cnt -= 1;
             }
             for _i in 0..node_cnt {
-                let index = graph.add_node(py.None());
-                node_list.push(index);
+                graph.add_node(py.None());
             }
-            node_list
         }
-        None => (0..num_nodes).map(|_| graph.add_node(py.None())).collect(),
+        None => {
+            (0..num_nodes).for_each(|_| {
+                graph.add_node(py.None());
+            });
+        }
     };
 
     for i in 0..rowlen {
         for j in 0..collen {
             if i + 1 < rowlen {
                 graph.add_edge(
-                    nodes[i * collen + j],
-                    nodes[(i + 1) * collen + j],
+                    NodeIndex::new(i * collen + j),
+                    NodeIndex::new((i + 1) * collen + j),
                     py.None(),
                 );
                 if bidirectional {
                     graph.add_edge(
-                        nodes[(i + 1) * collen + j],
-                        nodes[i * collen + j],
+                        NodeIndex::new((i + 1) * collen + j),
+                        NodeIndex::new(i * collen + j),
                         py.None(),
                     );
                 }
             }
 
             if j + 1 < collen {
-                graph.add_edge(nodes[i * collen + j], nodes[i * collen + j + 1], py.None());
+                graph.add_edge(
+                    NodeIndex::new(i * collen + j),
+                    NodeIndex::new(i * collen + j + 1),
+                    py.None(),
+                );
                 if bidirectional {
-                    graph.add_edge(nodes[i * collen + j + 1], nodes[i * collen + j], py.None());
+                    graph.add_edge(
+                        NodeIndex::new(i * collen + j + 1),
+                        NodeIndex::new(i * collen + j),
+                        py.None(),
+                    );
                 }
             }
         }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -588,16 +588,16 @@ pub fn mesh_graph(
         ));
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
-    let num_edges = (node_len * (node_len - 1)) / 2;
-    let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, num_edges);
     if node_len == 0 {
         return Ok(graph::PyGraph {
-            graph,
+            graph: StablePyGraph::<Undirected>::default(),
             node_removed: false,
             multigraph,
             attrs: py.None(),
         });
     }
+    let num_edges = (node_len * (node_len - 1)) / 2;
+    let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, num_edges);
     match weights {
         Some(weights) => {
             for weight in weights {
@@ -664,11 +664,9 @@ pub fn directed_mesh_graph(
         ));
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
-    let num_edges = node_len * (node_len - 1);
-    let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
     if node_len == 0 {
         return Ok(digraph::PyDiGraph {
-            graph,
+            graph: StablePyGraph::<Directed>::default(),
             node_removed: false,
             check_cycle: false,
             cycle_state: algo::DfsSpace::default(),
@@ -676,6 +674,8 @@ pub fn directed_mesh_graph(
             attrs: py.None(),
         });
     }
+    let num_edges = node_len * (node_len - 1);
+    let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
     match weights {
         Some(weights) => {
             for weight in weights {
@@ -756,7 +756,19 @@ pub fn grid_graph(
     let mut rowlen = rows.unwrap_or(0);
     let mut collen = cols.unwrap_or(0);
     let mut num_nodes = rowlen * collen;
-    let num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    let mut num_edges = 0;
+    if num_nodes == 0 {
+        if weights.is_none() {
+            return Ok(graph::PyGraph {
+                graph: StablePyGraph::<Undirected>::default(),
+                node_removed: false,
+                multigraph,
+                attrs: py.None(),
+            });
+        }
+    } else {
+        num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    }
     let mut graph = StablePyGraph::<Undirected>::with_capacity(num_nodes, num_edges);
 
     match weights {
@@ -869,7 +881,21 @@ pub fn directed_grid_graph(
     let mut rowlen = rows.unwrap_or(0);
     let mut collen = cols.unwrap_or(0);
     let mut num_nodes = rowlen * collen;
-    let mut num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    let mut num_edges = 0;
+    if num_nodes == 0 {
+        if weights.is_none() {
+            return Ok(digraph::PyDiGraph {
+                graph: StablePyGraph::<Directed>::default(),
+                node_removed: false,
+                check_cycle: false,
+                cycle_state: algo::DfsSpace::default(),
+                multigraph,
+                attrs: py.None(),
+            });
+        }
+    } else {
+        num_edges = (rowlen - 1) * collen + (collen - 1) * rowlen;
+    }
     if bidirectional {
         num_edges *= 2;
     }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -91,6 +91,16 @@ pub fn directed_cycle_graph(
         node_len
     };
     let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
+    if node_len == 0 {
+        return Ok(digraph::PyDiGraph {
+            graph,
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+            attrs: py.None(),
+        });
+    }
 
     match weights {
         Some(weights) => {
@@ -168,6 +178,15 @@ pub fn cycle_graph(
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, node_len);
+    if node_len == 0 {
+        return Ok(graph::PyGraph {
+            graph,
+            node_removed: false,
+            multigraph,
+            attrs: py.None(),
+        });
+    }
+
     match weights {
         Some(weights) => {
             for weight in weights {
@@ -243,6 +262,16 @@ pub fn directed_path_graph(
         node_len
     };
     let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
+    if node_len == 0 {
+        return Ok(digraph::PyDiGraph {
+            graph,
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+            attrs: py.None(),
+        });
+    }
 
     match weights {
         Some(weights) => {
@@ -312,6 +341,14 @@ pub fn path_graph(
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, node_len);
+    if node_len == 0 {
+        return Ok(graph::PyGraph {
+            graph,
+            node_removed: false,
+            multigraph,
+            attrs: py.None(),
+        });
+    }
     match weights {
         Some(weights) => {
             for weight in weights {
@@ -390,6 +427,16 @@ pub fn directed_star_graph(
         ));
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
+    if node_len == 0 {
+        return Ok(digraph::PyDiGraph {
+            graph: StablePyGraph::<Directed>::default(),
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+            attrs: py.None(),
+        });
+    }
     let num_edges = if bidirectional {
         (2 * node_len) - 2
     } else {
@@ -470,6 +517,14 @@ pub fn star_graph(
         ));
     }
     let node_len = get_num_nodes(&num_nodes, &weights);
+    if node_len == 0 {
+        return Ok(graph::PyGraph {
+            graph: StablePyGraph::<Undirected>::default(),
+            node_removed: false,
+            multigraph,
+            attrs: py.None(),
+        });
+    }
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, node_len - 1);
     match weights {
         Some(weights) => {
@@ -535,6 +590,14 @@ pub fn mesh_graph(
     let node_len = get_num_nodes(&num_nodes, &weights);
     let num_edges = (node_len * (node_len - 1)) / 2;
     let mut graph = StablePyGraph::<Undirected>::with_capacity(node_len, num_edges);
+    if node_len == 0 {
+        return Ok(graph::PyGraph {
+            graph,
+            node_removed: false,
+            multigraph,
+            attrs: py.None(),
+        });
+    }
     match weights {
         Some(weights) => {
             for weight in weights {
@@ -603,6 +666,16 @@ pub fn directed_mesh_graph(
     let node_len = get_num_nodes(&num_nodes, &weights);
     let num_edges = node_len * (node_len - 1);
     let mut graph = StablePyGraph::<Directed>::with_capacity(node_len, num_edges);
+    if node_len == 0 {
+        return Ok(digraph::PyDiGraph {
+            graph,
+            node_removed: false,
+            check_cycle: false,
+            cycle_state: algo::DfsSpace::default(),
+            multigraph,
+            attrs: py.None(),
+        });
+    }
     match weights {
         Some(weights) => {
             for weight in weights {

--- a/tests/generators/test_cycle.py
+++ b/tests/generators/test_cycle.py
@@ -61,3 +61,11 @@ class TestCycleGraph(unittest.TestCase):
     def test_cycle_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.cycle_graph()
+
+    def test_zero_length_cycle_graph(self):
+        graph = retworkx.generators.cycle_graph(0)
+        self.assertEqual(0, len(graph))
+
+    def test_zero_length_directed_cycle_graph(self):
+        graph = retworkx.generators.directed_cycle_graph(0)
+        self.assertEqual(0, len(graph))

--- a/tests/generators/test_mesh.py
+++ b/tests/generators/test_mesh.py
@@ -57,3 +57,11 @@ class TestMeshGraph(unittest.TestCase):
     def test_mesh_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.mesh_graph()
+
+    def test_zero_size_mesh_graph(self):
+        graph = retworkx.generators.mesh_graph(0)
+        self.assertEqual(0, len(graph))
+
+    def test_zero_size_directed_mesh_graph(self):
+        graph = retworkx.generators.directed_mesh_graph(0)
+        self.assertEqual(0, len(graph))

--- a/tests/generators/test_path.py
+++ b/tests/generators/test_path.py
@@ -61,3 +61,11 @@ class TestPathGraph(unittest.TestCase):
     def test_path_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.path_graph()
+
+    def test_zero_length_path_graph(self):
+        graph = retworkx.generators.path_graph(0)
+        self.assertEqual(0, len(graph))
+
+    def test_zero_length_directed_path_graph(self):
+        graph = retworkx.generators.directed_path_graph(0)
+        self.assertEqual(0, len(graph))

--- a/tests/generators/test_star.py
+++ b/tests/generators/test_star.py
@@ -98,3 +98,11 @@ class TestStarGraph(unittest.TestCase):
     def test_star_no_weights_or_num(self):
         with self.assertRaises(IndexError):
             retworkx.generators.star_graph()
+
+    def test_zero_length_star_graph(self):
+        graph = retworkx.generators.star_graph(0)
+        self.assertEqual(0, len(graph))
+
+    def test_zero_length_directed_star_graph(self):
+        graph = retworkx.generators.directed_star_graph(0)
+        self.assertEqual(0, len(graph))


### PR DESCRIPTION
This commit makes some improvements to the internals cycle graph, path
graph, star graph, and  mesh graph generator functions to optimize the
performance and reduce the memory overhead when creating the graphs. The
improvements fall into a couple categories, first the graph memory
allocation is only done once now as opposed to on demand as we create
the graph, and second intermediate index lists are no longer used in
places they weren't required to avoid the overhead of having to maintain
dual `Vec`s.

Related to #623

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
