### PR TITLE
Use usize for all graph index types

### DIFF
--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -17,8 +17,8 @@ use crate::graph;
 use crate::iterators::CentralityMapping;
 use crate::CostFn;
 use crate::FailedToConverge;
+use crate::NodeIndex;
 
-use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeIndexable;
 use petgraph::visit::EdgeRef;
 use pyo3::prelude::*;

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -11,6 +11,7 @@
 // under the License.
 
 use crate::graph;
+use crate::NodeIndex;
 use retworkx_core::dictmap::*;
 
 use hashbrown::{HashMap, HashSet};
@@ -20,7 +21,6 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::NodeCount;
 

--- a/src/connectivity/all_pairs_all_simple_paths.rs
+++ b/src/connectivity/all_pairs_all_simple_paths.rs
@@ -12,11 +12,11 @@
 
 use rayon::prelude::*;
 
-use petgraph::graph::NodeIndex;
 use petgraph::EdgeType;
 use retworkx_core::connectivity::all_simple_paths_multiple_targets;
 
 use crate::iterators::{AllPairsMultiplePathMapping, MultiplePathMapping};
+use crate::NodeIndex;
 use crate::StablePyGraph;
 use retworkx_core::dictmap::*;
 

--- a/src/connectivity/core_number.rs
+++ b/src/connectivity/core_number.rs
@@ -17,11 +17,11 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
 use petgraph::EdgeType;
 
 use rayon::prelude::*;
 
+use crate::NodeIndex;
 use crate::StablePyGraph;
 
 pub fn core_number<Ty>(py: Python, graph: &StablePyGraph<Ty>) -> PyResult<PyObject>

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -15,6 +15,7 @@
 mod all_pairs_all_simple_paths;
 mod core_number;
 
+use super::NodeIndex;
 use super::{digraph, get_edge_iter_with_weights, graph, weight_callable, InvalidNode, NullGraph};
 
 use hashbrown::{HashMap, HashSet};
@@ -24,7 +25,6 @@ use pyo3::prelude::*;
 use pyo3::Python;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::unionfind::UnionFind;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeCount, NodeIndexable, Visitable};
 

--- a/src/dag_algo/longest_path.rs
+++ b/src/dag_algo/longest_path.rs
@@ -10,14 +10,13 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use crate::{digraph, DAGHasCycle};
+use crate::{digraph, DAGHasCycle, NodeIndex};
 
 use hashbrown::HashMap;
 
 use pyo3::prelude::*;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 
 use num_traits::{Num, Zero};

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -17,6 +17,7 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use super::iterators::NodeIndices;
+use crate::NodeIndex;
 use crate::{digraph, DAGHasCycle, InvalidNode};
 
 use pyo3::exceptions::PyValueError;
@@ -25,7 +26,6 @@ use pyo3::types::PyList;
 use pyo3::Python;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::NodeCount;
 

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -14,7 +14,6 @@ use std::collections::VecDeque;
 use std::iter;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences};
 use petgraph::Undirected;
@@ -24,7 +23,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
-use super::{digraph, graph, StablePyGraph};
+use super::{digraph, graph, NodeIndex, StablePyGraph};
 
 pub fn pairwise<I>(right: I) -> impl Iterator<Item = (Option<I::Item>, I::Item)>
 where
@@ -2294,7 +2293,7 @@ pub fn barbell_graph(
         return Err(PyIndexError::new_err("num_mesh_nodes not specified"));
     }
 
-    let mut left_mesh = StableUnGraph::<PyObject, PyObject>::default();
+    let mut left_mesh = StableUnGraph::<PyObject, PyObject, usize>::default();
     let mesh_nodes: Vec<NodeIndex> = (0..num_mesh_nodes.unwrap())
         .map(|_| left_mesh.add_node(py.None()))
         .collect();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -39,9 +39,9 @@ use super::{
     find_node_by_weight, merge_duplicates, weight_callable, IsNan, NoEdgeBetweenNodes,
     NodesRemoved, StablePyGraph,
 };
+use super::{EdgeIndex, NodeIndex};
 
 use petgraph::algo;
-use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::prelude::*;
 use petgraph::visit::{
     GraphBase, IntoEdgeReferences, IntoNodeReferences, NodeCount, NodeFiltered, NodeIndexable,

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -27,7 +27,6 @@ use pyo3::gc::PyVisit;
 use pyo3::prelude::*;
 use pyo3::PyTraverseError;
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
 use petgraph::EdgeType;
 use petgraph::{Directed, Incoming, Outgoing, Undirected};
@@ -35,6 +34,7 @@ use petgraph::{Directed, Incoming, Outgoing, Undirected};
 use rayon::slice::ParallelSliceMut;
 
 use crate::iterators::NodeMap;
+use crate::NodeIndex;
 use crate::StablePyGraph;
 
 /// Returns `true` if we can map every element of `xs` to a unique

--- a/src/layout/spring.rs
+++ b/src/layout/spring.rs
@@ -20,7 +20,6 @@ use hashbrown::{HashMap, HashSet};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::{IntoEdgeReferences, NodeIndexable};
 use petgraph::EdgeType;
@@ -29,6 +28,7 @@ use rand::distributions::{Distribution, Uniform};
 use rand::prelude::*;
 use rand_pcg::Pcg64;
 
+use crate::NodeIndex;
 use crate::StablePyGraph;
 
 type Nt = f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ use pyo3::wrap_pyfunction;
 use pyo3::wrap_pymodule;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
+use petgraph::graph::EdgeIndex as PGEdgeIndex;
+use petgraph::graph::NodeIndex as PGNodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::{
     Data, EdgeIndexable, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeIdentifiers, NodeCount,
@@ -98,7 +99,9 @@ impl IsNan for Complex64 {
         self.re.is_nan() || self.im.is_nan()
     }
 }
-pub type StablePyGraph<Ty> = StableGraph<PyObject, PyObject, Ty>;
+pub type StablePyGraph<Ty> = StableGraph<PyObject, PyObject, Ty, usize>;
+pub type NodeIndex = PGNodeIndex<usize>;
+pub type EdgeIndex = PGEdgeIndex<usize>;
 
 pub trait NodesRemoved {
     fn nodes_removed(&self) -> bool;

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -18,11 +18,11 @@ use hashbrown::HashSet;
 use pyo3::prelude::*;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::IntoEdgeReferences;
 
 use crate::weight_callable;
+use crate::NodeIndex;
 
 /// Compute a maximum-weighted matching for a :class:`~retworkx.PyGraph`
 ///

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -12,6 +12,9 @@
 
 #![allow(clippy::float_cmp)]
 
+use std::convert::TryInto;
+
+use crate::NodeIndex;
 use crate::{digraph, graph, StablePyGraph};
 
 use pyo3::exceptions::PyValueError;
@@ -20,7 +23,6 @@ use pyo3::types::PyDict;
 use pyo3::Python;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 
 use rand::distributions::{Distribution, Uniform};
@@ -71,7 +73,7 @@ pub fn directed_gnp_random_graph(
         Some(seed) => Pcg64::seed_from_u64(seed),
         None => Pcg64::from_entropy(),
     };
-    let mut inner_graph = StablePyGraph::<Directed>::new();
+    let mut inner_graph = StablePyGraph::<Directed>::with_capacity(num_nodes.try_into()?, 0);
     for x in 0..num_nodes {
         inner_graph.add_node(x.to_object(py));
     }
@@ -270,7 +272,10 @@ pub fn directed_gnm_random_graph(
         Some(seed) => Pcg64::seed_from_u64(seed),
         None => Pcg64::from_entropy(),
     };
-    let mut inner_graph = StablePyGraph::<Directed>::new();
+    let mut inner_graph = StablePyGraph::<Directed>::with_capacity(
+        num_nodes.try_into()?,
+        (num_nodes * (num_nodes - 1)).try_into()?,
+    );
     for x in 0..num_nodes {
         inner_graph.add_node(x.to_object(py));
     }

--- a/src/shortest_path/all_pairs_bellman_ford.rs
+++ b/src/shortest_path/all_pairs_bellman_ford.rs
@@ -19,7 +19,6 @@ use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::EdgeType;
 
@@ -28,6 +27,8 @@ use rayon::prelude::*;
 use crate::iterators::{
     AllPairsPathLengthMapping, AllPairsPathMapping, PathLengthMapping, PathMapping,
 };
+use crate::EdgeIndex;
+use crate::NodeIndex;
 use crate::{edge_weights_from_callable, NegativeCycle, StablePyGraph};
 
 pub fn all_pairs_bellman_ford_path_lengths<Ty: EdgeType + Sync>(

--- a/src/shortest_path/all_pairs_dijkstra.rs
+++ b/src/shortest_path/all_pairs_dijkstra.rs
@@ -21,7 +21,6 @@ use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::Python;
 
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
 use petgraph::visit::EdgeIndexable;
 use petgraph::EdgeType;
@@ -32,6 +31,7 @@ use crate::iterators::{
     AllPairsPathLengthMapping, AllPairsPathMapping, PathLengthMapping, PathMapping,
 };
 use crate::{CostFn, StablePyGraph};
+use crate::{EdgeIndex, NodeIndex};
 
 pub fn all_pairs_dijkstra_path_lengths<Ty: EdgeType + Sync>(
     py: Python,

--- a/src/shortest_path/average_length.rs
+++ b/src/shortest_path/average_length.rs
@@ -12,11 +12,11 @@
 
 use hashbrown::HashSet;
 
-use petgraph::prelude::*;
 use petgraph::EdgeType;
 
 use rayon::prelude::*;
 
+use crate::NodeIndex;
 use crate::StablePyGraph;
 
 pub fn compute_distance_sum<Ty: EdgeType + Sync>(

--- a/src/shortest_path/distance_matrix.rs
+++ b/src/shortest_path/distance_matrix.rs
@@ -15,10 +15,10 @@ use std::ops::Index;
 use hashbrown::{HashMap, HashSet};
 
 use ndarray::prelude::*;
-use petgraph::prelude::*;
 use petgraph::EdgeType;
 use rayon::prelude::*;
 
+use crate::NodeIndex;
 use crate::NodesRemoved;
 use crate::StablePyGraph;
 

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -19,17 +19,16 @@ mod num_shortest_path;
 
 use std::convert::TryFrom;
 
+use crate::EdgeIndex;
+use crate::NodeIndex;
 use crate::{digraph, edge_weights_from_callable, graph, CostFn, NegativeCycle, NoPathFound};
 
-use pyo3::prelude::*;
-use pyo3::Python;
-
-use petgraph::graph::NodeIndex;
 use petgraph::prelude::*;
-use petgraph::stable_graph::EdgeIndex;
 use petgraph::visit::NodeCount;
 use pyo3::exceptions::PyIndexError;
 use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::Python;
 
 use numpy::IntoPyArray;
 

--- a/src/shortest_path/num_shortest_path.rs
+++ b/src/shortest_path/num_shortest_path.rs
@@ -15,12 +15,12 @@ use retworkx_core::dictmap::*;
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 
-use petgraph::graph::NodeIndex;
 use petgraph::visit::{Bfs, NodeIndexable};
 use petgraph::EdgeType;
 
 use num_bigint::{BigUint, ToBigUint};
 
+use crate::NodeIndex;
 use crate::StablePyGraph;
 
 pub fn num_shortest_paths_unweighted<Ty: EdgeType>(

--- a/src/steiner_tree.rs
+++ b/src/steiner_tree.rs
@@ -19,7 +19,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::Python;
 
-use petgraph::stable_graph::{EdgeIndex, EdgeReference, NodeIndex};
+use petgraph::stable_graph::EdgeReference;
 use petgraph::unionfind::UnionFind;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
 
@@ -27,6 +27,7 @@ use crate::generators::pairwise;
 use crate::graph;
 use crate::is_valid_weight;
 use crate::shortest_path::all_pairs_dijkstra::all_pairs_dijkstra_shortest_paths;
+use crate::{EdgeIndex, NodeIndex};
 
 use retworkx_core::dictmap::*;
 use retworkx_core::shortest_path::dijkstra;
@@ -144,7 +145,7 @@ fn fast_metric_edges(
             .add_edge(dummy, NodeIndex::new(*node), py.None());
     }
 
-    let cost_fn = |edge: EdgeReference<'_, PyObject>| -> PyResult<f64> {
+    let cost_fn = |edge: EdgeReference<'_, PyObject, usize>| -> PyResult<f64> {
         if edge.source() != dummy && edge.target() != dummy {
             let weight: f64 = weight_fn.call1(py, (edge.weight(),))?.extract(py)?;
             is_valid_weight(weight)

--- a/src/toposort.rs
+++ b/src/toposort.rs
@@ -19,11 +19,11 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::Python;
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::IntoNodeIdentifiers;
 
 use crate::dag_algo::is_directed_acyclic_graph;
 use crate::DAGHasCycle;
+use crate::NodeIndex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NodeState {

--- a/src/transitivity.rs
+++ b/src/transitivity.rs
@@ -15,7 +15,7 @@ use hashbrown::HashSet;
 
 use pyo3::prelude::*;
 
-use petgraph::graph::NodeIndex;
+use crate::NodeIndex;
 use rayon::prelude::*;
 
 fn _graph_triangles(graph: &graph::PyGraph, node: usize) -> (usize, usize) {

--- a/src/traversal/bfs_visit.rs
+++ b/src/traversal/bfs_visit.rs
@@ -12,9 +12,9 @@
 
 use pyo3::prelude::*;
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::Control;
 
+use crate::NodeIndex;
 use crate::{PruneSearch, StopSearch};
 use retworkx_core::traversal::BfsEvent;
 

--- a/src/traversal/dfs_visit.rs
+++ b/src/traversal/dfs_visit.rs
@@ -12,9 +12,9 @@
 
 use pyo3::prelude::*;
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::{Control, Time};
 
+use crate::NodeIndex;
 use crate::PruneSearch;
 use retworkx_core::traversal::DfsEvent;
 

--- a/src/traversal/dijkstra_visit.rs
+++ b/src/traversal/dijkstra_visit.rs
@@ -12,9 +12,9 @@
 
 use pyo3::prelude::*;
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::Control;
 
+use crate::NodeIndex;
 use crate::{PruneSearch, StopSearch};
 use retworkx_core::traversal::DijkstraEvent;
 

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -32,10 +32,10 @@ use pyo3::prelude::*;
 use pyo3::Python;
 
 use petgraph::algo;
-use petgraph::graph::NodeIndex;
 use petgraph::visit::{Bfs, NodeCount, Reversed};
 
 use crate::iterators::EdgeList;
+use crate::NodeIndex;
 
 /// Get an edge list of the tree edges from a depth-first traversal
 ///

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -59,7 +59,7 @@ pub fn minimum_spanning_edges(
 ) -> PyResult<WeightedEdgeList> {
     let mut subgraphs = UnionFind::<usize>::new(graph.graph.node_bound());
 
-    let mut edge_list: Vec<(f64, EdgeReference<PyObject>)> =
+    let mut edge_list: Vec<(f64, EdgeReference<PyObject, usize>)> =
         Vec::with_capacity(graph.graph.edge_count());
     for edge in graph.graph.edge_references() {
         let weight = weight_callable(py, &weight_fn, edge.weight(), default_weight)?;

--- a/src/union.rs
+++ b/src/union.rs
@@ -10,9 +10,9 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use crate::NodeIndex;
 use crate::{digraph, find_node_by_weight, graph, StablePyGraph};
 
-use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences, NodeIndexable};
 use petgraph::{algo, EdgeType};
 


### PR DESCRIPTION
This commit fixes an issue with scaling retworkx graphs above 2**32 - 1
nodes and/or edges. Originally in retworkx we used a usize for all index
types to ensure the graphs could scale as big as the platform would
allow. However, since those earliest retworkx releases we lost the
explicit usize index typing along the way (likely before 0.1.0 and the
library was still very rough and not really used yet). This commit
corrects this oversight and defines a retworkx crate NodeIndex and
EdgeIndex type which are built around a usize and defines StablePyGraph
to be usize indexed instead of the implicit default of u32. Additionally
to support this several generics bugs in retworkx-core were fixed for
max weight matching and betweenness centrality as they both were only
implementable previously with graphs that used a u32 NodeIndex type.

Fixes #623

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
