### PR TITLE
Document maximum number of nodes in edges allowed in graph classes

### DIFF
--- a/retworkx/__init__.py
+++ b/retworkx/__init__.py
@@ -115,6 +115,10 @@ class PyDAG(PyDiGraph):
     if a method call is made that would add a parallel edge it will instead
     update the existing edge's weight/data payload.
 
+    The maximum number of nodes and edges allowed on a ``PyGraph`` object is
+    :math:`2^{32} - 1` (4,294,967,294) each. Attempting to add more nodes or
+    edges than this will result in an exception being raised.
+
     :param bool check_cycle: When this is set to ``True`` the created
         ``PyDAG`` has runtime cycle detection enabled.
     :param bool multgraph: When this is set to ``False`` the created

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -157,6 +157,10 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///     source_path = graph.attrs
 ///     graph.attrs = {'new_path': '/tmp/new.csv', 'old_path': source_path}
 ///
+/// The maximum number of nodes and edges allowed on a ``PyGraph`` object is
+/// :math:`2^{32} - 1` (4,294,967,294) each. Attempting to add more nodes or
+/// edges than this will result in an exception being raised.
+///
 /// :param bool check_cycle: When this is set to ``True`` the created
 ///     ``PyDiGraph`` has runtime cycle detection enabled.
 /// :param bool multgraph: When this is set to ``False`` the created

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -122,6 +122,10 @@ use petgraph::visit::{
 ///     source_path = graph.attrs
 ///     graph.attrs = {'new_path': '/tmp/new.csv', 'old_path': source_path}
 ///
+/// The maximum number of nodes and edges allowed on a ``PyGraph`` object is
+/// :math:`2^{32} - 1` (4,294,967,294) each. Attempting to add more nodes or
+/// edges than this will result in an exception being raised.
+///
 /// :param bool multigraph: When this is set to ``False`` the created PyGraph
 ///     object will not be a multigraph. When ``False`` if a method call is
 ///     made that would add parallel edges the the weight/weight from that


### PR DESCRIPTION
The graph classes use a unsigned 32 bit integer as the index type which
means the maximum allowed size for the number of nodes or edges in a
graph object is std::u32::MAX - 1, roughly 4 billion. We should document
this limitation. In theory we can change the index type to use a usize
(see #628 for where this was attempted) which would increase the upper
limit to 2**64 - 1 (on 64 bit platforms), but there is a significant
memory cost for this and to have graphs so large you will need a
significant amount of local memory. In the future we might add a new
large graph type that makes this tradeoff to enable scaling above 4
billion nodes or edges but for now this commit just documents the
limitation with the current graph types.

Fixes #623

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
